### PR TITLE
BFB restartability

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1180,6 +1180,7 @@ add_default($nl, 'config_AM_globalStats_write_on_startup');
 add_default($nl, 'config_AM_globalStats_text_file');
 add_default($nl, 'config_AM_globalStats_directory');
 add_default($nl, 'config_AM_globalStats_output_stream');
+add_default($nl, 'config_AM_globalStats_backward_output_offset');
 
 ##################################################
 # Namelist group: AM_surfaceAreaWeightedAverages #
@@ -1260,6 +1261,7 @@ add_default($nl, 'config_AM_meridionalHeatTransport_num_bins');
 add_default($nl, 'config_AM_meridionalHeatTransport_min_bin');
 add_default($nl, 'config_AM_meridionalHeatTransport_max_bin');
 add_default($nl, 'config_AM_meridionalHeatTransport_region_group');
+add_default($nl, 'config_AM_meridionalHeatTransport_backward_output_offset');
 
 ##########################################
 # Namelist group: AM_testComputeInterval #
@@ -1611,6 +1613,7 @@ add_default($nl, 'config_AM_eddyProductVariables_compute_interval');
 add_default($nl, 'config_AM_eddyProductVariables_output_stream');
 add_default($nl, 'config_AM_eddyProductVariables_compute_on_startup');
 add_default($nl, 'config_AM_eddyProductVariables_write_on_startup');
+add_default($nl, 'config_AM_eddyProductVariables_backward_output_offset');
 
 ########################################
 # Namelist group: AM_mocStreamfunction #
@@ -1626,6 +1629,7 @@ add_default($nl, 'config_AM_mocStreamfunction_max_bin');
 add_default($nl, 'config_AM_mocStreamfunction_num_bins');
 add_default($nl, 'config_AM_mocStreamfunction_region_group');
 add_default($nl, 'config_AM_mocStreamfunction_transect_group');
+add_default($nl, 'config_AM_mocStreamfunction_backward_output_offset');
 
 #######################################
 # Namelist group: AM_oceanHeatContent #
@@ -1636,6 +1640,7 @@ add_default($nl, 'config_AM_oceanHeatContent_compute_interval');
 add_default($nl, 'config_AM_oceanHeatContent_output_stream');
 add_default($nl, 'config_AM_oceanHeatContent_compute_on_startup');
 add_default($nl, 'config_AM_oceanHeatContent_write_on_startup');
+add_default($nl, 'config_AM_oceanHeatContent_backward_output_offset');
 
 ###########################################
 # Namelist group: AM_mixedLayerHeatBudget #

--- a/bld/build-namelist-section
+++ b/bld/build-namelist-section
@@ -638,6 +638,7 @@ add_default($nl, 'config_AM_globalStats_write_on_startup');
 add_default($nl, 'config_AM_globalStats_text_file');
 add_default($nl, 'config_AM_globalStats_directory');
 add_default($nl, 'config_AM_globalStats_output_stream');
+add_default($nl, 'config_AM_globalStats_backward_output_offset');
 
 ##################################################
 # Namelist group: AM_surfaceAreaWeightedAverages #
@@ -718,6 +719,7 @@ add_default($nl, 'config_AM_meridionalHeatTransport_num_bins');
 add_default($nl, 'config_AM_meridionalHeatTransport_min_bin');
 add_default($nl, 'config_AM_meridionalHeatTransport_max_bin');
 add_default($nl, 'config_AM_meridionalHeatTransport_region_group');
+add_default($nl, 'config_AM_meridionalHeatTransport_backward_output_offset');
 
 ##########################################
 # Namelist group: AM_testComputeInterval #
@@ -1069,6 +1071,7 @@ add_default($nl, 'config_AM_eddyProductVariables_compute_interval');
 add_default($nl, 'config_AM_eddyProductVariables_output_stream');
 add_default($nl, 'config_AM_eddyProductVariables_compute_on_startup');
 add_default($nl, 'config_AM_eddyProductVariables_write_on_startup');
+add_default($nl, 'config_AM_eddyProductVariables_backward_output_offset');
 
 ########################################
 # Namelist group: AM_mocStreamfunction #
@@ -1084,6 +1087,7 @@ add_default($nl, 'config_AM_mocStreamfunction_max_bin');
 add_default($nl, 'config_AM_mocStreamfunction_num_bins');
 add_default($nl, 'config_AM_mocStreamfunction_region_group');
 add_default($nl, 'config_AM_mocStreamfunction_transect_group');
+add_default($nl, 'config_AM_mocStreamfunction_backward_output_offset');
 
 #######################################
 # Namelist group: AM_oceanHeatContent #
