### PR TITLE
Add timers to mpas-ocean

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -282,7 +282,7 @@ def _build_mpaso():
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot, "libocn.a")
-        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS={} {}" \
+        cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_PERF_MOD_TIMERS -DMPAS_NAMELIST_SUFFIX=ocean\" FIXEDFLAGS={} {}" \
             .format(gmake, gmake_j, complib, makefile, fixedflags, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ocn", "obj"))


### PR DESCRIPTION
The proper preprocessor directive is added to the compilation of mpas-ocean so that timing information will be recorded in ESMF_Profile.summary by default.