### PR TITLE
Use tag for MARBL submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	path = src/MARBL
 	url = https://github.com/E3SM-Project/MARBL.git
         fxrequired = AlwaysRequired
-        fxtag = stable
+        fxtag = marbl0.39.1
 	fxDONOTUSEurl = https://github.com/E3SM-Project/MARBL.git


### PR DESCRIPTION
Change the MARBL submodule to pull from an equivalent tag to the currently used 'stable' branch.