@@ -1094,6 +1098,7 @@ add_default($nl, 'config_AM_oceanHeatContent_compute_interval');
 add_default($nl, 'config_AM_oceanHeatContent_output_stream');
 add_default($nl, 'config_AM_oceanHeatContent_compute_on_startup');
 add_default($nl, 'config_AM_oceanHeatContent_write_on_startup');
+add_default($nl, 'config_AM_oceanHeatContent_backward_output_offset');
 
 ###########################################
 # Namelist group: AM_mixedLayerHeatBudget #

--- a/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -662,6 +662,7 @@
 <config_AM_globalStats_text_file>.false.</config_AM_globalStats_text_file>
 <config_AM_globalStats_directory>'analysis_members'</config_AM_globalStats_directory>
 <config_AM_globalStats_output_stream>'globalStatsOutput'</config_AM_globalStats_output_stream>
+<config_AM_globalStats_backward_output_offset>'00-00-01_00:00:00'</config_AM_globalStats_backward_output_offset>
 
 <!-- AM_surfaceAreaWeightedAverages -->
 <config_AM_surfaceAreaWeightedAverages_enable>.true.</config_AM_surfaceAreaWeightedAverages_enable>
@@ -724,6 +725,7 @@
 <config_AM_meridionalHeatTransport_min_bin>-1.0e34</config_AM_meridionalHeatTransport_min_bin>
 <config_AM_meridionalHeatTransport_max_bin>-1.0e34</config_AM_meridionalHeatTransport_max_bin>
 <config_AM_meridionalHeatTransport_region_group>''</config_AM_meridionalHeatTransport_region_group>
+<config_AM_meridionalHeatTransport_backward_output_offset>'00-00-01_00:00:00'</config_AM_meridionalHeatTransport_backward_output_offset>
 
 <!-- AM_testComputeInterval -->
 <config_AM_testComputeInterval_enable>.false.</config_AM_testComputeInterval_enable>
@@ -1012,6 +1014,7 @@
 <config_AM_eddyProductVariables_output_stream>'eddyProductVariablesOutput'</config_AM_eddyProductVariables_output_stream>
 <config_AM_eddyProductVariables_compute_on_startup>.true.</config_AM_eddyProductVariables_compute_on_startup>
 <config_AM_eddyProductVariables_write_on_startup>.false.</config_AM_eddyProductVariables_write_on_startup>
+<config_AM_eddyProductVariables_backward_output_offset>'00-00-01_00:00:00'</config_AM_eddyProductVariables_backward_output_offset>
 
 <!-- AM_mocStreamfunction -->
 <config_AM_mocStreamfunction_enable ocn_grid="oQU480">.false.</config_AM_mocStreamfunction_enable>
@@ -1046,6 +1049,7 @@
 <config_AM_mocStreamfunction_num_bins>180</config_AM_mocStreamfunction_num_bins>
 <config_AM_mocStreamfunction_region_group>'all'</config_AM_mocStreamfunction_region_group>
 <config_AM_mocStreamfunction_transect_group>'all'</config_AM_mocStreamfunction_transect_group>
+<config_AM_mocStreamfunction_backward_output_offset>'00-00-01_00:00:00'</config_AM_mocStreamfunction_backward_output_offset>
 
 <!-- AM_oceanHeatContent -->
 <config_AM_oceanHeatContent_enable>.true.</config_AM_oceanHeatContent_enable>
@@ -1053,6 +1057,7 @@
 <config_AM_oceanHeatContent_output_stream>'oceanHeatContentOutput'</config_AM_oceanHeatContent_output_stream>
 <config_AM_oceanHeatContent_compute_on_startup>.true.</config_AM_oceanHeatContent_compute_on_startup>
 <config_AM_oceanHeatContent_write_on_startup>.false.</config_AM_oceanHeatContent_write_on_startup>
+<config_AM_oceanHeatContent_backward_output_offset>'00-00-01_00:00:00'</config_AM_oceanHeatContent_backward_output_offset>
 
 <!-- AM_mixedLayerHeatBudget -->
 <config_AM_mixedLayerHeatBudget_enable>.true.</config_AM_mixedLayerHeatBudget_enable>

--- a/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/bld/namelist_files/namelist_definition_mpaso.xml
@@ -3324,6 +3324,14 @@ Valid values: Any existing stream, or 'none'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_AM_globalStats_backward_output_offset" type="char*1024"
+	category="AM_globalStats" group="AM_globalStats">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_surfaceAreaWeightedAverages -->
 
