### PR TITLE
Copy mpaso config_archive entry from E3SM

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -1,0 +1,21 @@
+<components version="2.0">
+
+  <comp_archive_spec compname="mpaso" compclass="ocn" exclude_testing="true">
+    <rest_file_extension>rst</rest_file_extension>
+    <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
+    <hist_file_extension>hist</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
+      <rpointer_content>$MPAS_DATENAME</rpointer_content>
+    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ocn</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpaso.hist.am.globalStats.1976-01-01.nc</tfile>
+      <tfile disposition="move">casename.mpaso.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
+    </test_file_names>
+  </comp_archive_spec>
+
+</components>


### PR DESCRIPTION
This entry will allow the short and long term archiver scripts to handle MPAS-O appropriately. This will allow the cime create_test workflow to mark the ARCHIVE step as a success.

This entry is copied from
[E3SM-Project/E3SM:cime_config/config_archive.xml](https://github.com/E3SM-Project/E3SM/blob/264a352acdbbdc161db76cfbd3622db8829c07bf/cime_config/config_archive.xml#L102-L118)