### PR TITLE
Enable initial GNU compilation of mpas-ocean within the FullyCoupled compset

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -163,6 +163,13 @@ def _build_mpaso():
         #    mpaso_cppdefs = mod.buildcpp(case)
         #except:
         #    raise
+        compiler = case.get_value("COMPILER")
+        if compiler == 'intel':
+            fixedflags =  '-free'
+        elif compiler == 'gnu':
+            fixedflags =  '-ffree-form'
+        else:
+            fixedflags = ''
 
     with Case(caseroot) as case:
         casetools = case.get_value("CASETOOLS")
@@ -189,28 +196,28 @@ def _build_mpaso():
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
 
         #build the code that creates the registry *cheyenne, intel specific)
-        cmd = "icc -c ../source/ezxml.c"    
+        cmd = "mpicc -c ../source/ezxml.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/utility.c"    
+        cmd = "mpicc -c ../source/utility.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/fortprintf.c"    
+        cmd = "mpicc -c ../source/fortprintf.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/gen_inc.c"    
+        cmd = "mpicc -c ../source/gen_inc.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/dictionary.c"    
+        cmd = "mpicc -c ../source/dictionary.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/parse.c"    
+        cmd = "mpicc -c ../source/parse.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -o parse parse.o dictionary.o gen_inc.o fortprintf.o utility.o ezxml.o"
+        cmd = "mpicc -o parse parse.o dictionary.o gen_inc.o fortprintf.o utility.o ezxml.o"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
+        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
         cmd = "../obj/parse ../Registry_processed.xml"
@@ -220,8 +227,8 @@ def _build_mpaso():
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot, "libocn.a")
-        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS=-free {}" \
-            .format(gmake, gmake_j, complib, makefile, get_standard_makefile_args(case))
+        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS={} {}" \
+            .format(gmake, gmake_j, complib, makefile, fixedflags, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))

--- a/driver_nuopc/ocn_comp_nuopc.F90
+++ b/driver_nuopc/ocn_comp_nuopc.F90
@@ -37,7 +37,7 @@ module ocn_comp_nuopc
   use ocn_config
   use ocn_gm
   use ocn_diagnostics
-  !use mpas_ocn_constants, only : coupleAlarmID
+  use ocn_constants, only : coupleAlarmID
   use ocn_tracer_ecosys
   use ocn_tracer_CFC
   use ocn_tracer_surface_restoring
@@ -81,8 +81,8 @@ module ocn_comp_nuopc
   integer :: itimestep   ! time step number for MPAS
 
   integer :: ocnLogUnit ! unit number for ocn log
-  character (len=*), parameter :: coupleAlarmID = 'coupling'
-   character(len=StrKIND) :: coupleTimeStamp
+!  character (len=*), parameter :: coupleAlarmID = 'coupling'
+  character(len=StrKIND) :: coupleTimeStamp
 
 ! !PRIVATE MODULE VARIABLES
 


### PR DESCRIPTION
This PR makes small fixes and generalizes the rules in mpas-ocean/cime_config/buildlib to allow this component to build with the GNU compiler suite.

NOTE: currently this only enables the build but the code does not execute correctly. The ability to build and run with the Intel compilers is unaffected by these changes.