@@ -3739,6 +3747,14 @@ Default: Defined in namelist_defaults.xml
 The name of the region group, for which the MHT should be computed in addition to the global MHT.
 
 Valid values: 'all', '', or the name of a region group.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_AM_meridionalHeatTransport_backward_output_offset" type="char*1024"
+        category="AM_meridionalHeatTransport" group="AM_meridionalHeatTransport">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -5773,6 +5789,14 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_AM_eddyProductVariables_backward_output_offset" type="char*1024"
+        category="AM_eddyProductVariables" group="AM_eddyProductVariables">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_mocStreamfunction -->
 
@@ -5856,6 +5880,14 @@ Valid values: Any valid transect group name.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_AM_mocStreamfunction_backward_output_offset" type="char*1024"
+        category="AM_mocStreamfunction" group="AM_mocStreamfunction">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_oceanHeatContent -->
 
@@ -5896,6 +5928,14 @@ Default: Defined in namelist_defaults.xml
 Logical flag determining if an analysis member write occurs on start-up.
 
 Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_AM_oceanHeatContent_backward_output_offset" type="char*1024"
+        category="AM_oceanHeatContent" group="AM_oceanHeatContent">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/driver_nuopc/ocn_comp_nuopc.F90
+++ b/driver_nuopc/ocn_comp_nuopc.F90
@@ -1442,7 +1442,7 @@ contains
 
       ! Import state from coupler
        call ocn_import(importState, flds_scalar_name, domain_ptr,  &
-                       errorCode, rc)
+                       errorCode, rc, do_sw_chk=.true. )
 
       ! Ensures MPAS AM write/compute startup steps are performed
       call ocn_analysis_compute_startup(domain_ptr, ierr)

--- a/driver_nuopc/ocn_comp_nuopc.F90
+++ b/driver_nuopc/ocn_comp_nuopc.F90
@@ -1002,9 +1002,16 @@ contains
     integer                   :: shrlogunit      ! old values
     integer                   :: ocnid
     character(len=*), parameter  :: subname = "ocn_comp_nuopc:(DataInitialize)"
+
+    type (block_type), pointer :: block_ptr
+    type (mpas_pool_type), pointer :: statePool, &
+                                      forcingPool
+    integer :: ierr
+
     !-----------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    errorCode = ESMF_SUCCESS
 
     !--------------------------------
     ! Reset shr logging to my log file
@@ -1229,6 +1236,67 @@ contains
     !?   call document ('DataInitialize', 'orb_obliqr  ',  orb_obliqr)
     !?endif
 
