### PR TITLE
Make mpas-ocean compatible with cesm2_3_alpha17a EarthWorks version

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2079,57 +2079,6 @@ sub print_nl_to_screen {
 
 #-------------------------------------------------------------------------------
 
-sub valid_date {
-# return 1 if given date ($$month/$$day/$$year) exists in calendar $cal
-# otherwise subtract number of days in $$month from $$day, and increment
-# $$month by 1 (also incrementing $$year if going from Dec to Jan) and
-# then return 0.
-
-  use Switch;
-
-  my $day = shift;
-  my $month = shift;
-  my $year = shift;
-  my $cal = shift;
-
-  my $maxday = -1;
-  switch ($$month) {
-    case 1 { $maxday = 31; }
-    case 2 {
-      if (($cal eq 'NO_LEAP') || (not leap($$year))) {
-        $maxday = 28;
-      } else {
-        $maxday = 29;
-      }
-    }
-    case 3 { $maxday = 31; }
-    case 4 { $maxday = 30; }
-    case 5 { $maxday = 31; }
-    case 6 { $maxday = 30; }
-    case 7 { $maxday = 31; }
-    case 8 { $maxday = 31; }
-    case 9 { $maxday = 30; }
-    case 10 { $maxday = 31; }
-    case 11 { $maxday = 30; }
-    case 12 { $maxday = 31; }
-  }
-  if ($maxday == -1) {
-    die "ERROR: can not figure out what month $$month is";
-  }
-  if ($$day > $maxday) {
-    $$month++;
-    if ($$month == 13) {
-      $$year++;
-      $$month = 1;
-    }
-    $$day = $$day - $maxday;
-    return 0;
-  }
-  return 1;
-}
-
-#-------------------------------------------------------------------------------
-
 sub leap() {
 # return 1 if given year is a leap year, 0 otherwise
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -221,7 +221,7 @@ def _build_mpaso():
         cmd = "mpicc -o parse parse.o dictionary.o gen_inc.o fortprintf.o utility.o ezxml.o"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
+        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_PIO_SUPPORT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
         cmd = "../obj/parse ../Registry_processed.xml"
@@ -231,7 +231,7 @@ def _build_mpaso():
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot, "libocn.a")
-        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS={} {}" \
+        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS={} {}" \
             .format(gmake, gmake_j, complib, makefile, fixedflags, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))


### PR DESCRIPTION
Remove dependence on Switch perl module from build-namelist and add flag to buildlib for changes in the MPAS-A framework.