### PR TITLE
Add missing domainID initialization

### DIFF
--- a/driver_nuopc/ocn_comp_nuopc.F90
+++ b/driver_nuopc/ocn_comp_nuopc.F90
@@ -363,6 +363,7 @@ contains
       logical, pointer :: tempLogicalConfig
       character(len=StrKIND), pointer :: tempCharConfig
       real (kind=RKIND) :: dt
+      integer, save :: domainID = 0
 
      ! Added for coupling interval initialization
       integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
@@ -483,6 +484,9 @@ contains
 
     ! Write to ocnLogUnit here, because the log module is not open yet.
     if (iam==0) write(ocnLogUnit,'(a,i6)') '=== Beginning InitializeRealize for ocn: rank=',iam
+
+    domain_ptr % domainID = domainID
+    domainID = domainID + 1
 
     call mpas_framework_init_phase1(domain_ptr % dminfo, lmpicom)
     


### PR DESCRIPTION
An initialization was missing for domainID. This has been added.

This deals with part of @gdicker1 's [point 4](https://github.com/EarthWorksOrg/EarthWorks/pull/133#issuecomment-3134048398) in EarthWorks PR#133, with funky error filenames when using the GNU compiler.