+!!!!!get this section from ocn_comp_mct afer the first ocn_export_mct
+    if (errorCode /= 0) then
+       call mpas_log_write('ERROR in ocn_export', MPAS_LOG_CRIT)
+    endif
+
+    ! Setup clock for initial runs
+    if (runtype == "continue" .or. runtype == "branch" ) then
+       block_ptr => domain_ptr % blocklist
+       do while(associated(block_ptr))
+          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+
+          call ocn_time_average_coupled_init(forcingPool)
+          call ocn_time_average_coupled_accumulate(statePool, forcingPool, 1)
+          block_ptr => block_ptr % next
+       end do
+    end if
+
+
+    !call mpas_pool_get_config(domain_ptr % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+    !if ( trim(config_land_ice_flux_mode) .eq. 'pressure_only' ) then
+    !   call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
+    !                                        ocn_c2_glcshelf=.false.)
+    !else if ( trim(config_land_ice_flux_mode) .eq. 'standalone' ) then
+    !   call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
+    !                                        ocn_c2_glcshelf=.false.)
+    !else if ( trim(config_land_ice_flux_mode) .eq. 'coupled' ) then
+    !   call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
+    !                                        ocn_c2_glcshelf=.true.)
+    !else
+    !   call mpas_log_write('ERROR: unknown land_ice_flux_mode: ' // trim(config_land_ice_flux_mode), MPAS_LOG_CRIT)
+    !end if
+
+!-----------------------------------------------------------------------
+!
+!   get initial state from driver
+!
+!-----------------------------------------------------------------------
+
+    !timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
+    call ESMF_ClockGet(clock, timeStep=timeStep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    !call mpas_get_timeInterval(timeStep, dt=dt)
+    call ESMF_TimeIntervalGet( timeStep, s=ocn_cpl_dt, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ocn_import(importState, flds_scalar_name, domain_ptr,  &
+                       errorCode, rc)
+    if (errorCode /= 0) then
+       call mpas_log_write('Error in ocn_import', MPAS_LOG_CRIT)
+    endif
+
+    itimestep = 0
+
+    ! Reset all output alarms, to prevent intial time step from writing any output, unless it's ringing.
+    call mpas_stream_mgr_reset_alarms(domain_ptr % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
+    call mpas_stream_mgr_reset_alarms(domain_ptr % streamManager, direction=MPAS_STREAM_INPUT, ierr=ierr)
+
+
+!!!!!end section from ocn_comp_mct
+
     !-----------------------------------------------------------------------
     ! check whether all Fields in the exportState are "Updated"
     !-----------------------------------------------------------------------
@@ -1375,6 +1443,7 @@ contains
       ! Import state from coupler
        call ocn_import(importState, flds_scalar_name, domain_ptr,  &
                        errorCode, rc)
+
       ! Ensures MPAS AM write/compute startup steps are performed
       call ocn_analysis_compute_startup(domain_ptr, ierr)
 

--- a/driver_nuopc/ocn_import_export.F90
+++ b/driver_nuopc/ocn_import_export.F90
@@ -364,7 +364,7 @@ contains
 
   !==============================================================================
   subroutine ocn_import( importState, flds_scalar_name, domain,    &
-                         errorCode, rc )
+                         errorCode, rc, do_sw_chk )
 
     !-----------------------------------------------------------------------
     ! swnet  -- net short-wave heat flux                 (W/m2   )
@@ -377,6 +377,7 @@ contains
     type (domain_type), pointer, intent(in) :: domain
     integer            , intent(out) :: errorCode
     integer            , intent(out) :: rc
+    logical,   optional, intent(in)  :: do_sw_chk
 
     ! local variables
     character (cl) :: label,  message
@@ -427,9 +428,9 @@ contains
     character (cl) :: fldname
     type(ESMF_StateItem_Flag) :: itemflag
 !?#ifdef _HIRES
-!?    real (r8)            :: qsw_eps = -1.e-3_r8
+    real (r8)            :: qsw_eps = -1.e-3_r8
 !?#else
-    real (r8)            :: qsw_eps = 0._r8
+!?    real (r8)            :: qsw_eps = 0._r8
 !?#endif
 
     ! local variables - mpas names
@@ -699,13 +700,17 @@ contains
           seaIcePressure(iCell)       = Si_bpress (gcell) * med2mod_areacor(gcell)
        end do
 
-       if (ANY(shortWaveHeatFlux < qsw_eps)) then
-         do iCell = 1, nCells
-           gcell = iCell + cell_offset
-           write(stdout,*)'ERROR: gcell,shortWaveHeatFlux = ',&
-                      gcell,shortWaveHeatFlux(icell)
-         enddo
-         call shr_sys_abort('(set_surface_forcing) ERROR: SHF_QSW < qsw_eps in set_surface_forcing')
+       if(present(do_sw_chk)) then
+         if(do_sw_chk) then
+           if (ANY(shortWaveHeatFlux < qsw_eps)) then
+             do iCell = 1, nCells
+               gcell = iCell + cell_offset
+               write(stdout,*)'ERROR: gcell,shortWaveHeatFlux = ',&
+                          gcell,shortWaveHeatFlux(icell)
+             enddo
+             call shr_sys_abort('(set_surface_forcing) ERROR: SHF_QSW < qsw_eps in set_surface_forcing')
+           endif
+         endif
        endif
        
        ! for wave - uncomment later

--- a/driver_nuopc/ocn_import_export.F90
+++ b/driver_nuopc/ocn_import_export.F90
@@ -428,7 +428,7 @@ contains
     character (cl) :: fldname
     type(ESMF_StateItem_Flag) :: itemflag
 !?#ifdef _HIRES
-    real (r8)            :: qsw_eps = -1.e-3_r8
+    real (rkind)            :: qsw_eps = -1.e-3_rkind
 !?#else
 !?    real (r8)            :: qsw_eps = 0._r8
 !?#endif
@@ -702,14 +702,22 @@ contains
 
        if(present(do_sw_chk)) then
          if(do_sw_chk) then
-           if (ANY(shortWaveHeatFlux < qsw_eps)) then
-             do iCell = 1, nCells
+           !if (ANY(shortWaveHeatFlux(1:ncells) < qsw_eps)) then
+           !  do iCell = 1, nCells
+           !    gcell = iCell + cell_offset
+           !    write(stdout,*)'ERROR: gcell,shortWaveHeatFlux = ',&
+           !               gcell,shortWaveHeatFlux(icell)
+           !  enddo
+           !  call shr_sys_abort('(set_surface_forcing) ERROR: SHF_QSW < qsw_eps in set_surface_forcing')
+           !endif
+           do iCell = 1, nCells
+             if (shortWaveHeatFlux(icell) < qsw_eps) then
                gcell = iCell + cell_offset
                write(stdout,*)'ERROR: gcell,shortWaveHeatFlux = ',&
                           gcell,shortWaveHeatFlux(icell)
-             enddo
-             call shr_sys_abort('(set_surface_forcing) ERROR: SHF_QSW < qsw_eps in set_surface_forcing')
-           endif
+               call shr_sys_abort('(set_surface_forcing) ERROR: SHF_QSW < qsw_eps in set_surface_forcing')
+             endif
+           enddo
          endif
        endif
        
@@ -891,6 +899,7 @@ contains
     !-----------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    errorcode = ESMF_SUCCESS
 
     if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
 

--- a/src/analysis_members/Registry_eddy_product_variables.xml
+++ b/src/analysis_members/Registry_eddy_product_variables.xml
@@ -19,6 +19,10 @@
 			description="Logical flag determining if an analysis member write occurs on start-up."
 			possible_values=".true. or .false."
 		/>
+                <nml_option name="config_AM_eddyProductVariables_backward_output_offset" type="character" default_value="00-00-01_00:00:00"
+                        description="Backward offset for filename timestamps when writing the output stream"
+                        possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+                />
 	</nml_record>
 	<packages>
 		<package name="eddyProductVariablesAMPKG" description="This package includes variables required for the eddyProductVariables analysis member."/>

--- a/src/analysis_members/Registry_global_stats.xml
+++ b/src/analysis_members/Registry_global_stats.xml
@@ -27,6 +27,10 @@
 			description="Name of the stream that the globalStats analysis member should get information from."
 			possible_values="Any existing stream, or 'none'"
 		/>
+		<nml_option name="config_AM_globalStats_backward_output_offset" type="character" default_value="00-00-01_00:00:00"
+			description="Backward offset for filename timestamps when writing the output stream"
+			possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+		/>
 	</nml_record>
 	<packages>
 		<package name="globalStatsAMPKG" description="This package includes variables required for the global statistics analysis member."/>

--- a/src/analysis_members/Registry_meridional_heat_transport.xml
+++ b/src/analysis_members/Registry_meridional_heat_transport.xml
@@ -35,6 +35,10 @@
 			description="The name of the region group, for which the MHT should be computed in addition to the global MHT."
 			possible_values="'all', '', or the name of a region group."
 		/>
+                <nml_option name="config_AM_meridionalHeatTransport_backward_output_offset" type="character" default_value="00-00-01_00:00:00"
+                        description="Backward offset for filename timestamps when writing the output stream"
+                        possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+                />
 	</nml_record>
 	<dims>
 		<dim name="nMerHeatTransBins" definition="namelist:config_AM_meridionalHeatTransport_num_bins"

--- a/src/analysis_members/Registry_moc_streamfunction.xml
+++ b/src/analysis_members/Registry_moc_streamfunction.xml
@@ -39,6 +39,10 @@
 			description="The name of the transect group that holds the boundaries for the regions in the region group, configured in 'config_AM_mocStreamfunction_region_group'. Please note, that these two should have the same amount of entries."
 			possible_values="Any valid transect group name."
 		/>
+                <nml_option name="config_AM_mocStreamfunction_backward_output_offset" type="character" default_value="00-00-01_00:00:00"
+                        description="Backward offset for filename timestamps when writing the output stream"
+                        possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+                />
 	</nml_record>
 	<dims>
 		<dim name="nMocStreamfunctionBins" definition="namelist:config_AM_mocStreamfunction_num_bins"

--- a/src/analysis_members/Registry_ocean_heat_content.xml
+++ b/src/analysis_members/Registry_ocean_heat_content.xml
@@ -19,6 +19,10 @@
 			description="Logical flag determining if an analysis member write occurs on start-up."
 			possible_values=".true. or .false."
 		/>
+                <nml_option name="config_AM_oceanHeatContent_backward_output_offset" type="character" default_value="00-00-01_00:00:00"
+                        description="Backward offset for filename timestamps when writing the output stream"
+                        possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+                />
 	</nml_record>
 	<packages>
 		<package name="oceanHeatContentAMPKG" description="This package includes variables required for the temPlate analysis member."/>


### PR DESCRIPTION
ocn_comp_nuopc.F90 had its import of coupler fields fixed and this now establishes bit-for-bit restartability of the restart files for mpas-ocean. Some modifications to defaults for diagnostic output were made so that restarted runs produce bit-for-bit reproducible output as well for some of the diagnostics. Monthly mean time average output is not yet reproducible as the first time step after initialization fails to accumulate