### PR TITLE
Edited: OpenACC port of the Split-Explicit implementation.

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -283,7 +283,7 @@ def _build_mpaso():
         user_cppdefs = '\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_PERF_MOD_TIMERS -DUSE_LAPACK'
         if gpu_type != 'none':
             user_cppdefs += ' -DMPAS_OPENACC -DMPAS_NVTX_RANGES '
-            fixedflags += ' -gopt -O4 -Mnosave -Mrecursive -Mstack_arrays -acc=gpu -Minfo=acc -gpu=lineinfo,cc80,safecache,mem:managed -cudalib=cublas '
+            fixedflags += ' -gopt -O4 -Mnosave -Mrecursive -Mstack_arrays -acc=gpu -Minfo=acc -gpu=lineinfo,cc80,safecache -cudalib=cublas '
         user_cppdefs += ' -DMPAS_NAMELIST_SUFFIX=ocean\"'
         fixedflags += '"'
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -215,15 +215,15 @@ def _build_mpaso():
         #    raise
         compiler = case.get_value("COMPILER")
         if compiler == 'intel':
-            fixedflags =  '-free'
+            fixedflags =  '"-free'
         elif compiler == 'intel-oneapi':
-            fixedflags =  '-free'
+            fixedflags =  '"-free'
         elif compiler == 'gnu':
-            fixedflags =  '-ffree-form'
+            fixedflags =  '"-ffree-form'
         elif compiler == 'nvhpc':
-            fixedflags =  '-Mfree'
+            fixedflags =  '"-Mfree'
         else:
-            fixedflags = ''
+            fixedflags = '"'
 
     with Case(caseroot) as case:
         casetools = case.get_value("CASETOOLS")
@@ -282,8 +282,10 @@ def _build_mpaso():
 
         user_cppdefs = '\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_PERF_MOD_TIMERS -DUSE_LAPACK'
         if gpu_type != 'none':
-            user_cppdefs += ' -DMPAS_OPENACC'
+            user_cppdefs += ' -DMPAS_OPENACC -DMPAS_NVTX_RANGES '
+            fixedflags += ' -gopt -O4 -Mnosave -Mrecursive -Mstack_arrays -acc=gpu -Minfo=acc -gpu=lineinfo,cc80,safecache,mem:managed -cudalib=cublas '
         user_cppdefs += ' -DMPAS_NAMELIST_SUFFIX=ocean\"'
+        fixedflags += '"'
 
         cmd = "{} complib -j {} MODEL=mpaso COMPLIB={} -f {} USER_CPPDEFS={} FIXEDFLAGS={} {}" \
             .format(gmake, gmake_j, complib, makefile, user_cppdefs, fixedflags, get_standard_makefile_args(case))

--- a/src/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/mode_analysis/mpas_ocn_analysis_mode.F
@@ -332,62 +332,7 @@ module ocn_analysis_mode
 
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
 
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThickness, normalVelocity)
-         !$acc update device (normalTransportVelocity, &
-         !$acc                normalGMBolusVelocity)
-         !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-         !$acc enter data copyin(ssh)
-         !$acc enter data copyin(activeTracers)
-         !$acc update device(tracersSurfaceValue)
-         if ( associated(frazilSurfacePressure) ) then
-            !$acc enter data copyin(frazilSurfacePressure)
-         endif
-         if (landIcePressureOn) then
-            !$acc enter data copyin(landIcePressure)
-            !$acc enter data copyin(landIceDraft)
-         endif
-#endif
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
-#ifdef MPAS_OPENACC
-         !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-         !$acc update host(relativeVorticity, circulation)
-         !$acc update host(vertTransportVelocityTop, &
-         !$acc             vertGMBolusVelocityTop, &
-         !$acc             relativeVorticityCell, &
-         !$acc             divergence, &
-         !$acc             kineticEnergyCell, &
-         !$acc             tangentialVelocity, &
-         !$acc             vertVelocityTop)
-         !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-         !$acc             normalizedRelativeVorticityCell)
-         !$acc update host (surfacePressure)
-         !$acc update host(zMid, zTop)
-         !$acc exit data copyout(ssh)
-         !$acc update host(tracersSurfaceValue)
-         !$acc update host(normalVelocitySurfaceLayer)
-         !$acc exit data delete (atmosphericPressure, seaIcePressure)
-         if ( associated(frazilSurfacePressure) ) then
-            !$acc exit data delete(frazilSurfacePressure)
-         endif
-         if (landIcePressureOn) then
-            !$acc exit data delete(landIcePressure)
-            !$acc exit data delete(landIceDraft)
-         endif
-         !$acc exit data delete (activeTracers)
-         !$acc exit data delete (layerThickness, normalVelocity)
-         !$acc update host(density, potentialDensity, displacedDensity)
-         !$acc update host(thermExpCoeff,  &
-         !$acc&            salineContractCoeff)
-         !$acc update host(montgomeryPotential, pressure)
-         !$acc update host(RiTopOfCell, &
-         !$acc             BruntVaisalaFreqTop)
-         !$acc update host(tracersSurfaceLayerValue, &
-         !$acc             indexSurfaceLayerDepth, &
-         !$acc             normalVelocitySurfaceLayer, &
-         !$acc             sfcFlxAttCoeff, &
-         !$acc             surfaceFluxAttenuationCoefficientRunoff)
-#endif
          block_ptr => block_ptr % next
       end do
 

--- a/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -768,77 +768,11 @@ module ocn_time_integration_rk4
             call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          endif
 
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-         !$acc update device (normalTransportVelocity)
-         if (config_use_gm) then
-            !$acc update device (normalGMBolusVelocity)
-         end if
-         if (config_submesoscale_enable) then
-            !$acc update device (normalMLEvelocity)
-         end if
-         !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-         !$acc enter data copyin(sshNew)
-         !$acc enter data copyin(activeTracersNew)
-         !$acc update device(tracersSurfaceValue)
-         if ( associated(frazilSurfacePressure) ) then
-            !$acc enter data copyin(frazilSurfacePressure)
-         endif
-         if (landIcePressureOn) then
-            !$acc enter data copyin(landIcePressure)
-            !$acc enter data copyin(landIceDraft)
-         endif
-#endif
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(forcingPool, &
                                                        statePool, err)
-
-#ifdef MPAS_OPENACC
-         !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-         !$acc update host(relativeVorticity, circulation)
-         if (config_use_gm) then
-            !$acc update host(vertGMBolusVelocityTop)
-         end if
-         if (config_submesoscale_enable) then
-            !$acc update host(vertMLEBolusVelocityTop)
-         end if
-         !$acc update host(vertTransportVelocityTop, &
-         !$acc             relativeVorticityCell, &
-         !$acc             divergence, &
-         !$acc             kineticEnergyCell, &
-         !$acc             tangentialVelocity, &
-         !$acc             vertVelocityTop)
-         !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-         !$acc             normalizedRelativeVorticityCell)
-         !$acc update host (surfacePressure)
-         !$acc update host(zMid, zTop)
-         !$acc exit data copyout(sshNew)
-         !$acc exit data delete(activeTracersNew)
-         !$acc update host(tracersSurfaceValue)
-         !$acc update host(normalVelocitySurfaceLayer)
-         !$acc exit data delete (atmosphericPressure, seaIcePressure)
-         if ( associated(frazilSurfacePressure) ) then
-            !$acc exit data delete(frazilSurfacePressure)
-         endif
-         if (landIcePressureOn) then
-            !$acc exit data delete(landIcePressure)
-            !$acc exit data delete(landIceDraft)
-         endif
-         !$acc exit data delete(layerThicknessNew, normalVelocityNew)
-         !$acc update host(density, potentialDensity, displacedDensity)
-         !$acc update host(thermExpCoeff,  &
-         !$acc&            salineContractCoeff)
-         !$acc update host(montgomeryPotential, pressure)
-         !$acc update host(RiTopOfCell, &
-         !$acc             BruntVaisalaFreqTop)
-         !$acc update host(tracersSurfaceLayerValue, &
-         !$acc             indexSurfaceLayerDepth, &
-         !$acc             normalVelocitySurfaceLayer, &
-         !$acc             sfcFlxAttCoeff, &
-         !$acc             surfaceFluxAttenuationCoefficientRunoff)
-#endif
 
          ! ------------------------------------------------------------------
          ! Accumulating various parameterizations of the transport velocity
@@ -1473,72 +1407,7 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       endif
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessCur, normalVelocityCur)
-      !$acc update device (normalTransportVelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEvelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshCur)
-      !$acc enter data copyin(activeTracersCur)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
       call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host(vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host(vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshCur)
-      !$acc exit data delete(activeTracersCur)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete(layerThicknessCur, normalVelocityCur)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-#endif
 
       ! ------------------------------------------------------------------
       ! Accumulating various parametrizations of the transport velocity
@@ -1798,73 +1667,7 @@ module ocn_time_integration_rk4
          end if
       end do
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity,normalMLEvelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEvelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(activeTracersNew)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host(vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host(vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshNew)
-      !$acc exit data delete(activeTracersNew)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete (layerThicknessNew, normalVelocityNew)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-#endif
 
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 

--- a/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -56,6 +56,8 @@ module ocn_time_integration_si
    use ocn_surface_land_ice_fluxes
    use ocn_transport_tests
 
+   use cublas
+
    implicit none
    private
    save
@@ -133,6 +135,11 @@ module ocn_time_integration_si
       ncpus,            &! Total number of cores
       nSiLargeIter       ! #iteration for the barotropic system
    character(len=5) :: si_algorithm ! Name of the iterative solver algorithm
+   type(cublasHandle) :: h
+   integer :: istat
+!$acc declare create(prec_ivmat,SIcst_allreduce_local2,SIcst_allreduce_global2,SIcst_allreduce_local3,SIcst_allreduce_global3,&
+!$acc                SIcst_allreduce_local9,SIcst_allreduce_global9,globalReprodSum2fld1,globalReprodSum2fld2,globalReprodSum3fld1,&
+!$acc                globalReprodSum3fld2,globalReprodSum9fld1,globalReprodSum9fld2)
 
    integer :: ssh_sal_on
 
@@ -250,6 +257,7 @@ module ocn_time_integration_si
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp, &
          bottomDepthEdge
+!$acc declare create(uTemp,bottomDepthEdge,btrvel_temp)
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -408,43 +416,43 @@ module ocn_time_integration_si
 
       !*** Retrieve state variables at two time levels
 
-      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityCur, 1)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityCur, 1)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocitySubcycle', &
                                            normalBarotropicVelocitySubcycleCur, 1)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                            normalVelocityCur, 1)
 
-      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityNew, 2)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityNew, 2)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocitySubcycle', &
                                            normalBarotropicVelocitySubcycleNew, 2)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                            normalVelocityNew, 2)
 
-      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-      call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', sshNew, 2)
 
-      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', sshSubcycleCur, 1)
+      call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', sshSubcycleNew, 2)
 
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThicknessCur, 1)
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThicknessNew, 2)
 
-      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
                                            highFreqThicknessCur, 1)
-      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
                                            highFreqThicknessNew, 2)
 
-      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceCur, 1)
-      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceNew, 2)
 
       call mpas_pool_get_dimension_scalar(tracersPool, 'index_salinity', &
@@ -454,13 +462,13 @@ module ocn_time_integration_si
 
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
-      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
-      call mpas_pool_get_array(tendPool, 'ssh', &
+      call mpas_pool_get_array_gpu(tendPool, 'ssh', &
                                           sshTend)
-      call mpas_pool_get_array(tendPool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(tendPool, 'layerThickness', &
                                           layerThicknessTend)
-      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
@@ -472,7 +480,7 @@ module ocn_time_integration_si
                                           vertVelocityNonhydroNew, 2)
       call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', &
                                           vertVelocityNonhydroCur, 1)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracersNew, 2)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
@@ -482,21 +490,6 @@ module ocn_time_integration_si
         call ocn_transport_test_velocity(meshPool, daysSinceStartOfSim, &
           0.5*dt, normalVelocityCur)
       endif
-
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc   sshCur, layerThicknessCur, sshSubcycleCur, sshSubcycleNew)
-      !$acc enter data create(normalBaroClinicVelocityCur, normalVelocityNew, &
-      !$acc   normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
-      if (associated(highFreqThicknessNew)) then
-         !$acc enter data copyin(highFreqThicknessCur)
-         !$acc enter data create(highFreqThicknessNew)
-      endif
-      if (associated(lowFreqDivergenceNew)) then
-         !$acc enter data copyin(lowFreqDivergenceCur)
-         !$acc enter data create(lowFreqDivergenceNew)
-      endif
-#endif
 
       ! Initialize * variables that are used to compute baroclinic
       ! tendencies below.
@@ -511,20 +504,16 @@ module ocn_time_integration_si
       ! variable subtracts out the barotropic component from the
       ! baroclinic.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel present(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc    sshCur, layerThicknessCur, normalBaroClinicVelocityCur, &
-      !$acc    normalVelocityNew, normalBaroclinicVelocityNew, sshNew, &
-      !$acc    layerThicknessNew, minLevelCell, maxLevelCell,          &
-      !$acc    sshSubcycleCur,sshSubcycleNew)
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc loop collapse(2)
-#else
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              normalBaroclinicVelocityCur,normalVelocityCur,normalBarotropicVelocityCur,&
+!$acc              normalVelocityNew,normalBaroclinicVelocityNew,sshNew,sshCur,sshSubcycleCur,&
+!$acc              sshSubcycleNew,layerThicknessNew,layerThicknessCur,highFreqThicknessNew,&
+!$acc              highFreqThicknessCur,lowFreqDivergenceNew,lowFreqDivergenceCur)
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel vector_length(1024)
+!$acc loop gang vector collapse(2)
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
 
@@ -538,146 +527,111 @@ module ocn_time_integration_si
          normalBaroclinicVelocityCur(k,iEdge)
       end do
       end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc loop gang
-#else
       !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
       do iCell = 1, nCellsAll
          sshNew(iCell) = sshCur(iCell)
          sshSubcycleCur(iCell) = sshCur(iCell)
          sshSubcycleNew(iCell) = sshCur(iCell)
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
+!$acc loop vector
          do k = 1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc end parallel
-#else
+!$acc end parallel
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr))
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
                                      tracersGroupCur, 1)
-            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
                                      tracersGroupNew, 2)
 
             if ( associated(tracersGroupCur) .and. &
                  associated(tracersGroupNew) ) then
 
-#ifdef MPAS_OPENACC
-               !$acc enter data create(tracersGroupNew)
-               !$acc enter data copyin(tracersGroupCur)
-               !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
-               !$acc    tracersGroupNew, tracersGroupCur)
-#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iCell = 1, nCellsAll
+!$acc loop vector
                do k = minLevelCell(iCell), maxLevelCell(iCell)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                   do iTracer = 1,size(tracersGroupCur,1)
                      tracersGroupNew(iTracer,k,iCell) = &
                      tracersGroupCur(iTracer,k,iCell)
                   end do
                end do
                end do
-#ifdef MPAS_OPENACC
-               !$acc exit data copyout(tracersGroupNew)
-               !$acc exit data delete(tracersGroupCur)
-#else
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
             end if
          end if
       end do
 
       if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell=1,nCellsAll
             do k = 2, maxLevelCell(iCell)
                vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell)
            end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       if (associated(highFreqThicknessNew)) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang &
-         !$acc    present(highFreqThicknessCur, highFreqThicknessNew)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
          do k = 1,nVertLevels
             highFreqThicknessNew(k,iCell) = &
             highFreqThicknessCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       if (associated(lowFreqDivergenceNew)) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang &
-         !$acc    present(lowFreqDivergenceCur, lowFreqDivergenceNew)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
          do k = 1,nVertLevels
             lowFreqDivergenceNew(k,iCell) = &
             lowFreqDivergenceCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
       endif
+!$acc end data
+
 
       call mpas_timer_stop("si prep")
 
-      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
       if (landIcePressureOn) then
-         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
       endif
 
       if ( config_btr_si_partition_match_mode ) then
@@ -693,21 +647,6 @@ module ocn_time_integration_si
                       globalReprodSum3fld2(nCellsOwned,3) )
          endif
       endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc    sshCur, layerThicknessCur)
-      !$acc exit data copyout(normalBaroClinicVelocityCur, normalVelocityNew, &
-      !$acc    normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
-      if (associated(highFreqThicknessNew)) then
-         !$acc exit data delete(highFreqThicknessCur)
-         !$acc exit data copyout(highFreqThicknessNew)
-      endif
-      if (associated(lowFreqDivergenceNew)) then
-         !$acc exit data delete(lowFreqDivergenceCur)
-         !$acc exit data copyout(lowFreqDivergenceNew)
-      endif
-#endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! BEGIN large outer timestep iteration loop
@@ -726,17 +665,8 @@ module ocn_time_integration_si
 
          stage1_tend_time = min(splitImplicitStep,2)
 
-         call mpas_pool_get_array(statePool, 'normalVelocity', &
+         call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                            normalVelocityCur, stage1_tend_time)
-
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update device(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
-            !$acc enter data create(highFreqThicknessNew)
-            !$acc enter data copyin(highFreqThicknessCur, highFreqThicknessTend)
-         endif
-#endif
 
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
@@ -777,17 +707,9 @@ module ocn_time_integration_si
 
             call mpas_timer_stop("si freq-filtered-thick halo update")
 
-#ifdef MPAS_OPENACC
-            !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
-            !$acc    highFreqThicknessNew, highFreqThicknessCur, highFreqThicknessTend)
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
             do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h^{hf}_{n+1}
                highFreqThicknessNew(k,iCell) = &
@@ -795,10 +717,8 @@ module ocn_time_integration_si
                highFreqThicknessTend(k,iCell)
             end do
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
 
          endif ! freq filtered thickness
 
@@ -811,30 +731,18 @@ module ocn_time_integration_si
          ! Use the most recent time level available.
 
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
-#ifdef MPAS_OPENACC
-            !$acc exit data delete(highFreqThicknessNew)
-#endif
          else
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, &
                  sshCur, dt, vertAleTransportTop, err)
          endif
 
-#ifdef MPAS_OPENACC
-         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update host(vertAleTransportTop)
-         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
-            !$acc exit data copyout(highFreqThicknessNew)
-            !$acc exit data delete(highFreqThicknessCur, highFreqThicknessTend)
-         endif
-#endif
-
-         call ocn_tend_vel(domain, tendPool, statePool, forcingPool, &
+         call ocn_tend_vel_gpu(domain, tendPool, statePool, forcingPool, &
                            stage1_tend_time, domain % dminfo, dt)
 
          call mpas_timer_stop('si bcl vel tend')
@@ -849,7 +757,7 @@ module ocn_time_integration_si
 
             ! Put f*normalBaroclinicVelocity^{perp} in
             ! normalVelocityNew as a work variable
-            call ocn_fuperp(statePool, meshPool, 2)
+            call ocn_fuperp_gpu(statePool, meshPool, 2)
 
             !TODO: look at loop optimizations here
             ! Only need to loop over owned cells, since there is a halo
@@ -857,17 +765,24 @@ module ocn_time_integration_si
 
             allocate(uTemp(nVertLevels,nEdgesOwned))
 
-#ifndef MPAS_OPENACC
+!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,dcEdge,nEdgesHalo,&
+!$acc              normalBaroclinicVelocityCur,normalVelocityTend,normalVelocityNew,sshNew,&
+!$acc              layerThickEdgeFlux,barotropicForcing,normalBaroclinicVelocityNew,uTemp,bottomDepthEdge)
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k, cell1, cell2, uTemp, &
             !$omp         normalThicknessFluxSum, thicknessSum)
-#endif
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,normalThicknessFluxSum,thicknessSum)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-               uTemp(:,iEdge) = 0.0_RKIND
+!$acc loop vector
+               do k = 1, nVertLevels
+                  uTemp(k,iEdge) = 0.0_RKIND
+               enddo
+!$acc loop vector
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! normalBaroclinicVelocityNew =
                   ! normalBaroclinicVelocityOld +
@@ -892,7 +807,7 @@ module ocn_time_integration_si
                   * uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum = &
                     layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-
+!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                  layerThickEdgeFlux(k,iEdge)*uTemp(k,iEdge)
@@ -901,7 +816,7 @@ module ocn_time_integration_si
                enddo
                barotropicForcing(iEdge) = &
                               normalThicknessFluxSum/thicknessSum/dt
-
+!$acc loop vector
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
                   !{\bf u}'_{k,n+1} =
@@ -913,20 +828,21 @@ module ocn_time_integration_si
                   normalBaroclinicVelocityCur(k,iEdge) + uTemp(k,iEdge) - &
                          dt * barotropicForcing(iEdge))
                enddo
-
             enddo ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1, cell2, k, thicknessSum)
-#endif
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,thicknessSum)
             do iEdge = 1, nEdgesHalo(config_num_halos+1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+!$acc loop seq
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
@@ -934,10 +850,10 @@ module ocn_time_integration_si
                bottomDepthEdge(iEdge) = thicknessSum &
                   - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
+!$acc end data
 
             deallocate(uTemp)
 
@@ -966,7 +882,6 @@ module ocn_time_integration_si
 !                  iterGroupName)
 !        call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
 !        call mpas_timer_stop("si halo btr vel")
-
 
 
          call mpas_timer_stop("si bcl vel")
@@ -1047,17 +962,15 @@ module ocn_time_integration_si
          nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
 
          if (config_filter_btr_mode) then
-#ifndef MPAS_OPENACC
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_filter_btr_mode NOT EXECUTING"
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
             do iEdge = 1, nEdges
                barotropicForcing(iEdge) = 0.0_RKIND
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
          endif
 
 
@@ -1073,36 +986,36 @@ module ocn_time_integration_si
             if ( splitImplicitStep == 2 .or. siLargeIter > 1 ) then
                ! Here sshSubcycleNew and normalBarotropicVelocityCur
                ! are at time n+1/2.
-   
-#ifndef MPAS_OPENACC
+
                !$omp parallel
                !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
                do iCell = 1,nCellsAll
                   sshSubcycleNew(iCell) = &
                      0.5_RKIND*( sshSubcycleNew(iCell) &
                                 +sshCur(iCell) )
                   sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
                end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
-   
+  
                !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
                do iEdge = 1,nEdgesAll
                   normalBarotropicVelocityCur(iEdge) = &
                      normalBarotropicVelocitySubcycleCur(iEdge)
                end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
             endif ! splitImplicitStep
-   
-#ifndef MPAS_OPENACC
+  
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-#endif
+!$acc parallel
+!$acc loop gang vector private(CoriolisTerm,eoe)
             do iEdge = 1, nEdgesAll
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.d0
@@ -1114,10 +1027,9 @@ module ocn_time_integration_si
                end do ! i
                   barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
    
             ! Subtract tidal potential from ssh, if needed
             ! Subtract the tidal potential from the current
@@ -1126,6 +1038,8 @@ module ocn_time_integration_si
             ! tidal potential terms are included in the grad
             ! operator inside the edge loop.
             if (config_use_tidal_potential_forcing) then
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_use_tidal_potential_forcing NOT EXECUTING"
    
                call mpas_pool_get_array(forcingPool,            &
                                      'sshSubcycleCurWithTides', &
@@ -1134,10 +1048,8 @@ module ocn_time_integration_si
                                        'tidalPotentialEta', &
                                         tidalPotentialEta)
    
-#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
-#endif
                do iCell = 1, nCellsAll
                  sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) &
                             - tidalPotentialEta(iCell)                  &
@@ -1146,26 +1058,20 @@ module ocn_time_integration_si
                             * config_self_attraction_and_loading_beta   &
                             * sshSubcycleCur(iCell)
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
    
                call mpas_pool_get_array(forcingPool,            &
                                      'sshSubcycleCurWithTides', &
                                       sshSubcycleNew)
    
-#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
-#endif
                do iCell = 1,nCellsAll
                   sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
    
             endif !config_use_tidal_potential_forcing
    
@@ -1177,22 +1083,24 @@ module ocn_time_integration_si
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr residual")
-   
-#ifndef MPAS_OPENACC
+
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
             !$omp         cell1,cell2,sshEdgeCur,thicknessSumCur, &
             !$omp         sshDiffCur,fluxb1,fluxb2,fluxAx,sshCurArea)
-#endif
+!$acc parallel
+!$acc loop gang vector private(sshTendb1,sshTendb2,sshTendAx,iEdge,cell1,cell2,sshEdgeCur,thicknessSumCur,sshDiffCur,&
+!$acc                          fluxb1,fluxb2,fluxAx,sshCurArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-   
+!$acc loop seq 
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
+!NV!                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
+                  if (maxLevelEdgeTop(iEdge).ne.0) then
    
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
@@ -1223,6 +1131,7 @@ module ocn_time_integration_si
                                         * fluxb2 * dvEdge(iEdge)
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                                         * fluxAx * dvEdge(iEdge)
+                  endif
                end do ! i
    
                sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
@@ -1235,14 +1144,14 @@ module ocn_time_integration_si
                SIvec_r00(iCell) = SIvec_r0(iCell)
    
             end do ! iCell
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
    
             ! Preconditioning --------------------------------------------!
 
-            call si_precond(SIvec_r0,SIvec_rh0)
+!NV!        On GPU
+            call si_precond_gpu(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
@@ -1250,15 +1159,15 @@ module ocn_time_integration_si
   
    
             ! SpMV -------------------------------------------------------!
-   
-            call si_matvec_mul(SIvec_rh0,bottomDepthEdge, &
+            call si_matvec_mul_gpu(SIvec_rh0,bottomDepthEdge, &
                                SIvec_w0,sshSubcycleCur)
 
             if ( si_algorithm == 'sbicg' ) then !!!
-
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "si_algorithm == 'sbicg' NOT EXECUTING"
             ! Preconditioning --------------------------------------------!
 
-               call si_precond(SIvec_w0,SIvec_wh0)
+               call si_precond_gpu(SIvec_w0,SIvec_wh0)
       
                call mpas_timer_start("si halo r0")
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
@@ -1288,20 +1197,24 @@ module ocn_time_integration_si
                SIcst_omega0 = 0.0_RKIND
 
             else if ( si_algorithm == 'scg' ) then !!!
-           
+         
+!$acc parallel
+!$acc loop gang vector  
                do iCell = 1, nPrecVec
                   SIvec_s0(iCell)  = 0.0_RKIND
                   SIvec_z0(iCell)  = 0.0_RKIND
                end do ! iCell
+!$acc end parallel
    
                ! Reduction --------------------------------------------------!
                call mpas_timer_start("si reduction r0")
-               call si_global_reduction(SIcst_allreduce_local2, &
+               call si_global_reduction_gpu(SIcst_allreduce_local2, &
                                    SIcst_allreduce_global2,     &
                                    globalReprodSum2fld1,        &
                                    globalReprodSum2fld2,        &
                                    si_algorithm,2,domain,       &
                                    SIvec_r0,SIvec_w0,SIvec_rh0)
+!$acc update host(SIcst_allreduce_local2,SIcst_allreduce_global2)
                call mpas_timer_stop ("si reduction r0")
    
                SIcst_r0rh0_global = SIcst_allreduce_global2(1)
@@ -1324,12 +1237,15 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr iteration")
 
             if ( si_algorithm == 'sbicg' ) then
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "si_algorithm == 'sbicg' si_solver_sbicg NOT EXECUTING"
                call si_solver_sbicg(domain,                                &
                     sshSubcycleNew,sshSubcycleCur,bottomDepthEdge,         &
                     tolerance_outer,SIcst_alpha0,SIcst_beta0,SIcst_gamma0, &
                     SIcst_rho0)
             else if ( si_algorithm == 'scg' ) then
-               call si_solver_scg(domain,                                  &
+!NV!           ON GPU
+               call si_solver_scg_gpu(domain,                                  &
                     sshSubcycleNew,sshSubcycleCur,bottomDepthEdge,         &
                     tolerance_outer,SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
             endif
@@ -1349,22 +1265,23 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr vel update")
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
             do iCell = 1,nCellsAll
                ! Use of sshNew to save the lagged SSH
                sshNew(iCell) = sshSubcycleNew(iCell)
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+  
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo( edgeHaloComputeCounter-1 )
                temp_mask = edgeMask(1, iEdge)
    
@@ -1385,16 +1302,18 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+  
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-#endif
+!$acc parallel
+!$acc loop gang vector private(CoriolisTerm,eoe)
             do iEdge = 1,nEdgesHalo(2)
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
+!$acc loop seq
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
                   CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge)       &
@@ -1405,14 +1324,15 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1425,13 +1345,14 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)        &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+  
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-#endif
+!$acc parallel
+!$acc loop gang vector private(CoriolisTerm,eoe)
             do iEdge = 1,nEdgesOwned
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
@@ -1445,10 +1366,9 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
    
             call mpas_timer_start("si halo btr coriolis")
             call mpas_dmpar_field_halo_exch(domain, 'barotropicCoriolisTerm')
@@ -1465,8 +1385,7 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr residual")
    
             ! SpMV -------------------------------------------------------!
-   
-#ifndef MPAS_OPENACC
+  
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
@@ -1474,15 +1393,19 @@ module ocn_time_integration_si
             !$omp         thicknessSumCur,thicknessSumMid, &
             !$omp         thicknessSumLag,sshDiffCur,sshDiffLag, &
             !$omp         fluxb1,fluxb2,fluxAx,sshCurArea,sshLagArea)
-#endif
+!$acc parallel
+!$acc loop gang vector private(sshTendb1,sshTendb2,sshTendAx,iEdge,cell1,cell2,sshEdgeCur,sshEdgeLag,sshEdgeMid,&
+!$acc                          thicknessSumCur,thicknessSumLag,thicknessSumMid,sshDiffCur,sshDiffLag,fluxb1,fluxb2,fluxAx,&
+!$acc                          sshCurArea,sshLagArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-   
+!$acc loop seq
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
+!NV!                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
+                  if (maxLevelEdgeTop(iEdge).ne.0) then
    
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
@@ -1523,6 +1446,7 @@ module ocn_time_integration_si
                                         * fluxb2 * dvEdge(iEdge)
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                                         * fluxAx * dvEdge(iEdge)
+                  endif
                end do ! i
    
                sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
@@ -1536,28 +1460,28 @@ module ocn_time_integration_si
                                 -(-sshLagArea - sshTendAx)
                SIvec_r00(iCell) = SIvec_r0(iCell)
             end do ! iCell
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
    
             ! Preconditioning --------------------------------------------!
 
-            call si_precond(SIvec_r0,SIvec_rh0)
+!NV!        ON GPU
+            call si_precond_gpu(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
             call mpas_timer_stop("si halo r0")
    
             ! SpMV -------------------------------------------------------!
-
-            call si_matvec_mul(SIvec_rh0,bottomDepthEdge,SIvec_w0,sshNew)
+            call si_matvec_mul_gpu(SIvec_rh0,bottomDepthEdge,SIvec_w0,sshNew)
 
             if ( si_algorithm == 'sbicg' ) then !!!
-
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "si_algorithm == 'sbicg' NOT EXECUTING"
             ! Preconditioning --------------------------------------------!
 
-               call si_precond(SIvec_w0,SIvec_wh0)
+               call si_precond_gpu(SIvec_w0,SIvec_wh0)
       
                call mpas_timer_start("si halo r0")
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
@@ -1587,20 +1511,24 @@ module ocn_time_integration_si
                SIcst_omega0 = 0.0_RKIND
 
             else if ( si_algorithm == 'scg' ) then !!!
-           
+          
+!$acc parallel
+!$acc loop gang vector 
                do iCell = 1, nPrecVec
                   SIvec_s0(iCell)  = 0.0_RKIND
                   SIvec_z0(iCell)  = 0.0_RKIND
                end do ! iCell
+!$acc end parallel
    
                ! Reduction --------------------------------------------------!
                call mpas_timer_start("si reduction r0")
-               call si_global_reduction(SIcst_allreduce_local2, &
+               call si_global_reduction_gpu(SIcst_allreduce_local2, &
                                    SIcst_allreduce_global2,     &
                                    globalReprodSum2fld1,        &
                                    globalReprodSum2fld2,        &
                                    si_algorithm,2,domain,       &
                                    SIvec_r0,SIvec_w0,SIvec_rh0)
+!$acc update host(SIcst_allreduce_local2,SIcst_allreduce_global2)
                call mpas_timer_stop ("si reduction r0")
    
                SIcst_r0rh0_global = SIcst_allreduce_global2(1)
@@ -1621,12 +1549,15 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr iteration")
 
             if ( si_algorithm == 'sbicg' ) then
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "si_algorithm == 'sbicg' si btr iteration NOT EXECUTING"
                call si_solver_sbicg(domain,                                &
                     sshSubcycleNew,sshNew,bottomDepthEdge,                 &
                     tolerance_inner,SIcst_alpha0,SIcst_beta0,SIcst_gamma0, &
                     SIcst_rho0)
             else if ( si_algorithm == 'scg' ) then
-               call si_solver_scg(domain,                                  &
+!NV!           ON GPU
+               call si_solver_scg_gpu(domain,                                  &
                     sshSubcycleNew,sshNew,bottomDepthEdge,                 &
                     tolerance_inner,SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
             endif
@@ -1643,12 +1574,12 @@ module ocn_time_integration_si
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr vel update")
-   
-#ifndef MPAS_OPENACC
+ 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1669,16 +1600,18 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+  
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-#endif
+!$acc parallel
+!$acc loop gang vector private(CoriolisTerm,eoe)
             do iEdge = 1,nEdgesHalo(1)
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
+!$acc loop seq
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
                   CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)     &
@@ -1689,14 +1622,15 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesOwned
                temp_mask = edgeMask(1, iEdge)
    
@@ -1710,16 +1644,18 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-   
+
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1,cell2,sshEdge,thicknessSum)
-#endif
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,sshEdge,thicknessSum)
             do iEdge = 1, nEdgesOwned
-               if (maxLevelEdgeTop(iEdge).eq.0) cycle
+!NV!               if (maxLevelEdgeTop(iEdge).eq.0) cycle
+               if (maxLevelEdgeTop(iEdge).ne.0) then
 
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
@@ -1742,11 +1678,11 @@ module ocn_time_integration_si
                   = 0.5*(  normalBarotropicVelocitySubcycleNew(iEdge) &
                          + normalBarotropicVelocityCur(iEdge) )       &
                          * thicknessSum
+               endif
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
    
    
             ! boundary update on F
@@ -1762,19 +1698,18 @@ module ocn_time_integration_si
                       finalBtrGroupName)
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
             call mpas_timer_stop("si halo btr vel")
-   
-#ifndef MPAS_OPENACC
+
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
             do iEdge = 1, nEdgesAll
                normalBarotropicVelocityNew(iEdge)              &
                   = normalBarotropicVelocitySubcycleCur(iEdge) 
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             call mpas_timer_stop("si btr vel update")
 
@@ -1805,27 +1740,29 @@ module ocn_time_integration_si
          nEdges = nEdgesHalo(config_num_halos-1 )
          allocate(uTemp(nVertLevels,nEdges))
 
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iEdge = 1, nEdges
-            uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
-                         + normalBaroclinicVelocityNew(:,iEdge)
+            do k = 1, nVertLevels
+               uTemp(k,iEdge) = normalBarotropicVelocityNew(iEdge) &
+                         + normalBaroclinicVelocityNew(k,iEdge)
+            enddo
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
 
-         call ocn_GM_add_to_transport_vel(uTemp, nEdges, nVertLevels)
-         call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
+         call ocn_GM_add_to_transport_vel_gpu(uTemp, nEdges, nVertLevels)
+!NV!     !!! NOT EXECUTING !!!
+         call ocn_MLE_add_to_transport_vel_gpu(uTemp, nEdges)
 
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iEdge = 1, nEdges
             do k = 1, nVertLevels
                normalTransportVelocity(k,iEdge) =  &
@@ -1833,22 +1770,22 @@ module ocn_time_integration_si
                         normalBaroclinicVelocityNew(k,iEdge)
             end do
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
 
          ! add GM and submesoscale contributions if requested
-         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, &
+         call ocn_GM_add_to_transport_vel_gpu(normalTransportVelocity, nEdges, &
                                           nVertLevels)
-         call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
+!NV!     !!! NOT EXECUTING !!!
+         call ocn_MLE_add_to_transport_vel_gpu(normalTransportVelocity, nEdges)
 
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp private(k, normalThicknessFluxSum, &
          !$omp         thicknessSum, normalVelocityCorrection)
-#endif
+!$acc parallel
+!$acc loop gang worker private(normalThicknessFluxSum,thicknessSum,normalVelocityCorrection)
          do iEdge = 1, nEdges
 
             ! thicknessSum is initialized outside the loop because
@@ -1860,7 +1797,7 @@ module ocn_time_integration_si
                * uTemp(minLevelEdgeBot(iEdge),iEdge)
             thicknessSum &
                = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-
+!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
             do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                normalThicknessFluxSum = normalThicknessFluxSum + &
                                         layerThickEdgeFlux(k,iEdge)* &
@@ -1872,7 +1809,7 @@ module ocn_time_integration_si
             normalVelocityCorrection = useVelocityCorrection* &
                           ((barotropicThicknessFlux(iEdge) -  &
                             normalThicknessFluxSum)/thicknessSum)
-
+!$acc loop vector
             do k = 1, nVertLevels
 
                ! normalTransportVelocity = normalBarotropicVelocity
@@ -1888,10 +1825,9 @@ module ocn_time_integration_si
             enddo
 
          end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
 
          deallocate(uTemp)
 
@@ -1922,34 +1858,20 @@ module ocn_time_integration_si
          ! layerThickEdgeFlux because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessCur, sshCur)
-         !$acc update device(layerThickEdgeFlux, normalTransportVelocity)
-#endif
          if (associated(highFreqThicknessNew)) then
-#ifdef MPAS_OPENACC
-            !$acc enter data copyin(highFreqThicknessNew)
-#endif
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
-#ifdef MPAS_OPENACC
-            !$acc exit data delete(highFreqThicknessNew)
-#endif
          else
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
-#ifdef MPAS_OPENACC
-         !$acc exit data delete(layerThicknessCur, sshCur)
-         !$acc update host(vertAleTransportTop, normalTransportVelocity)
-#endif
          call mpas_timer_stop('thick vert trans vel top')
 
-         call ocn_tend_thick(tendPool, forcingPool)
+         call ocn_tend_thick_gpu(tendPool, forcingPool)
 
          call mpas_timer_stop('si thick tend')
 
@@ -1962,67 +1884,18 @@ module ocn_time_integration_si
 
          call mpas_timer_start('si tracer tend', .false.)
 
-         call ocn_tend_tracer(tendPool, statePool, forcingPool, &
+         call ocn_tend_tracer_gpu(tendPool, statePool, forcingPool, &
                               meshPool, swForcingPool, &
                               dt, activeTracersOnly, 2)
 
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupCur, 1)
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupNew, 2)
-         call mpas_pool_get_array(statePool,   'normalVelocity', &
+         call mpas_pool_get_array_gpu(statePool,   'normalVelocity', &
                                                 normalVelocityCur, 1)
-         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
+         call mpas_pool_get_array_gpu(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
-
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-         !$acc enter data copyin(normalBarotropicVelocityNew, &
-         !$acc                   normalBaroclinicVelocityNew)
-         !$acc enter data copyin(activeTracersNew)
-         !$acc update device(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness) then
-            !$acc enter data copyin(lowFreqDivergenceNew)
-            !$acc enter data copyin(lowFreqDivergenceCur)
-            !$acc enter data copyin(lowFreqDivergenceTend)
-         endif
-         if (splitImplicitStep < numTSIterations) then
-            !$acc update device (normalTransportVelocity)
-            !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-            !$acc enter data copyin(sshNew)
-            !$acc update device(tracersSurfaceValue)
-            if ( associated(normalGMBolusVelocity) ) then
-               !$acc update device (normalGMBolusVelocity)
-            end if
-            if ( associated(normalMLEVelocity) ) then
-               !$acc update device (normalMLEvelocity)
-            end if
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc enter data copyin(frazilSurfacePressure)
-            endif
-            if (landIcePressureOn) then
-               !$acc enter data copyin(landIcePressure)
-               !$acc enter data copyin(landIceDraft)
-            endif
-            if (config_use_freq_filtered_thickness) then
-               !$acc enter data copyin(highFreqThicknessNew)
-               !$acc enter data copyin(highFreqThicknessCur)
-            endif
-         elseif (splitImplicitStep == numTSIterations) then
-            !$acc enter data copyin(layerThicknessCur)
-            !$acc enter data copyin(layerThicknessTend)
-            !$acc enter data copyin(normalBaroclinicVelocityCur)
-            if (config_compute_active_tracer_budgets) then
-               !$acc update device(activeTracerHorizontalAdvectionEdgeFlux)
-               !$acc update device(activeTracerHorizontalAdvectionTendency)
-               !$acc update device(activeTracerVerticalAdvectionTendency)
-               !$acc update device(activeTracerHorMixTendency)
-               !$acc update device(activeTracerSurfaceFluxTendency)
-               !$acc update device(temperatureShortWaveTendency)
-               !$acc update device(activeTracerNonLocalTendency)
-            endif
-         endif
-#endif
 
          if(config_enable_nonhydrostatic_mode) then
             call ocn_tend_vvel(tendPool, statePool, & 
@@ -2072,13 +1945,9 @@ module ocn_time_integration_si
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.
 
-!! Keeping this calc on the CPU for now
-#ifdef MPAS_OPENACC
-            !$acc update host(layerThicknessNew)
-            !$acc update host(activeTracersNew)
-            !$acc update host(tracersSurfaceValue)
-#else
             if(config_enable_nonhydrostatic_mode) then
+!NV!          !!! NOT EXECUTING !!!
+              write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp_h)
                do iCell=1,nCells
@@ -2093,8 +1962,10 @@ module ocn_time_integration_si
 
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
-#endif
+!$acc parallel
+!$acc loop gang worker
             do iCell = 1, nCellsAll
+!$acc loop vector private(temp_h,temp)
             do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                ! this is h_{n+1}
@@ -2104,7 +1975,6 @@ module ocn_time_integration_si
                ! this is h_{n+1/2}
                layerThicknessNew(k,iCell) = 0.5* &
                (layerThicknessCur(k,iCell) + temp_h)
-
                do i = startIndex, endIndex
                   ! This is Phi at n+1
                   temp = (tracersGroupCur(i,k,iCell)* &
@@ -2117,48 +1987,30 @@ module ocn_time_integration_si
                end do ! tracer index
             end do ! vertical
             end do ! iCell
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
-!NOTE - this is not setup for OPENACC here
 
             if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
+!NV!          !!! NOT EXECUTING !!!
+              write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, temp_h)
-#endif
                   do iCell=1,nCells
                      do k=2,maxLevelCell(iCell)
                         temp_h = vertVelocityNonhydroCur(k,iCell) + dt * vertVelocityNonhydroTend(k,iCell)
                         vertVelocityNonhydroNew(k,iCell) = 0.5_RKIND*(vertVelocityNonhydroCur(k,iCell) + temp_h)
                      end do
                   end do
-#ifndef MPAS_OPENACC
                   !$omp end do
                   !$omp end parallel
-#endif
                end if
 
-
-#ifdef MPAS_OPENACC
-            !$acc update device(layerThicknessNew)
-            !$acc update device(activeTracersNew)
-#endif
-
             if (config_use_freq_filtered_thickness) then
-
-#ifdef MPAS_OPENACC
-               !$acc parallel loop present(minLevelCell, maxLevelCell) &
-               !$acc   present(highFreqThicknessNew) &
-               !$acc   present(highFreqThicknessCur) &
-               !$acc   present(lowFreqDivergenceNew) &
-               !$acc   present(lowFreqDivergenceCur) &
-               !$acc   present(lowFreqDivergenceTend)
-#else
+!NV!          !!! NOT EXECUTING !!!
+              write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp)
-#endif
                do iCell = 1, nCellsAll
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
@@ -2178,20 +2030,14 @@ module ocn_time_integration_si
                            (lowFreqDivergenceCur(k,iCell) + temp)
                end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
             end if
 
-#ifdef MPAS_OPENACC
-            !$acc parallel loop collapse(2) present(normalVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityNew, edgeMask) &
-            !$acc   present(normalBarotropicVelocityNew)
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
             do iEdge = 1, nEdgesAll
             do k = 1, nVertLevels
 
@@ -2204,15 +2050,14 @@ module ocn_time_integration_si
 
             enddo
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             ! Efficiency note: We really only need this to compute
             ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
-            call ocn_diagnostic_solve(dt, statePool, forcingPool, &
+            call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
 
@@ -2223,32 +2068,12 @@ module ocn_time_integration_si
 
          elseif (splitImplicitStep == numTSIterations) then
 
-#ifdef MPAS_OPENACC
-            !$acc parallel present(minLevelCell, maxLevelCell) &
-            !$acc   present(layerThicknessTend) &
-            !$acc   present(layerThicknessCur) &
-            !$acc   present(minLevelEdgeBot, maxLevelEdgeTop) &
-            !$acc   present(layerThickEdgeFlux) &
-            !$acc   present(activeTracerHorizontalAdvectionEdgeFlux) &
-            !$acc   present(layerThicknessNew) &
-            !$acc   present(activeTracerHorizontalAdvectionTendency) &
-            !$acc   present(activeTracerVerticalAdvectionTendency) &
-            !$acc   present(activeTracerHorMixTendency) &
-            !$acc   present(activeTracerSurfaceFluxTendency) &
-            !$acc   present(temperatureShortWaveTendency) &
-            !$acc   present(activeTracerNonLocalTendency)
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc loop gang
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
             do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
+!$acc loop vector
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h_{n+1}
                layerThicknessNew(k,iCell) = &
@@ -2256,43 +2081,32 @@ module ocn_time_integration_si
                                   dt*layerThicknessTend(k,iCell)
             end do
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
                do iCell=1,nCells
                   do k=1,maxLevelCell(iCell)
                      vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell) + dt*vertVelocityNonhydroTend(k,iCell)
                   end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
             end if
 
             if (config_compute_active_tracer_budgets) then
-
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iEdge = 1, nEdgesAll
-#ifdef MPAS_OPENACC
-               !$acc loop seq
-#endif
+!$acc loop vector
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                   do iTracer = 1, size(activeTracerHorizontalAdvectionEdgeFlux,1)
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) / &
@@ -2300,84 +2114,47 @@ module ocn_time_integration_si
                   enddo
                enddo
                enddo
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iCell = 1, nCellsAll
+!$acc loop vector
                do k= minLevelCell(iCell), maxLevelCell(iCell)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-                  do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
-                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
-                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
-                               layerThicknessNew(k,iCell)
-
-                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
-                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
-                               layerThicknessNew(k,iCell)
-
-                     activeTracerHorMixTendency(iTracer,k,iCell) = &
-                     activeTracerHorMixTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-
-                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
-                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-
-                     activeTracerNonLocalTendency(iTracer,k,iCell) = &
-                     activeTracerNonLocalTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-                  end do
-#else
-                  activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
-                  activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
+               do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
+                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerVerticalAdvectionTendency(:,k,iCell) = &
-                  activeTracerVerticalAdvectionTendency(:,k,iCell) / &
+                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerHorMixTendency(:,k,iCell) = &
-                  activeTracerHorMixTendency(:,k,iCell) / &
+                  activeTracerHorMixTendency(iTracer,k,iCell) = &
+                  activeTracerHorMixTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerSurfaceFluxTendency(:,k,iCell) = &
-                  activeTracerSurfaceFluxTendency(:,k,iCell) / &
+                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
+                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerNonLocalTendency(:,k,iCell) = &
-                  activeTracerNonLocalTendency(:,k,iCell) / &
+                  activeTracerNonLocalTendency(iTracer,k,iCell) = &
+                  activeTracerNonLocalTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
-#endif
+               end do
 
                   temperatureShortWaveTendency(k,iCell) = &
                   temperatureShortWaveTendency(k,iCell) / &
                              layerThicknessNew(k,iCell)
                end do
                end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
             endif
 
-#ifdef MPAS_OPENACC
-            !$acc end parallel
-#endif
-
-! This tracer block is still computed on the CPU
-#ifdef MPAS_OPENACC
-            !$acc update host(layerThicknessNew)
-            !$acc update host(layerThicknessCur, layerThicknessTend)
-            !$acc update host(activeTracersNew)
-            !$acc update host(tracersSurfaceValue)
-#endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &
@@ -2388,66 +2165,68 @@ module ocn_time_integration_si
                                 configName, config_use_tracerGroup)
 
                   if ( config_use_tracerGroup ) then
-                     call mpas_pool_get_array(tracersPool, &
+                     call mpas_pool_get_array_gpu(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupCur, 1)
-                     call mpas_pool_get_array(tracersPool, &
+                     call mpas_pool_get_array_gpu(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupNew, 2)
 
                      modifiedGroupName = &
                              trim(groupItr % memberName) // 'Tend'
-                     call mpas_pool_get_array(tracersTendPool, &
+                     call mpas_pool_get_array_gpu(tracersTendPool, &
                                               modifiedGroupName, &
                                               tracersGroupTend)
 
-#ifndef MPAS_OPENACC
                      !$omp parallel
                      !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                      do iCell = 1, nCellsAll
+!$acc loop vector
                      do k = minLevelCell(iCell), maxLevelCell(iCell)
-                        tracersGroupNew(:,k,iCell) = &
-                       (tracersGroupCur(:,k,iCell) * &
+                     do iTracer = 1, size(tracersGroupNew,1)
+                        tracersGroupNew(iTracer,k,iCell) = &
+                       (tracersGroupCur(iTracer,k,iCell) * &
                         layerThicknessCur(k,iCell) + dt* &
-                       tracersGroupTend(:,k,iCell))/ &
+                       tracersGroupTend(iTracer,k,iCell))/ &
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-#ifndef MPAS_OPENACC
+                     end do
+!$acc end parallel
                      !$omp end do
                      !$omp end parallel
-#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
                          'activeTracers' ) then
-#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                         do iCell = 1, nCellsAll
+!$acc loop vector
                         do k = minLevelCell(iCell), maxLevelCell(iCell)
                            tracersGroupNew(indexSalinity,k,iCell) = &
                            max(0.001_RKIND,  &
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
                      if (trim(groupItr % memberName) == &
                          'debugTracers' .and. &
                          config_reset_debugTracers_near_surface) then
+!NV!                    !!! NOT EXECUTING !!!
+                        write(*,*) "config_reset_debugTracers_near_surface NOT EXECUTING"
 
-#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k, lat)
-#endif
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
@@ -2490,38 +2269,19 @@ module ocn_time_integration_si
                               end do
                            end if
                         end do ! cells
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer
             end do ! tracer group
 
-#ifdef MPAS_OPENACC
-            !$acc update device(layerThicknessNew)
-            !$acc update device(activeTracersNew)
-#endif
-
             if (config_use_freq_filtered_thickness) then
-#ifdef MPAS_OPENACC
-               !$acc parallel present(minLevelCell, maxLevelCell) &
-               !$acc   present(lowFreqDivergenceNew) &
-               !$acc   present(lowFreqDivergenceCur) &
-               !$acc   present(lowFreqDivergenceTend)
-#endif
-
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
                do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
@@ -2532,14 +2292,8 @@ module ocn_time_integration_si
                   lowFreqDivergenceTend(k,iCell)
                end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-               !$acc end parallel
-#endif
 
             end if
 
@@ -2559,24 +2313,12 @@ module ocn_time_integration_si
             ! so normalBaroclinicVelocity does not have to be
             ! recomputed here.
 
-#ifdef MPAS_OPENACC
-            !$acc parallel present(minLevelEdgeBot, maxLevelEdgeTop) &
-            !$acc   present(normalVelocityNew) &
-            !$acc   present(normalBarotropicVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityCur)
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc loop gang
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
             do iEdge = 1, nEdgesAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
+!$acc loop vector
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
                                normalBarotropicVelocityNew(iEdge) + &
@@ -2584,81 +2326,12 @@ module ocn_time_integration_si
                                normalBaroclinicVelocityCur(k,iEdge)
             end do
             end do ! iEdges
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc end parallel
-#endif
 
          endif ! splitImplicitStep
 
-#ifdef MPAS_OPENACC
-         !$acc exit data copyout(layerThicknessNew)
-         !$acc exit data copyout(normalVelocityNew)
-         !$acc exit data delete(normalBarotropicVelocityNew, &
-         !$acc                  normalBaroclinicVelocityNew)
-         !$acc exit data copyout(activeTracersNew)
-         !$acc update host(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness) then
-            !$acc exit data copyout(lowFreqDivergenceNew)
-            !$acc exit data delete(lowFreqDivergenceCur)
-            !$acc exit data delete(lowFreqDivergenceTend)
-         endif
-         if (splitImplicitStep < numTSIterations) then
-            if (config_use_gm) then
-               !$acc update host(vertGMBolusVelocityTop)
-            end if
-            if (config_submesoscale_enable) then
-               !$acc update host(vertMLEBolusVelocityTop)
-            end if
-            !$acc exit data delete (atmosphericPressure, seaIcePressure)
-            !$acc exit data copyout(sshNew)
-            !$acc update host(layerThickEdgeMean)
-            !$acc update host(relativeVorticity, circulation)
-            !$acc update host(vertTransportVelocityTop, &
-            !$acc             relativeVorticityCell, &
-            !$acc             divergence, &
-            !$acc             kineticEnergyCell, &
-            !$acc             tangentialVelocity, &
-            !$acc             vertVelocityTop)
-            !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-            !$acc             normalizedRelativeVorticityCell)
-            !$acc update host (surfacePressure)
-            !$acc update host(zMid, zTop)
-            !$acc update host(tracersSurfaceValue)
-            !$acc update host(normalVelocitySurfaceLayer)
-            !$acc update host(density, potentialDensity, displacedDensity)
-            !$acc update host(thermExpCoeff,  &
-            !$acc&            salineContractCoeff)
-            !$acc update host(montgomeryPotential, pressure)
-            if (landIcePressureOn) then
-               !$acc exit data delete(landIcePressure)
-               !$acc exit data delete(landIceDraft)
-            endif
-            if (config_use_freq_filtered_thickness) then
-               !$acc exit data copyout(highFreqThicknessNew)
-               !$acc exit data delete(highFreqThicknessCur)
-            endif
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc exit data delete(frazilSurfacePressure)
-            endif
-         elseif (splitImplicitStep == numTSIterations) then
-            !$acc exit data delete(layerThicknessCur, layerThicknessTend)
-            !$acc exit data delete(normalBaroclinicVelocityCur)
-            if (config_compute_active_tracer_budgets) then
-               !$acc update host(activeTracerHorizontalAdvectionEdgeFlux)
-               !$acc update host(activeTracerHorizontalAdvectionTendency)
-               !$acc update host(activeTracerVerticalAdvectionTendency)
-               !$acc update host(activeTracerHorMixTendency)
-               !$acc update host(activeTracerSurfaceFluxTendency)
-               !$acc update host(temperatureShortWaveTendency)
-               !$acc update host(activeTracerNonLocalTendency)
-            endif
-         endif
-#endif
 
          call mpas_timer_stop('si loop fini')
          call mpas_timer_stop('si loop')
@@ -2688,78 +2361,12 @@ module ocn_time_integration_si
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      !$acc update device (normalTransportVelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEvelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(activeTracersNew)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host (vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host (vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshNew)
-      !$acc exit data delete(activeTracersNew)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
-#endif
-
-      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
+      call ocn_vmix_implicit_gpu(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
 
       ! Update halo on u and tracers, which were just updated for
@@ -2777,6 +2384,8 @@ module ocn_time_integration_si
       call mpas_timer_stop('si vmix halos normalVelFld')
 
       if(config_enable_nonhydrostatic_mode) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroNew, 2)
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroCur, 1)
             call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureNew, 2)
@@ -2803,6 +2412,8 @@ module ocn_time_integration_si
 
             ! Reset iAge to zero where mask == 0
             if (config_use_idealAgeTracers.and.trim(groupItr%memberName) == 'idealAgeTracers') then
+!NV!            !!! NOT EXECUTING !!!
+                write(*,*) "config_use_idealAgeTracers NOT EXECUTING"
                 call mpas_pool_get_array(tracersPool, &
                                          groupItr%memberName, &
                                          tracersGroupNew, 2)
@@ -2813,17 +2424,13 @@ module ocn_time_integration_si
                                          'idealAgeTracersIdealAgeMask', &
                                           tracerGroupIdealAgeMask)
 
-#ifndef MPAS_OPENACC
                 !$omp parallel
                 !$omp do schedule(runtime)
-#endif
                 do iCell = 1, nCellsOwned
                    tracersGroupNew(1,1,iCell) = tracerGroupIdealAgeMask(1,iCell)*tracersGroupNew(1,1,iCell)
                 end do ! cells
-#ifndef MPAS_OPENACC
                 !$omp end do
                 !$omp end parallel
-#endif
              endif
 
             ! Halo update on all tracer groups
@@ -2837,6 +2444,8 @@ module ocn_time_integration_si
       call mpas_timer_stop("si implicit vert mix")
 
       if ( configVertAdvMethod == vertAdvRemap ) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "configVertAdvMethod == vertAdvRemap NOT EXECUTING"
 
          call mpas_timer_start("vertical remap")
 
@@ -2855,87 +2464,44 @@ module ocn_time_integration_si
 
       call mpas_timer_start('si fini')
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      if (config_prescribe_velocity) then
-         !$acc enter data copyin(normalVelocityCur) 
-      endif
-      if (config_prescribe_thickness) then
-         !$acc enter data copyin(layerThicknessCur)
-      endif
-      !$acc update device (normalTransportVelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEvelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(activeTracersNew)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
 
       if (config_prescribe_velocity) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) present(normalVelocityNew, normalVelocityCur)
-#else
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_prescribe_velocity NOT EXECUTING"
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       if (config_prescribe_thickness) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) present(layerThicknessNew, layerThicknessCur)
-#else
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_prescribe_thickness NOT EXECUTING"
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCellsAll
          do k=1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice
-      call ocn_effective_density_in_land_ice_update(forcingPool, &
+      call ocn_effective_density_in_land_ice_update_gpu(forcingPool, &
                                                     statePool, err)
 
-      call mpas_timer_start('si final mpas reconstruct', .false.)
-
-#ifdef MPAS_OPENACC
-      !$acc enter data create(velocityX, velocityY, velocityZ)
-      !$acc enter data create(velocityZonal, velocityMeridional)
-      !$acc enter data create(gradSSHX, gradSSHY, gradSSHZ)
-      !$acc enter data create(gradSSHZonal, gradSSHMeridional)
-      !$acc enter data create(surfaceVelocity, SSHGradient)
-#endif
+      call mpas_timer_start('si final mpas reconstruct gpu', .false.)
 
       call mpas_reconstruct_gpu(meshPool, normalVelocityNew,       &
                                 velocityX, velocityY, velocityZ,   &
@@ -2947,16 +2513,12 @@ module ocn_time_integration_si
                                 gradSSHZonal, gradSSHMeridional, &
                                 includeHalos = .true.)
 
-      call mpas_timer_stop('si final mpas reconstruct')
+      call mpas_timer_stop('si final mpas reconstruct gpu')
 
-
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(surfaceVelocity, velocityZonal, velocityMeridional, &
-      !$acc   SSHGradient, gradSSHZonal, gradSSHMeridional)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
       do iCell = 1, nCellsAll
          surfaceVelocity(indexSurfaceVelocityZonal,iCell) = &
                                    velocityZonal(minLevelCell(iCell),iCell)
@@ -2967,73 +2529,19 @@ module ocn_time_integration_si
          SSHGradient(indexSSHGradientMeridional,iCell) = &
                                                gradSSHMeridional(iCell)
       end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
       !$omp end do
       !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host(vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host(vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshNew)
-      !$acc exit data delete(activeTracersNew)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data copyout(layerThicknessNew, normalVelocityNew)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-      if (config_prescribe_velocity) then
-         !$acc exit data delete(normalVelocityCur)
-      endif
-      if (config_prescribe_thickness) then
-         !$acc exit data delete(layerThicknessCur)
-      endif
-      !$acc exit data copyout(velocityX, velocityY, velocityZ)
-      !$acc exit data copyout(gradSSHX, gradSSHY, gradSSHZ)
-      !$acc exit data copyout(velocityZonal, velocityMeridional)
-      !$acc exit data copyout(gradSSHZonal, gradSSHMeridional)
-      !$acc exit data copyout(surfaceVelocity, SSHGradient)
-#endif
-      call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
+      call ocn_time_average_coupled_accumulate_gpu(statePool,forcingPool,2)
 
       if (config_use_GM .or. config_submesoscale_enable) then
-         call ocn_reconstruct_eddy_vectors(meshPool)
+         call ocn_reconstruct_eddy_vectors_gpu(meshPool)
       end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
          call mpas_timer_start("si effective density halo")
          call mpas_pool_get_field(statePool, &
                                  'effectiveDensityInLandIce', &
@@ -3045,6 +2553,8 @@ module ocn_time_integration_si
 
       call mpas_timer_stop('si fini')
       call mpas_timer_stop("si timestep")
+
+!!!$acc update host(pressure,thermExpCoeff,salineContractCoeff,zMid,density,potentialDensity)
 
    end subroutine ocn_time_integrator_si
 
@@ -3128,6 +2638,7 @@ module ocn_time_integration_si
       'MPAS was not compiled with LAPACK/BLAS. LAPACK required for SI' &
       , MPAS_LOG_CRIT)
 #endif
+      istat = cublasCreate(h)
 
       !*** Set mask for using velocity correction
       if (config_vel_correction) then
@@ -3180,29 +2691,31 @@ module ocn_time_integration_si
       call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', &
                                                         nEdgesArray)
 
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThickness, 1)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                            normalVelocity, 1)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocity, 1)
-      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocity, 1)
 
-      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
+      call mpas_pool_get_array_gpu(meshPool, 'refBottomDepth', &
                                           refBottomDepth)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', &
                                           cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', &
                                           minLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', &
                                           maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'bottomDepth', bottomDepth)
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
 
-      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, 2)
+!$acc update host(layerThickness,normalVelocity,normalBarotropicVelocity,normalBaroclinicVelocity,&
+!$acc             refBottomDepth,cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,minLevelCell,maxLevelCell,bottomDepth,areaCell,ssh)
 
       nCells = nCellsArray(config_num_halos)
       nEdges = nEdgesArray(config_num_halos+1)
@@ -3312,7 +2825,6 @@ module ocn_time_integration_si
          tolerance_inner  = config_btr_si_tolerance * area_mean
       endif
 
-
       ! Detection of ISMF (Temporariliy implemented. 
       !                    This will be revised in next SI version)
       ! If ISMF is detected, the split-implicit barotropic mode solver
@@ -3390,6 +2902,7 @@ module ocn_time_integration_si
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta
 
+!$acc update device(normalBarotropicVelocity,normalBaroclinicVelocity,normalVelocity,zTop,ssh)
    end subroutine ocn_time_integration_si_init
 
 !***********************************************************************
@@ -3453,7 +2966,8 @@ module ocn_time_integration_si
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_array(meshPool, 'indexToCellID', globalCellId)
+      call mpas_pool_get_array_gpu(meshPool, 'indexToCellID', globalCellId)
+!$acc update host(globalCellId)
 
       nCells   = nCellsOwned
       nEdges   = nEdgesOwned
@@ -3501,6 +3015,7 @@ module ocn_time_integration_si
       ! Restricted Additive Schwarz preconditioner --------------------!
       if ( trim(config_btr_si_preconditioner) == 'ras' ) then
 
+         write(*,*) "Generating ras preconditioner NOT EXECUTING"
          nPrecVec = nCellsHalo2nd ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
                                   ! Packed size of preconditiong matrix
@@ -3560,10 +3075,12 @@ module ocn_time_integration_si
 #endif
          prec_ivmat(:) = -prec_ivmat(:)
 
+!$acc update device(prec_ivmat)
          ! Block-Jacobi preconditioner --------------------------------!
       elseif ( trim(config_btr_si_preconditioner) == &
                                         'block_jacobi' ) then
 
+         write(*,*) "Generating block_jacobi preconditioner NOT EXECUTING"
          nPrecVec = nCells        ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
                                   ! Packed size of preconditiong matrix
@@ -3622,6 +3139,7 @@ module ocn_time_integration_si
 #endif
          prec_ivmat(:) = -prec_ivmat(:)
 
+!$acc update device(prec_ivmat)
       ! Jacobi preconditioner -----------------------------------------!
       else if ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
 
@@ -3661,16 +3179,20 @@ module ocn_time_integration_si
 
          end do ! iCell
 
+!$acc update device(prec_ivmat)
       ! No preconditioner ---------------------------------------------!
       else if ( trim(config_btr_si_preconditioner) == 'none' ) then
 
+         write(*,*) "Not generating any preconditioner NOT EXECUTING"
          nPrecVec = nCells ! length of preconditioning vector
 
          allocate(prec_ivmat(1))
          prec_ivmat(:) = 1.0_RKIND
 
+!$acc update device(prec_ivmat)
       else
 
+         write(*,*) "Generating else NOT EXECUTING"
          call mpas_log_write( &
          'Incorrect choice for config_btr_si_preconditioner: ' &
          // trim(config_btr_si_preconditioner) //              &
@@ -3678,6 +3200,8 @@ module ocn_time_integration_si
          MPAS_LOG_CRIT)
 
       endif ! config_btr_si_preconditioner
+
+!$acc update device(prec_ivmat)
 
    end subroutine ocn_time_integrator_si_preconditioner 
 
@@ -3710,12 +3234,10 @@ module ocn_time_integration_si
 
       integer :: iEdge, cell1, cell2, i, iCell
  
-#ifndef MPAS_OPENACC
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdge, &
       !$omp         thicknessSum,sshDiff,fluxAx,sshArea )
-#endif
       do iCell = 1, nPrecVec
          sshTendAx = 0.0_RKIND
 
@@ -3751,12 +3273,77 @@ module ocn_time_integration_si
          SIvec_out(iCell) = -sshArea - sshTendAx
 
       end do ! iCell
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
       
    end subroutine si_matvec_mul
+
+   subroutine si_matvec_mul_gpu(SIvec_in,bottomDepthEdge,SIvec_out,ssh) 
+
+      real(kind=RKIND),dimension(:),intent(in)  :: &
+          SIvec_in,      &! Input SI vector
+          ssh,           &! Intermediate ssh
+          bottomDepthEdge ! Bottom Depth at Edge
+
+      real(kind=RKIND),dimension(:),intent(out) :: &
+          SIvec_out  ! Output SI vector
+
+      real(kind=RKIND) :: sshTendAx, sshEdge, thicknessSum, sshDiff
+      real(kind=RKIND) :: fluxAx, sshArea
+
+      integer :: iEdge, cell1, cell2, i, iCell
+
+!$acc data present(nEdgesOnCell,edgesOnCell,maxLevelEdgeTop,cellsOnEdge,dcEdge,edgeSignOnCell,dvEdge,areaCell,&
+!$acc              ssh,bottomDepthEdge,SIvec_in,SIvec_out) 
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdge, &
+      !$omp         thicknessSum,sshDiff,fluxAx,sshArea )
+!$acc parallel
+!$acc loop gang vector private(sshTendAx,iEdge,cell1,cell2,sshEdge,thicknessSum,sshDiff,fluxAx,sshArea)
+      do iCell = 1, nPrecVec
+         sshTendAx = 0.0_RKIND
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+!NV!            if (maxLevelEdgeTop(iEdge).eq.0) cycle
+            if (maxLevelEdgeTop(iEdge).ne.0) then
+
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+
+            ! Interpolation sshEdge
+            sshEdge = 0.5_RKIND * (  ssh(cell1)   &
+                                   + ssh(cell2) )
+
+            ! method 1, matches method 0 without pbcs,
+            ! works with pbcs.
+            thicknessSum = si_ismf * sshEdge    &
+                         + bottomDepthEdge(iEdge)
+
+            ! nabla (ssh^0)
+            sshDiff = (SIvec_in(cell2)-SIvec_in(cell1)) &
+                    / dcEdge(iEdge)
+
+            fluxAx = thicknessSum * sshDiff
+
+            sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                      * fluxAx * dvEdge(iEdge)
+            endif
+         end do ! i
+
+         sshArea = R1_alpha1s_g_dts * SIvec_in(iCell) &
+                    * areaCell(iCell)
+
+         SIvec_out(iCell) = -sshArea - sshTendAx
+
+      end do ! iCell
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+!$acc end data
+      
+   end subroutine si_matvec_mul_gpu
 
 !***********************************************************************
 !
@@ -3810,6 +3397,74 @@ module ocn_time_integration_si
       end if
    end subroutine si_precond 
 
+   subroutine si_precond_gpu(SIvec_in,SIvec_out)
+
+      real(kind=RKIND), dimension(:), intent(in)  :: SIvec_in
+                                        ! Input SI vector
+
+      real(kind=RKIND), dimension(:), intent(out) :: SIvec_out
+                                        ! SI vector to be preconditioned
+      integer :: i
+
+!$acc data present(prec_ivmat,SIvec_in,SIvec_out)
+
+      ! Preconditioning --------------------------------------------!
+      if ( trim(config_btr_si_preconditioner) == 'ras' ) then
+         write(*,*) "config_btr_si_preconditioner ras NOT EXECUTING"
+         ! RAS preconditioning: Use BLAS for the symmetric 
+         !                      matrix-vector multiplication
+!NV!#ifdef USE_LAPACK
+!NV!      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+!NV!                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+!NV!                 SIvec_out(1:nPrecVec), 1)
+!NV!#endif
+
+#ifdef USE_CUBLAS
+!$acc host_data use_device(prec_ivmat,SIvec_in,SIvec_out)
+         call cublasDspmv('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                          SIvec_out(1:nPrecVec), 1)
+!$acc end host_data
+#endif
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                        'block_jacobi' ) then
+      write(*,*) "config_btr_si_preconditioner block_jacobi NOT EXECUTING"
+         ! Block-Jacobi preconditioning: Use BLAS for the symmetric 
+         !                               matrix-vector multiplication
+!NV!#ifdef USE_LAPACK
+!NV!      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+!NV!                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+!NV!                 SIvec_out(1:nPrecVec), 1)
+!NV!#endif
+
+#ifdef USE_CUBLAS
+!$acc host_data use_device(prec_ivmat,SIvec_in,SIvec_out)
+          call cublasDspmv('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                          SIvec_out(1:nPrecVec), 1)
+!$acc end host_data
+#endif
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                              'jacobi' ) then
+!NV!         write(*,*) "config_btr_si_preconditioner block NOT EXECUTING"
+         ! Jacobi preconditioning
+!$acc parallel
+!$acc loop gang vector
+         do i = 1, nPrecVec
+             SIvec_out(i) = SIvec_in(i) &
+                                   * prec_ivmat(i)
+         enddo
+!$acc end parallel
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                                'none' ) then
+         write(*,*) "config_btr_si_preconditioner none NOT EXECUTING"
+         ! No preconditioning
+         SIvec_out(1:nPrecVec) = SIvec_in(1:nPrecVec)
+      end if
+
+!$acc end data
+   end subroutine si_precond_gpu 
+
 !***********************************************************************
 !
 !  routine si_global_reduction
@@ -3860,10 +3515,8 @@ module ocn_time_integration_si
    
          if ( config_btr_si_partition_match_mode ) then
     
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
             ! Reproducible sum of multiple fields over products
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r0
@@ -3872,10 +3525,8 @@ module ocn_time_integration_si
                reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
         
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3908,10 +3559,8 @@ module ocn_time_integration_si
          if ( config_btr_si_partition_match_mode ) then
    
             ! Reproducible sum of multiple fields over products
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r1
                reprodSum1(iCell,2) = SIvec_2(iCell) !w1
@@ -3921,10 +3570,8 @@ module ocn_time_integration_si
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
                reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
       
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3965,10 +3612,8 @@ module ocn_time_integration_si
 
             ! Reproducible sum of multiple fields over products
  
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
             do iCell = 1,nCellsOwned
                globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -3976,10 +3621,8 @@ module ocn_time_integration_si
                globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
                globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
 
             SIcst_allreduce_global2(:) =                   &
                mpas_global_sum_nfld(globalReprodSum2fld1, &
@@ -4014,10 +3657,8 @@ module ocn_time_integration_si
  
             ! Reproducible sum of multiple fields over products
              
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
             do iCell = 1,nCellsOwned
                globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -4039,10 +3680,8 @@ module ocn_time_integration_si
                globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
                globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
     
             SIcst_allreduce_global9(:) =                   &
                mpas_global_sum_nfld(globalReprodSum9fld1, &
@@ -4113,6 +3752,311 @@ module ocn_time_integration_si
    
    end subroutine si_global_reduction 
 
+   subroutine si_global_reduction_gpu(localProd,globalProd,       & 
+                             reprodSum1,reprodSum2,           &
+                             si_algorithm,nfld,domain,        &
+                             SIvec_1,SIvec_2,SIvec_3,SIvec_4, &
+                             SIvec_5,SIvec_6,SIvec_7,SIvec_8)  
+
+      type (domain_type), intent(in) :: &
+         domain  !< [inout] model state to advance forward
+
+      real(kind=RKIND), dimension(:), intent(in) :: &
+         SIvec_1,SIvec_2 ! SI vectors
+      real(kind=RKIND), dimension(:), intent(in), optional :: &
+         SIvec_3,SIvec_4,SIvec_5,SIvec_6,SIvec_7,SIvec_8 ! SI vectors
+
+      character(*), intent(in) :: si_algorithm ! Solver algorithm
+
+      integer, intent(in) :: nfld ! Number of reductions
+
+      real(kind=RKIND), dimension(:,:), intent(out) :: &
+         reprodSum1,reprodSum2 ! Array for reprod. global summation
+
+      real(kind=RKIND), dimension(:), intent(out) :: &
+         localProd,globalProd ! Array for global summation
+
+      real(kind=RKIND) :: &
+         SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0,SIcst_r00r0,SIcst_r00w0, &
+         SIcst_r00s0,SIcst_r00z0,SIcst_q0y0,SIcst_y0y0,SIcst_r00q0,  &
+         SIcst_r00y0,SIcst_r00t0,SIcst_r00v0,SIcst_q0q0
+
+      real(kind=RKIND) :: &
+         tmp2(2), tmp3(3) 
+
+      integer :: iCell
+
+      if ( si_algorithm == 'scg' .and. nfld == 2 ) then !!!
+   
+         if ( config_btr_si_partition_match_mode ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_btr_si_partition_match_mode NOT EXECUTING"    
+            !$omp parallel
+            !$omp do schedule(runtime)
+            ! Reproducible sum of multiple fields over products
+            do iCell = 1,nCellsOwned
+               reprodSum1(iCell,1) = SIvec_1(iCell) !r0
+               reprodSum1(iCell,2) = SIvec_2(iCell) !w0
+    
+               reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
+               reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
+            end do
+            !$omp end do
+            !$omp end parallel
+        
+            globalProd(:) = 0.0_RKIND
+            globalProd(:) =                   &
+               mpas_global_sum_nfld(reprodSum1, &
+                                    reprodSum2, &
+                                    domain%dminfo%comm)
+         else
+
+!NV!        !!! EXECUTING !!!
+
+!$acc data present(SIvec_1,SIvec_2,SIvec_3,localProd,globalProd) create(tmp2)
+
+!$acc serial
+            SIcst_r0rh0 = 0.0_RKIND
+            SIcst_w0rh0 = 0.0_RKIND
+!$acc end serial
+
+!$acc parallel
+!$acc loop gang vector private(SIcst_r0rh0,SIcst_w0rh0) reduction(+:SIcst_r0rh0,SIcst_w0rh0)
+            do iCell = 1, nCellsOwned
+               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
+                                         * SIvec_3(iCell)
+            end do ! iCell
+!$acc end parallel
+
+!$acc serial
+            localProd(1) = SIcst_r0rh0
+            localProd(2) = SIcst_w0rh0
+!$acc end serial
+    
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array_gpu(domain % dminfo, nfld,      &
+                                           localProd,  &
+                                           globalProd)
+
+!$acc end data
+         endif
+   
+      elseif ( si_algorithm == 'scg' .and. nfld == 3 ) then !!!
+         if ( config_btr_si_partition_match_mode ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_btr_si_partition_match_mode NOT EXECUTING"
+   
+            ! Reproducible sum of multiple fields over products
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iCell = 1,nCellsOwned
+               reprodSum1(iCell,1) = SIvec_1(iCell) !r1
+               reprodSum1(iCell,2) = SIvec_2(iCell) !w1
+               reprodSum1(iCell,3) = SIvec_1(iCell) !r1
+      
+               reprodSum2(iCell,1) = SIvec_3(iCell) !rh1
+               reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
+               reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
+            end do
+            !$omp end do
+            !$omp end parallel
+      
+            globalProd(:) = 0.0_RKIND
+            globalProd(:) =                   &
+               mpas_global_sum_nfld(reprodSum1, &
+                                    reprodSum2, &
+                                    domain%dminfo%comm)
+         else
+   
+!NV!        !!! EXECUTING !!!
+
+!$acc data present(SIvec_1,SIvec_2,SIvec_3,localProd,globalProd)
+
+!$acc serial
+            SIcst_r0rh0 = 0.0_RKIND
+            SIcst_w0rh0 = 0.0_RKIND
+            SIcst_r0r0 = 0.0_RKIND
+!$acc end serial
+         
+!$acc parallel
+!$acc loop gang vector private(SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0) reduction(+:SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0)
+            do iCell = 1,nCellsOwned
+               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell) ! s1
+         
+               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
+                                         * SIvec_3(iCell) ! z1
+   
+               SIcst_r0r0 = SIcst_r0r0  + SIvec_1(iCell) &
+                                         * SIvec_1(iCell) ! z1
+            end do
+!$acc end parallel
+      
+!$acc serial
+            localProd(1) = SIcst_r0rh0
+            localProd(2) = SIcst_w0rh0
+            localProd(3) = SIcst_r0r0
+!$acc end serial
+         
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array_gpu(domain % dminfo, nfld,      &
+                                           localProd,  &
+                                           globalProd)
+!$acc end data
+   
+         endif
+   
+      elseif ( si_algorithm == 'sbicg' .and. nfld == 2 ) then !!!
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "si_algorithm == 'sbicg' .and. nfld == 2 NOT EXECUTING"
+         if ( config_btr_si_partition_match_mode ) then
+
+            ! Reproducible sum of multiple fields over products
+ 
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iCell = 1,nCellsOwned
+               globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
+               globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
+
+               globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
+               globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
+            end do
+            !$omp end do
+            !$omp end parallel
+
+            SIcst_allreduce_global2(:) =                   &
+               mpas_global_sum_nfld(globalReprodSum2fld1, &
+                                    globalReprodSum2fld2, &
+                                    domain%dminfo%comm)
+
+         else
+
+            SIcst_r00r0 = 0.0_RKIND
+            SIcst_r00w0 = 0.0_RKIND
+   
+            do iCell = 1, nCellsOwned
+               SIcst_r00r0 = SIcst_r00r0 + SIvec_1(iCell) &
+                                         * SIvec_2(iCell)
+               SIcst_r00w0 = SIcst_r00w0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+            end do ! iCell
+   
+            SIcst_allreduce_local2(1) = SIcst_r00r0
+            SIcst_allreduce_local2(2) = SIcst_r00w0
+   
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
+                                           SIcst_allreduce_local2,  &
+                                           SIcst_allreduce_global2)
+
+         endif
+
+      elseif ( si_algorithm == 'sbicg' .and. nfld == 9 ) then !!!
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "si_algorithm == 'sbicg' .and. nfld == 9 NOT EXECUTING"
+
+         if ( config_btr_si_partition_match_mode ) then
+ 
+            ! Reproducible sum of multiple fields over products
+             
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iCell = 1,nCellsOwned
+               globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,3) = SIvec_2(iCell) !q0
+               globalReprodSum9fld1(iCell,4) = SIvec_3(iCell) !y0
+               globalReprodSum9fld1(iCell,5) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,6) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,7) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,8) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,9) = SIvec_2(iCell) !q0
+    
+               globalReprodSum9fld2(iCell,1) = SIvec_4(iCell) !s1
+               globalReprodSum9fld2(iCell,2) = SIvec_5(iCell) !z1
+               globalReprodSum9fld2(iCell,3) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,4) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,5) = SIvec_2(iCell) !q0
+               globalReprodSum9fld2(iCell,6) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,7) = SIvec_6(iCell) !t0
+               globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
+               globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
+            end do
+            !$omp end do
+            !$omp end parallel
+    
+            SIcst_allreduce_global9(:) =                   &
+               mpas_global_sum_nfld(globalReprodSum9fld1, &
+                                    globalReprodSum9fld2, &
+                                    domain%dminfo%comm)
+    
+         else
+ 
+            SIcst_r00s0 = 0.0_RKIND
+            SIcst_r00z0 = 0.0_RKIND
+            SIcst_q0y0  = 0.0_RKIND
+            SIcst_y0y0  = 0.0_RKIND
+            SIcst_r00q0 = 0.0_RKIND
+            SIcst_r00y0 = 0.0_RKIND
+            SIcst_r00t0 = 0.0_RKIND
+            SIcst_r00v0 = 0.0_RKIND
+            SIcst_q0q0  = 0.0_RKIND
+       
+            do iCell = 1,nCellsOwned
+               SIcst_r00s0 = SIcst_r00s0 + SIvec_1(iCell) &
+                                         * SIvec_4(iCell) ! s1
+       
+               SIcst_r00z0 = SIcst_r00z0 + SIvec_1(iCell) &
+                                         * SIvec_5(iCell) ! z1
+       
+               SIcst_q0y0  = SIcst_q0y0  + SIvec_2(iCell)  &
+                                         * SIvec_3(iCell)
+       
+               SIcst_y0y0  = SIcst_y0y0  + SIvec_3(iCell)  &
+                                         * SIvec_3(iCell)
+       
+               SIcst_r00q0 = SIcst_r00q0 + SIvec_1(iCell) &
+                                         * SIvec_2(iCell)
+       
+               SIcst_r00y0 = SIcst_r00y0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+       
+               SIcst_r00t0 = SIcst_r00t0 + SIvec_1(iCell) &
+                                         * SIvec_6(iCell)
+       
+               SIcst_r00v0 = SIcst_r00v0 + SIvec_1(iCell) &
+                                         * SIvec_7(iCell)
+       
+               SIcst_q0q0 = SIcst_q0q0   + SIvec_2(iCell) &
+                                         * SIvec_2(iCell)
+            end do
+    
+            SIcst_allreduce_local9(1) = SIcst_r00s0
+            SIcst_allreduce_local9(2) = SIcst_r00z0
+            SIcst_allreduce_local9(3) = SIcst_q0y0 
+            SIcst_allreduce_local9(4) = SIcst_y0y0 
+            SIcst_allreduce_local9(5) = SIcst_r00q0
+            SIcst_allreduce_local9(6) = SIcst_r00y0
+            SIcst_allreduce_local9(7) = SIcst_r00t0
+            SIcst_allreduce_local9(8) = SIcst_r00v0
+            SIcst_allreduce_local9(9) = SIcst_q0q0
+       
+            ! Global sum across CPUs
+            call mpas_timer_start("si reduction iter")
+            call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
+                                           SIcst_allreduce_local9,  &
+                                           SIcst_allreduce_global9)
+            call mpas_timer_stop("si reduction iter")
+    
+         endif
+
+      endif !!!
+   
+   end subroutine si_global_reduction_gpu 
+
 !***********************************************************************
 !
 !  routine si_solver_scg
@@ -4164,10 +4108,8 @@ module ocn_time_integration_si
 
          iter = iter + 1
 
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nPrecVec
             SIvec_z1(iCell) = SIvec_rh0(iCell) &
                             + SIcst_beta0 * SIvec_z0(iCell)
@@ -4181,10 +4123,8 @@ module ocn_time_integration_si
             SIvec_r1(iCell) = SIvec_r0(iCell) &
                             - SIcst_alpha0 * SIvec_s1(iCell)
          end do ! iCell
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
   
          ! Preconditioning -----------------------------------------!
          call si_precond(SIvec_r1,SIvec_rh1)
@@ -4220,10 +4160,8 @@ module ocn_time_integration_si
                       /(SIcst_omega0 - SIcst_beta1*SIcst_gamma1 &
                                      / SIcst_alpha0 )
 
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1,nPrecVec
             SIvec_r0(iCell)  = SIvec_r1(iCell)
             SIvec_s0(iCell)  = SIvec_s1(iCell)
@@ -4231,10 +4169,8 @@ module ocn_time_integration_si
             SIvec_z0(iCell)  = SIvec_z1(iCell)
             SIvec_rh0(iCell) = SIvec_rh1(iCell)
          end do ! iCell
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
          SIcst_beta0  = SIcst_beta1
          SIcst_alpha0 = SIcst_alpha1
@@ -4260,6 +4196,144 @@ module ocn_time_integration_si
       !-------------------------------------------------------------!
      
    end subroutine si_solver_scg 
+
+   subroutine si_solver_scg_gpu(domain,sshSolved,ssh,bottomDepthEdge, & 
+                            tolerance,SIcst_alpha0,SIcst_beta0,   &
+                            SIcst_gamma0)
+
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
+
+      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
+         ssh                                    ! Intermediate ssh
+
+      real(kind=RKIND), dimension(:), pointer, intent(inout) :: &
+         sshSolved                              ! ssh to be solved
+
+      real(kind=RKIND), dimension(:), intent(inout) :: &
+         bottomDepthEdge                        ! Bottome depth at Edge
+
+      real(kind=RKIND), intent(in) :: tolerance ! Tolerance of solver
+
+      real(kind=RKIND), intent(inout) :: &
+         SIcst_alpha0,SIcst_beta0,SIcst_gamma0  ! Initial reductions
+
+      real(kind=RKIND) :: &
+         SIcst_beta1,SIcst_alpha1,SIcst_gamma1,resid,SIcst_omega0, &
+         SIcst_r0rh0_global,SIcst_w0rh0_global
+
+      integer :: iter, iCell
+
+      iter = 0
+      resid = (tolerance+100.0)**2.0
+
+!$acc data present(SIvec_z1,SIvec_rh0,SIvec_z0,SIvec_s1,SIvec_w0,SIvec_s0,SIvec_r1,SIvec_r0,SIvec_rh1,SIvec_w1,&
+!$acc               sshSolved,bottomDepthEdge,ssh,SIcst_allreduce_local3,SIcst_allreduce_global3)
+
+      !-------------------------------------------------------------!
+      do while ( dsqrt(resid) > tolerance )
+      !-------------------------------------------------------------!
+
+         iter = iter + 1
+
+         !$omp parallel
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+         do iCell = 1, nPrecVec
+            SIvec_z1(iCell) = SIvec_rh0(iCell) &
+                            + SIcst_beta0 * SIvec_z0(iCell)
+
+            SIvec_s1(iCell) = SIvec_w0(iCell) &
+                            + SIcst_beta0 * SIvec_s0(iCell)
+
+            sshSolved(iCell) = sshSolved(iCell) &
+                            + SIcst_alpha0 * SIvec_z1(iCell)
+
+            SIvec_r1(iCell) = SIvec_r0(iCell) &
+                            - SIcst_alpha0 * SIvec_s1(iCell)
+         end do ! iCell
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+  
+         ! Preconditioning -----------------------------------------!
+!NV!     ON CPU
+         call si_precond_gpu(SIvec_r1,SIvec_rh1)
+  
+         call mpas_timer_start("si halo iter")
+         call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh1')
+         call mpas_timer_stop("si halo iter")
+  
+  
+         ! SpMV ----------------------------------------------------!
+         call si_matvec_mul_gpu(SIvec_rh1,bottomDepthEdge,SIvec_w1,ssh)
+  
+         ! Reduction -----------------------------------------------!
+
+         call mpas_timer_start("si reduction iter")
+         call si_global_reduction_gpu(SIcst_allreduce_local3,&
+                             SIcst_allreduce_global3,    &
+                             globalReprodSum3fld1,       &
+                             globalReprodSum3fld2,       &
+                             si_algorithm,3,domain,      &
+                             SIvec_r1,SIvec_w1,SIvec_rh1)
+!$acc update host(SIcst_allreduce_local3,SIcst_allreduce_global3)
+         call mpas_timer_stop("si reduction iter")
+ 
+         SIcst_r0rh0_global = SIcst_allreduce_global3(1) 
+         SIcst_w0rh0_global = SIcst_allreduce_global3(2)
+                      resid = SIcst_allreduce_global3(3)
+
+         ! Omega0
+         SIcst_gamma1 = SIcst_r0rh0_global
+         SIcst_omega0 = SIcst_w0rh0_global
+         SIcst_beta1  = SIcst_gamma1 / SIcst_gamma0
+         SIcst_alpha1 = SIcst_gamma1                            &
+                      /(SIcst_omega0 - SIcst_beta1*SIcst_gamma1 &
+                                     / SIcst_alpha0 )
+
+         !$omp parallel
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+         do iCell = 1,nPrecVec
+            SIvec_r0(iCell)  = SIvec_r1(iCell)
+            SIvec_s0(iCell)  = SIvec_s1(iCell)
+            SIvec_w0(iCell)  = SIvec_w1(iCell)
+            SIvec_z0(iCell)  = SIvec_z1(iCell)
+            SIvec_rh0(iCell) = SIvec_rh1(iCell)
+         end do ! iCell
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+         SIcst_beta0  = SIcst_beta1
+         SIcst_alpha0 = SIcst_alpha1
+         SIcst_gamma0 = SIcst_gamma1
+
+         if ( iter > int(mean_num_cells*5) ) then
+            call mpas_log_write(&
+            '******************************************************')
+            call mpas_log_write(&
+            'Iteration number exceeds Max. #iteration: PROGRAM STOP')
+            call mpas_log_write(&
+            'Current #Iteration = $i ', intArgs=(/ iter /) )
+            call mpas_log_write(&
+            'Max.    #Iteration = $i ', &
+            intArgs=(/ int(mean_num_cells*5) /) )
+            call mpas_log_write(&
+            '******************************************************')
+            call mpas_log_write('',MPAS_LOG_CRIT)
+         endif
+
+      !-------------------------------------------------------------!
+      end do ! do iter
+      !-------------------------------------------------------------!i
+
+!$acc end data
+     
+   end subroutine si_solver_scg_gpu 
 
 !***********************************************************************
 !
@@ -4318,10 +4392,8 @@ module ocn_time_integration_si
  
          iter = iter + 1
  
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nPrecVec
             SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                              * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -4348,10 +4420,8 @@ module ocn_time_integration_si
             SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                  * SIvec_z1(iCell)
          end do ! iCell
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
  
          ! Preconditioning -----------------------------------------!
  
@@ -4396,10 +4466,8 @@ module ocn_time_integration_si
                - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
  
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1,nPrecVec
             sshSolved(iCell) = sshSolved(iCell)           &
                                   + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -4416,10 +4484,8 @@ module ocn_time_integration_si
                              * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                  * SIvec_v0(iCell))
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
  
          ! Preconditioning -----------------------------------------!
  
@@ -4448,10 +4514,8 @@ module ocn_time_integration_si
                                                      * SIcst_r00z0_global )
          SIcst_rho0 = SIcst_rho1
  
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1,nPrecVec
            SIvec_r0(iCell) = SIvec_r1(iCell)
            SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -4465,10 +4529,8 @@ module ocn_time_integration_si
            SIvec_wh0(iCell) = SIvec_wh1(iCell)
            SIvec_zh0(iCell) = SIvec_zh1(iCell)
         end do ! iCell
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
         if ( iter > int(mean_num_cells*5) ) then
            call mpas_log_write(&

--- a/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -56,10 +56,6 @@ module ocn_time_integration_si
    use ocn_surface_land_ice_fluxes
    use ocn_transport_tests
 
-#ifdef USE_CUBLAS
-    use cublas
-#endif
-
    implicit none
    private
    save
@@ -137,13 +133,6 @@ module ocn_time_integration_si
       ncpus,            &! Total number of cores
       nSiLargeIter       ! #iteration for the barotropic system
    character(len=5) :: si_algorithm ! Name of the iterative solver algorithm
-#ifdef USE_CUBLAS
-    type(cublasHandle) :: h
-#endif
-   integer :: istat
-!$acc declare create(prec_ivmat,SIcst_allreduce_local2,SIcst_allreduce_global2,SIcst_allreduce_local3,SIcst_allreduce_global3,&
-!$acc                SIcst_allreduce_local9,SIcst_allreduce_global9,globalReprodSum2fld1,globalReprodSum2fld2,globalReprodSum3fld1,&
-!$acc                globalReprodSum3fld2,globalReprodSum9fld1,globalReprodSum9fld2)
 
    integer :: ssh_sal_on
 
@@ -261,7 +250,6 @@ module ocn_time_integration_si
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp, &
          bottomDepthEdge
-!$acc declare create(uTemp,bottomDepthEdge,btrvel_temp)
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -420,43 +408,43 @@ module ocn_time_integration_si
 
       !*** Retrieve state variables at two time levels
 
-      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocitySubcycle', &
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
                                            normalBarotropicVelocitySubcycleCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
                                            normalVelocityCur, 1)
 
-      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityNew, 2)
-      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityNew, 2)
-      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocitySubcycle', &
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
                                            normalBarotropicVelocitySubcycleNew, 2)
-      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
                                            normalVelocityNew, 2)
 
-      call mpas_pool_get_array_gpu(statePool, 'ssh', sshCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'ssh', sshNew, 2)
+      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
 
-      call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', sshSubcycleNew, 2)
+      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
+      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
 
-      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
+      call mpas_pool_get_array(statePool, 'layerThickness', &
                                            layerThicknessCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
+      call mpas_pool_get_array(statePool, 'layerThickness', &
                                            layerThicknessNew, 2)
 
-      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array(statePool, 'highFreqThickness', &
                                            highFreqThicknessCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array(statePool, 'highFreqThickness', &
                                            highFreqThicknessNew, 2)
 
-      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceCur, 1)
-      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceNew, 2)
 
       call mpas_pool_get_dimension_scalar(tracersPool, 'index_salinity', &
@@ -466,13 +454,13 @@ module ocn_time_integration_si
 
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
-      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
-      call mpas_pool_get_array_gpu(tendPool, 'ssh', &
+      call mpas_pool_get_array(tendPool, 'ssh', &
                                           sshTend)
-      call mpas_pool_get_array_gpu(tendPool, 'layerThickness', &
+      call mpas_pool_get_array(tendPool, 'layerThickness', &
                                           layerThicknessTend)
-      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
@@ -484,7 +472,7 @@ module ocn_time_integration_si
                                           vertVelocityNonhydroNew, 2)
       call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', &
                                           vertVelocityNonhydroCur, 1)
-      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracersNew, 2)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
@@ -494,6 +482,21 @@ module ocn_time_integration_si
         call ocn_transport_test_velocity(meshPool, daysSinceStartOfSim, &
           0.5*dt, normalVelocityCur)
       endif
+
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc   sshCur, layerThicknessCur, sshSubcycleCur, sshSubcycleNew)
+      !$acc enter data create(normalBaroClinicVelocityCur, normalVelocityNew, &
+      !$acc   normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
+      if (associated(highFreqThicknessNew)) then
+         !$acc enter data copyin(highFreqThicknessCur)
+         !$acc enter data create(highFreqThicknessNew)
+      endif
+      if (associated(lowFreqDivergenceNew)) then
+         !$acc enter data copyin(lowFreqDivergenceCur)
+         !$acc enter data create(lowFreqDivergenceNew)
+      endif
+#endif
 
       ! Initialize * variables that are used to compute baroclinic
       ! tendencies below.
@@ -508,16 +511,20 @@ module ocn_time_integration_si
       ! variable subtracts out the barotropic component from the
       ! baroclinic.
 
+#ifdef MPAS_OPENACC
+      !$acc parallel present(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc    sshCur, layerThicknessCur, normalBaroClinicVelocityCur, &
+      !$acc    normalVelocityNew, normalBaroclinicVelocityNew, sshNew, &
+      !$acc    layerThicknessNew, minLevelCell, maxLevelCell,          &
+      !$acc    sshSubcycleCur,sshSubcycleNew)
+#endif
 
-!$acc data present(minLevelCell,maxLevelCell,&
-!$acc              normalBaroclinicVelocityCur,normalVelocityCur,normalBarotropicVelocityCur,&
-!$acc              normalVelocityNew,normalBaroclinicVelocityNew,sshNew,sshCur,sshSubcycleCur,&
-!$acc              sshSubcycleNew,layerThicknessNew,layerThicknessCur,highFreqThicknessNew,&
-!$acc              highFreqThicknessCur,lowFreqDivergenceNew,lowFreqDivergenceCur)
+#ifdef MPAS_OPENACC
+      !$acc loop collapse(2)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-!$acc parallel vector_length(1024)
-!$acc loop gang vector collapse(2)
+#endif
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
 
@@ -531,111 +538,146 @@ module ocn_time_integration_si
          normalBaroclinicVelocityCur(k,iEdge)
       end do
       end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+      !$acc loop gang
+#else
       !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
       do iCell = 1, nCellsAll
          sshNew(iCell) = sshCur(iCell)
          sshSubcycleCur(iCell) = sshCur(iCell)
          sshSubcycleNew(iCell) = sshCur(iCell)
-!$acc loop vector
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
          do k = 1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
       end do
-!$acc end parallel
+#ifdef MPAS_OPENACC
+      !$acc end parallel
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr))
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
                                      tracersGroupCur, 1)
-            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
                                      tracersGroupNew, 2)
 
             if ( associated(tracersGroupCur) .and. &
                  associated(tracersGroupNew) ) then
 
+#ifdef MPAS_OPENACC
+               !$acc enter data create(tracersGroupNew)
+               !$acc enter data copyin(tracersGroupCur)
+               !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
+               !$acc    tracersGroupNew, tracersGroupCur)
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
                do iCell = 1, nCellsAll
-!$acc loop vector
                do k = minLevelCell(iCell), maxLevelCell(iCell)
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
                   do iTracer = 1,size(tracersGroupCur,1)
                      tracersGroupNew(iTracer,k,iCell) = &
                      tracersGroupCur(iTracer,k,iCell)
                   end do
                end do
                end do
-!$acc end parallel
+#ifdef MPAS_OPENACC
+               !$acc exit data copyout(tracersGroupNew)
+               !$acc exit data delete(tracersGroupCur)
+#else
                !$omp end do
                !$omp end parallel
+#endif
             end if
          end if
       end do
 
       if(config_enable_nonhydrostatic_mode) then
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) private(k)
+#endif
          do iCell=1,nCellsAll
             do k = 2, maxLevelCell(iCell)
                vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell)
            end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       end if
 
       if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang &
+         !$acc    present(highFreqThicknessCur, highFreqThicknessNew)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang vector collapse(2)
+#endif
          do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
          do k = 1,nVertLevels
             highFreqThicknessNew(k,iCell) = &
             highFreqThicknessCur(k,iCell)
          end do
          end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       end if
 
       if (associated(lowFreqDivergenceNew)) then
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang &
+         !$acc    present(lowFreqDivergenceCur, lowFreqDivergenceNew)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang vector collapse(2)
+#endif
          do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
          do k = 1,nVertLevels
             lowFreqDivergenceNew(k,iCell) = &
             lowFreqDivergenceCur(k,iCell)
          end do
          end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       endif
-!$acc end data
-
 
       call mpas_timer_stop("si prep")
 
-      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
       if (landIcePressureOn) then
-         call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
+         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       endif
 
       if ( config_btr_si_partition_match_mode ) then
@@ -651,6 +693,21 @@ module ocn_time_integration_si
                       globalReprodSum3fld2(nCellsOwned,3) )
          endif
       endif
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc    sshCur, layerThicknessCur)
+      !$acc exit data copyout(normalBaroClinicVelocityCur, normalVelocityNew, &
+      !$acc    normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
+      if (associated(highFreqThicknessNew)) then
+         !$acc exit data delete(highFreqThicknessCur)
+         !$acc exit data copyout(highFreqThicknessNew)
+      endif
+      if (associated(lowFreqDivergenceNew)) then
+         !$acc exit data delete(lowFreqDivergenceCur)
+         !$acc exit data copyout(lowFreqDivergenceNew)
+      endif
+#endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! BEGIN large outer timestep iteration loop
@@ -669,8 +726,17 @@ module ocn_time_integration_si
 
          stage1_tend_time = min(splitImplicitStep,2)
 
-         call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+         call mpas_pool_get_array(statePool, 'normalVelocity', &
                            normalVelocityCur, stage1_tend_time)
+
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update device(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
+            !$acc enter data create(highFreqThicknessNew)
+            !$acc enter data copyin(highFreqThicknessCur, highFreqThicknessTend)
+         endif
+#endif
 
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
@@ -711,9 +777,17 @@ module ocn_time_integration_si
 
             call mpas_timer_stop("si freq-filtered-thick halo update")
 
+#ifdef MPAS_OPENACC
+            !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
+            !$acc    highFreqThicknessNew, highFreqThicknessCur, highFreqThicknessTend)
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
+#endif
             do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h^{hf}_{n+1}
                highFreqThicknessNew(k,iCell) = &
@@ -721,8 +795,10 @@ module ocn_time_integration_si
                highFreqThicknessTend(k,iCell)
             end do
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
          endif ! freq filtered thickness
 
@@ -735,18 +811,30 @@ module ocn_time_integration_si
          ! Use the most recent time level available.
 
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top_gpu( &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
-            call ocn_vert_transport_velocity_top_gpu( &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, &
                  sshCur, dt, vertAleTransportTop, err)
          endif
 
-         call ocn_tend_vel_gpu(domain, tendPool, statePool, forcingPool, &
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update host(vertAleTransportTop)
+         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
+            !$acc exit data copyout(highFreqThicknessNew)
+            !$acc exit data delete(highFreqThicknessCur, highFreqThicknessTend)
+         endif
+#endif
+
+         call ocn_tend_vel(domain, tendPool, statePool, forcingPool, &
                            stage1_tend_time, domain % dminfo, dt)
 
          call mpas_timer_stop('si bcl vel tend')
@@ -761,7 +849,7 @@ module ocn_time_integration_si
 
             ! Put f*normalBaroclinicVelocity^{perp} in
             ! normalVelocityNew as a work variable
-            call ocn_fuperp_gpu(statePool, meshPool, 2)
+            call ocn_fuperp(statePool, meshPool, 2)
 
             !TODO: look at loop optimizations here
             ! Only need to loop over owned cells, since there is a halo
@@ -769,24 +857,17 @@ module ocn_time_integration_si
 
             allocate(uTemp(nVertLevels,nEdgesOwned))
 
-!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,dcEdge,nEdgesHalo,&
-!$acc              normalBaroclinicVelocityCur,normalVelocityTend,normalVelocityNew,sshNew,&
-!$acc              layerThickEdgeFlux,barotropicForcing,normalBaroclinicVelocityNew,uTemp,bottomDepthEdge)
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k, cell1, cell2, uTemp, &
             !$omp         normalThicknessFluxSum, thicknessSum)
-!$acc parallel
-!$acc loop gang worker private(cell1,cell2,normalThicknessFluxSum,thicknessSum)
+#endif
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-!$acc loop vector
-               do k = 1, nVertLevels
-                  uTemp(k,iEdge) = 0.0_RKIND
-               enddo
-!$acc loop vector
+               uTemp(:,iEdge) = 0.0_RKIND
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! normalBaroclinicVelocityNew =
                   ! normalBaroclinicVelocityOld +
@@ -811,7 +892,7 @@ module ocn_time_integration_si
                   * uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum = &
                     layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
+
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                  layerThickEdgeFlux(k,iEdge)*uTemp(k,iEdge)
@@ -820,7 +901,7 @@ module ocn_time_integration_si
                enddo
                barotropicForcing(iEdge) = &
                               normalThicknessFluxSum/thicknessSum/dt
-!$acc loop vector
+
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
                   !{\bf u}'_{k,n+1} =
@@ -832,21 +913,20 @@ module ocn_time_integration_si
                   normalBaroclinicVelocityCur(k,iEdge) + uTemp(k,iEdge) - &
                          dt * barotropicForcing(iEdge))
                enddo
+
             enddo ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1, cell2, k, thicknessSum)
-!$acc parallel
-!$acc loop gang vector private(cell1,cell2,thicknessSum)
+#endif
             do iEdge = 1, nEdgesHalo(config_num_halos+1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-!$acc loop seq
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
@@ -854,10 +934,10 @@ module ocn_time_integration_si
                bottomDepthEdge(iEdge) = thicknessSum &
                   - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-!$acc end data
+#endif
 
             deallocate(uTemp)
 
@@ -886,6 +966,7 @@ module ocn_time_integration_si
 !                  iterGroupName)
 !        call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
 !        call mpas_timer_stop("si halo btr vel")
+
 
 
          call mpas_timer_stop("si bcl vel")
@@ -966,15 +1047,17 @@ module ocn_time_integration_si
          nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
 
          if (config_filter_btr_mode) then
-!NV!        !!! NOT EXECUTING !!!
-            write(*,*) "config_filter_btr_mode NOT EXECUTING"
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
+#endif
             do iEdge = 1, nEdges
                barotropicForcing(iEdge) = 0.0_RKIND
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
          endif
 
 
@@ -990,36 +1073,36 @@ module ocn_time_integration_si
             if ( splitImplicitStep == 2 .or. siLargeIter > 1 ) then
                ! Here sshSubcycleNew and normalBarotropicVelocityCur
                ! are at time n+1/2.
-
+   
+#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
+#endif
                do iCell = 1,nCellsAll
                   sshSubcycleNew(iCell) = &
                      0.5_RKIND*( sshSubcycleNew(iCell) &
                                 +sshCur(iCell) )
                   sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
                end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
                !$omp end do
-  
+   
                !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
+#endif
                do iEdge = 1,nEdgesAll
                   normalBarotropicVelocityCur(iEdge) = &
                      normalBarotropicVelocitySubcycleCur(iEdge)
                end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             endif ! splitImplicitStep
-  
+   
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-!$acc parallel
-!$acc loop gang vector private(CoriolisTerm,eoe)
+#endif
             do iEdge = 1, nEdgesAll
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.d0
@@ -1031,9 +1114,10 @@ module ocn_time_integration_si
                end do ! i
                   barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
             ! Subtract tidal potential from ssh, if needed
             ! Subtract the tidal potential from the current
@@ -1042,8 +1126,6 @@ module ocn_time_integration_si
             ! tidal potential terms are included in the grad
             ! operator inside the edge loop.
             if (config_use_tidal_potential_forcing) then
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "config_use_tidal_potential_forcing NOT EXECUTING"
    
                call mpas_pool_get_array(forcingPool,            &
                                      'sshSubcycleCurWithTides', &
@@ -1052,8 +1134,10 @@ module ocn_time_integration_si
                                        'tidalPotentialEta', &
                                         tidalPotentialEta)
    
+#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
+#endif
                do iCell = 1, nCellsAll
                  sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) &
                             - tidalPotentialEta(iCell)                  &
@@ -1062,20 +1146,26 @@ module ocn_time_integration_si
                             * config_self_attraction_and_loading_beta   &
                             * sshSubcycleCur(iCell)
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
    
                call mpas_pool_get_array(forcingPool,            &
                                      'sshSubcycleCurWithTides', &
                                       sshSubcycleNew)
    
+#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
+#endif
                do iCell = 1,nCellsAll
                   sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
    
             endif !config_use_tidal_potential_forcing
    
@@ -1087,24 +1177,22 @@ module ocn_time_integration_si
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr residual")
-
+   
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
             !$omp         cell1,cell2,sshEdgeCur,thicknessSumCur, &
             !$omp         sshDiffCur,fluxb1,fluxb2,fluxAx,sshCurArea)
-!$acc parallel
-!$acc loop gang vector private(sshTendb1,sshTendb2,sshTendAx,iEdge,cell1,cell2,sshEdgeCur,thicknessSumCur,sshDiffCur,&
-!$acc                          fluxb1,fluxb2,fluxAx,sshCurArea)
+#endif
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-!$acc loop seq 
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-!NV!                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
-                  if (maxLevelEdgeTop(iEdge).ne.0) then
+                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
    
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
@@ -1135,7 +1223,6 @@ module ocn_time_integration_si
                                         * fluxb2 * dvEdge(iEdge)
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                                         * fluxAx * dvEdge(iEdge)
-                  endif
                end do ! i
    
                sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
@@ -1148,14 +1235,14 @@ module ocn_time_integration_si
                SIvec_r00(iCell) = SIvec_r0(iCell)
    
             end do ! iCell
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
             ! Preconditioning --------------------------------------------!
 
-!NV!        On GPU
-            call si_precond_gpu(SIvec_r0,SIvec_rh0)
+            call si_precond(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
@@ -1163,15 +1250,15 @@ module ocn_time_integration_si
   
    
             ! SpMV -------------------------------------------------------!
-            call si_matvec_mul_gpu(SIvec_rh0,bottomDepthEdge, &
+   
+            call si_matvec_mul(SIvec_rh0,bottomDepthEdge, &
                                SIvec_w0,sshSubcycleCur)
 
             if ( si_algorithm == 'sbicg' ) then !!!
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "si_algorithm == 'sbicg' NOT EXECUTING"
+
             ! Preconditioning --------------------------------------------!
 
-               call si_precond_gpu(SIvec_w0,SIvec_wh0)
+               call si_precond(SIvec_w0,SIvec_wh0)
       
                call mpas_timer_start("si halo r0")
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
@@ -1201,24 +1288,20 @@ module ocn_time_integration_si
                SIcst_omega0 = 0.0_RKIND
 
             else if ( si_algorithm == 'scg' ) then !!!
-         
-!$acc parallel
-!$acc loop gang vector  
+           
                do iCell = 1, nPrecVec
                   SIvec_s0(iCell)  = 0.0_RKIND
                   SIvec_z0(iCell)  = 0.0_RKIND
                end do ! iCell
-!$acc end parallel
    
                ! Reduction --------------------------------------------------!
                call mpas_timer_start("si reduction r0")
-               call si_global_reduction_gpu(SIcst_allreduce_local2, &
+               call si_global_reduction(SIcst_allreduce_local2, &
                                    SIcst_allreduce_global2,     &
                                    globalReprodSum2fld1,        &
                                    globalReprodSum2fld2,        &
                                    si_algorithm,2,domain,       &
                                    SIvec_r0,SIvec_w0,SIvec_rh0)
-!$acc update host(SIcst_allreduce_local2,SIcst_allreduce_global2)
                call mpas_timer_stop ("si reduction r0")
    
                SIcst_r0rh0_global = SIcst_allreduce_global2(1)
@@ -1241,15 +1324,12 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr iteration")
 
             if ( si_algorithm == 'sbicg' ) then
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "si_algorithm == 'sbicg' si_solver_sbicg NOT EXECUTING"
                call si_solver_sbicg(domain,                                &
                     sshSubcycleNew,sshSubcycleCur,bottomDepthEdge,         &
                     tolerance_outer,SIcst_alpha0,SIcst_beta0,SIcst_gamma0, &
                     SIcst_rho0)
             else if ( si_algorithm == 'scg' ) then
-!NV!           ON GPU
-               call si_solver_scg_gpu(domain,                                  &
+               call si_solver_scg(domain,                                  &
                     sshSubcycleNew,sshSubcycleCur,bottomDepthEdge,         &
                     tolerance_outer,SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
             endif
@@ -1269,23 +1349,22 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr vel update")
 
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
+#endif
             do iCell = 1,nCellsAll
                ! Use of sshNew to save the lagged SSH
                sshNew(iCell) = sshSubcycleNew(iCell)
             end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-  
+   
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-!$acc parallel
-!$acc loop gang vector private(temp_mask,cell1,cell2)
+#endif
             do iEdge = 1,nEdgesHalo( edgeHaloComputeCounter-1 )
                temp_mask = edgeMask(1, iEdge)
    
@@ -1306,18 +1385,16 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-  
+   
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-!$acc parallel
-!$acc loop gang vector private(CoriolisTerm,eoe)
+#endif
             do iEdge = 1,nEdgesHalo(2)
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
-!$acc loop seq
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
                   CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge)       &
@@ -1328,15 +1405,14 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-!$acc parallel
-!$acc loop gang vector private(temp_mask,cell1,cell2)
+#endif
             do iEdge = 1,nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1349,14 +1425,13 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)        &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-  
+   
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-!$acc parallel
-!$acc loop gang vector private(CoriolisTerm,eoe)
+#endif
             do iEdge = 1,nEdgesOwned
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
@@ -1370,9 +1445,10 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
             call mpas_timer_start("si halo btr coriolis")
             call mpas_dmpar_field_halo_exch(domain, 'barotropicCoriolisTerm')
@@ -1389,7 +1465,8 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr residual")
    
             ! SpMV -------------------------------------------------------!
-  
+   
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
@@ -1397,19 +1474,15 @@ module ocn_time_integration_si
             !$omp         thicknessSumCur,thicknessSumMid, &
             !$omp         thicknessSumLag,sshDiffCur,sshDiffLag, &
             !$omp         fluxb1,fluxb2,fluxAx,sshCurArea,sshLagArea)
-!$acc parallel
-!$acc loop gang vector private(sshTendb1,sshTendb2,sshTendAx,iEdge,cell1,cell2,sshEdgeCur,sshEdgeLag,sshEdgeMid,&
-!$acc                          thicknessSumCur,thicknessSumLag,thicknessSumMid,sshDiffCur,sshDiffLag,fluxb1,fluxb2,fluxAx,&
-!$acc                          sshCurArea,sshLagArea)
+#endif
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-!$acc loop seq
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-!NV!                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
-                  if (maxLevelEdgeTop(iEdge).ne.0) then
+                  if (maxLevelEdgeTop(iEdge).eq.0) cycle
    
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
@@ -1450,7 +1523,6 @@ module ocn_time_integration_si
                                         * fluxb2 * dvEdge(iEdge)
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                                         * fluxAx * dvEdge(iEdge)
-                  endif
                end do ! i
    
                sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
@@ -1464,28 +1536,28 @@ module ocn_time_integration_si
                                 -(-sshLagArea - sshTendAx)
                SIvec_r00(iCell) = SIvec_r0(iCell)
             end do ! iCell
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
             ! Preconditioning --------------------------------------------!
 
-!NV!        ON GPU
-            call si_precond_gpu(SIvec_r0,SIvec_rh0)
+            call si_precond(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
             call mpas_timer_stop("si halo r0")
    
             ! SpMV -------------------------------------------------------!
-            call si_matvec_mul_gpu(SIvec_rh0,bottomDepthEdge,SIvec_w0,sshNew)
+
+            call si_matvec_mul(SIvec_rh0,bottomDepthEdge,SIvec_w0,sshNew)
 
             if ( si_algorithm == 'sbicg' ) then !!!
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "si_algorithm == 'sbicg' NOT EXECUTING"
+
             ! Preconditioning --------------------------------------------!
 
-               call si_precond_gpu(SIvec_w0,SIvec_wh0)
+               call si_precond(SIvec_w0,SIvec_wh0)
       
                call mpas_timer_start("si halo r0")
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
@@ -1515,24 +1587,20 @@ module ocn_time_integration_si
                SIcst_omega0 = 0.0_RKIND
 
             else if ( si_algorithm == 'scg' ) then !!!
-          
-!$acc parallel
-!$acc loop gang vector 
+           
                do iCell = 1, nPrecVec
                   SIvec_s0(iCell)  = 0.0_RKIND
                   SIvec_z0(iCell)  = 0.0_RKIND
                end do ! iCell
-!$acc end parallel
    
                ! Reduction --------------------------------------------------!
                call mpas_timer_start("si reduction r0")
-               call si_global_reduction_gpu(SIcst_allreduce_local2, &
+               call si_global_reduction(SIcst_allreduce_local2, &
                                    SIcst_allreduce_global2,     &
                                    globalReprodSum2fld1,        &
                                    globalReprodSum2fld2,        &
                                    si_algorithm,2,domain,       &
                                    SIvec_r0,SIvec_w0,SIvec_rh0)
-!$acc update host(SIcst_allreduce_local2,SIcst_allreduce_global2)
                call mpas_timer_stop ("si reduction r0")
    
                SIcst_r0rh0_global = SIcst_allreduce_global2(1)
@@ -1553,15 +1621,12 @@ module ocn_time_integration_si
             call mpas_timer_start("si btr iteration")
 
             if ( si_algorithm == 'sbicg' ) then
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "si_algorithm == 'sbicg' si btr iteration NOT EXECUTING"
                call si_solver_sbicg(domain,                                &
                     sshSubcycleNew,sshNew,bottomDepthEdge,                 &
                     tolerance_inner,SIcst_alpha0,SIcst_beta0,SIcst_gamma0, &
                     SIcst_rho0)
             else if ( si_algorithm == 'scg' ) then
-!NV!           ON GPU
-               call si_solver_scg_gpu(domain,                                  &
+               call si_solver_scg(domain,                                  &
                     sshSubcycleNew,sshNew,bottomDepthEdge,                 &
                     tolerance_inner,SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
             endif
@@ -1578,12 +1643,12 @@ module ocn_time_integration_si
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr vel update")
- 
+   
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-!$acc parallel
-!$acc loop gang vector private(temp_mask,cell1,cell2)
+#endif
             do iEdge = 1, nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1604,18 +1669,16 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-  
+   
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-!$acc parallel
-!$acc loop gang vector private(CoriolisTerm,eoe)
+#endif
             do iEdge = 1,nEdgesHalo(1)
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
-!$acc loop seq
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
                   CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)     &
@@ -1626,15 +1689,14 @@ module ocn_time_integration_si
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-
+   
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(temp_mask,cell1,cell2)
-!$acc parallel
-!$acc loop gang vector private(temp_mask,cell1,cell2)
+#endif
             do iEdge = 1, nEdgesOwned
                temp_mask = edgeMask(1, iEdge)
    
@@ -1648,18 +1710,16 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-
+   
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1,cell2,sshEdge,thicknessSum)
-!$acc parallel
-!$acc loop gang vector private(cell1,cell2,sshEdge,thicknessSum)
+#endif
             do iEdge = 1, nEdgesOwned
-!NV!               if (maxLevelEdgeTop(iEdge).eq.0) cycle
-               if (maxLevelEdgeTop(iEdge).ne.0) then
+               if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
@@ -1682,11 +1742,11 @@ module ocn_time_integration_si
                   = 0.5*(  normalBarotropicVelocitySubcycleNew(iEdge) &
                          + normalBarotropicVelocityCur(iEdge) )       &
                          * thicknessSum
-               endif
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
    
             ! boundary update on F
@@ -1702,18 +1762,19 @@ module ocn_time_integration_si
                       finalBtrGroupName)
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
             call mpas_timer_stop("si halo btr vel")
-
+   
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
+#endif
             do iEdge = 1, nEdgesAll
                normalBarotropicVelocityNew(iEdge)              &
                   = normalBarotropicVelocitySubcycleCur(iEdge) 
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             call mpas_timer_stop("si btr vel update")
 
@@ -1744,29 +1805,27 @@ module ocn_time_integration_si
          nEdges = nEdgesHalo(config_num_halos-1 )
          allocate(uTemp(nVertLevels,nEdges))
 
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector collapse(2)
+#endif
          do iEdge = 1, nEdges
-            do k = 1, nVertLevels
-               uTemp(k,iEdge) = normalBarotropicVelocityNew(iEdge) &
-                         + normalBaroclinicVelocityNew(k,iEdge)
-            enddo
+            uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
+                         + normalBaroclinicVelocityNew(:,iEdge)
          end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
 
-         call ocn_GM_add_to_transport_vel_gpu(uTemp, nEdges, nVertLevels)
-!NV!     !!! NOT EXECUTING !!!
-         call ocn_MLE_add_to_transport_vel_gpu(uTemp, nEdges)
+         call ocn_GM_add_to_transport_vel(uTemp, nEdges, nVertLevels)
+         call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp private(k)
-!$acc parallel
-!$acc loop gang vector collapse(2)
+#endif
          do iEdge = 1, nEdges
             do k = 1, nVertLevels
                normalTransportVelocity(k,iEdge) =  &
@@ -1774,22 +1833,22 @@ module ocn_time_integration_si
                         normalBaroclinicVelocityNew(k,iEdge)
             end do
          end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
 
          ! add GM and submesoscale contributions if requested
-         call ocn_GM_add_to_transport_vel_gpu(normalTransportVelocity, nEdges, &
+         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, &
                                           nVertLevels)
-!NV!     !!! NOT EXECUTING !!!
-         call ocn_MLE_add_to_transport_vel_gpu(normalTransportVelocity, nEdges)
+         call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp private(k, normalThicknessFluxSum, &
          !$omp         thicknessSum, normalVelocityCorrection)
-!$acc parallel
-!$acc loop gang worker private(normalThicknessFluxSum,thicknessSum,normalVelocityCorrection)
+#endif
          do iEdge = 1, nEdges
 
             ! thicknessSum is initialized outside the loop because
@@ -1801,7 +1860,7 @@ module ocn_time_integration_si
                * uTemp(minLevelEdgeBot(iEdge),iEdge)
             thicknessSum &
                = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
+
             do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                normalThicknessFluxSum = normalThicknessFluxSum + &
                                         layerThickEdgeFlux(k,iEdge)* &
@@ -1813,7 +1872,7 @@ module ocn_time_integration_si
             normalVelocityCorrection = useVelocityCorrection* &
                           ((barotropicThicknessFlux(iEdge) -  &
                             normalThicknessFluxSum)/thicknessSum)
-!$acc loop vector
+
             do k = 1, nVertLevels
 
                ! normalTransportVelocity = normalBarotropicVelocity
@@ -1829,9 +1888,10 @@ module ocn_time_integration_si
             enddo
 
          end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
 
          deallocate(uTemp)
 
@@ -1862,20 +1922,34 @@ module ocn_time_integration_si
          ! layerThickEdgeFlux because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, sshCur)
+         !$acc update device(layerThickEdgeFlux, normalTransportVelocity)
+#endif
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top_gpu( &
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
-            call ocn_vert_transport_velocity_top_gpu( &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, sshCur)
+         !$acc update host(vertAleTransportTop, normalTransportVelocity)
+#endif
          call mpas_timer_stop('thick vert trans vel top')
 
-         call ocn_tend_thick_gpu(tendPool, forcingPool)
+         call ocn_tend_thick(tendPool, forcingPool)
 
          call mpas_timer_stop('si thick tend')
 
@@ -1888,18 +1962,67 @@ module ocn_time_integration_si
 
          call mpas_timer_start('si tracer tend', .false.)
 
-         call ocn_tend_tracer_gpu(tendPool, statePool, forcingPool, &
+         call ocn_tend_tracer(tendPool, statePool, forcingPool, &
                               meshPool, swForcingPool, &
                               dt, activeTracersOnly, 2)
 
-         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
                                                 tracersGroupCur, 1)
-         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
                                                 tracersGroupNew, 2)
-         call mpas_pool_get_array_gpu(statePool,   'normalVelocity', &
+         call mpas_pool_get_array(statePool,   'normalVelocity', &
                                                 normalVelocityCur, 1)
-         call mpas_pool_get_array_gpu(tracersTendPool,'activeTracersTend', &
+         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
+
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
+         !$acc enter data copyin(normalBarotropicVelocityNew, &
+         !$acc                   normalBaroclinicVelocityNew)
+         !$acc enter data copyin(activeTracersNew)
+         !$acc update device(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness) then
+            !$acc enter data copyin(lowFreqDivergenceNew)
+            !$acc enter data copyin(lowFreqDivergenceCur)
+            !$acc enter data copyin(lowFreqDivergenceTend)
+         endif
+         if (splitImplicitStep < numTSIterations) then
+            !$acc update device (normalTransportVelocity)
+            !$acc enter data copyin(atmosphericPressure, seaIcePressure)
+            !$acc enter data copyin(sshNew)
+            !$acc update device(tracersSurfaceValue)
+            if ( associated(normalGMBolusVelocity) ) then
+               !$acc update device (normalGMBolusVelocity)
+            end if
+            if ( associated(normalMLEVelocity) ) then
+               !$acc update device (normalMLEvelocity)
+            end if
+            if ( associated(frazilSurfacePressure) ) then
+               !$acc enter data copyin(frazilSurfacePressure)
+            endif
+            if (landIcePressureOn) then
+               !$acc enter data copyin(landIcePressure)
+               !$acc enter data copyin(landIceDraft)
+            endif
+            if (config_use_freq_filtered_thickness) then
+               !$acc enter data copyin(highFreqThicknessNew)
+               !$acc enter data copyin(highFreqThicknessCur)
+            endif
+         elseif (splitImplicitStep == numTSIterations) then
+            !$acc enter data copyin(layerThicknessCur)
+            !$acc enter data copyin(layerThicknessTend)
+            !$acc enter data copyin(normalBaroclinicVelocityCur)
+            if (config_compute_active_tracer_budgets) then
+               !$acc update device(activeTracerHorizontalAdvectionEdgeFlux)
+               !$acc update device(activeTracerHorizontalAdvectionTendency)
+               !$acc update device(activeTracerVerticalAdvectionTendency)
+               !$acc update device(activeTracerHorMixTendency)
+               !$acc update device(activeTracerSurfaceFluxTendency)
+               !$acc update device(temperatureShortWaveTendency)
+               !$acc update device(activeTracerNonLocalTendency)
+            endif
+         endif
+#endif
 
          if(config_enable_nonhydrostatic_mode) then
             call ocn_tend_vvel(tendPool, statePool, & 
@@ -1949,9 +2072,13 @@ module ocn_time_integration_si
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.
 
+!! Keeping this calc on the CPU for now
+#ifdef MPAS_OPENACC
+            !$acc update host(layerThicknessNew)
+            !$acc update host(activeTracersNew)
+            !$acc update host(tracersSurfaceValue)
+#else
             if(config_enable_nonhydrostatic_mode) then
-!NV!          !!! NOT EXECUTING !!!
-              write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp_h)
                do iCell=1,nCells
@@ -1966,10 +2093,8 @@ module ocn_time_integration_si
 
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
-!$acc parallel
-!$acc loop gang worker
+#endif
             do iCell = 1, nCellsAll
-!$acc loop vector private(temp_h,temp)
             do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                ! this is h_{n+1}
@@ -1979,6 +2104,7 @@ module ocn_time_integration_si
                ! this is h_{n+1/2}
                layerThicknessNew(k,iCell) = 0.5* &
                (layerThicknessCur(k,iCell) + temp_h)
+
                do i = startIndex, endIndex
                   ! This is Phi at n+1
                   temp = (tracersGroupCur(i,k,iCell)* &
@@ -1991,30 +2117,48 @@ module ocn_time_integration_si
                end do ! tracer index
             end do ! vertical
             end do ! iCell
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
+!NOTE - this is not setup for OPENACC here
 
             if(config_enable_nonhydrostatic_mode) then
-!NV!          !!! NOT EXECUTING !!!
-              write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
+#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, temp_h)
+#endif
                   do iCell=1,nCells
                      do k=2,maxLevelCell(iCell)
                         temp_h = vertVelocityNonhydroCur(k,iCell) + dt * vertVelocityNonhydroTend(k,iCell)
                         vertVelocityNonhydroNew(k,iCell) = 0.5_RKIND*(vertVelocityNonhydroCur(k,iCell) + temp_h)
                      end do
                   end do
+#ifndef MPAS_OPENACC
                   !$omp end do
                   !$omp end parallel
+#endif
                end if
 
+
+#ifdef MPAS_OPENACC
+            !$acc update device(layerThicknessNew)
+            !$acc update device(activeTracersNew)
+#endif
+
             if (config_use_freq_filtered_thickness) then
-!NV!          !!! NOT EXECUTING !!!
-              write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
+
+#ifdef MPAS_OPENACC
+               !$acc parallel loop present(minLevelCell, maxLevelCell) &
+               !$acc   present(highFreqThicknessNew) &
+               !$acc   present(highFreqThicknessCur) &
+               !$acc   present(lowFreqDivergenceNew) &
+               !$acc   present(lowFreqDivergenceCur) &
+               !$acc   present(lowFreqDivergenceTend)
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp)
+#endif
                do iCell = 1, nCellsAll
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
@@ -2034,14 +2178,20 @@ module ocn_time_integration_si
                            (lowFreqDivergenceCur(k,iCell) + temp)
                end do
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             end if
 
+#ifdef MPAS_OPENACC
+            !$acc parallel loop collapse(2) present(normalVelocityNew) &
+            !$acc   present(normalBaroclinicVelocityNew, edgeMask) &
+            !$acc   present(normalBarotropicVelocityNew)
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang vector collapse(2)
+#endif
             do iEdge = 1, nEdgesAll
             do k = 1, nVertLevels
 
@@ -2054,14 +2204,15 @@ module ocn_time_integration_si
 
             enddo
             end do ! iEdge
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             ! Efficiency note: We really only need this to compute
             ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
-            call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, &
+            call ocn_diagnostic_solve(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
 
@@ -2072,12 +2223,32 @@ module ocn_time_integration_si
 
          elseif (splitImplicitStep == numTSIterations) then
 
+#ifdef MPAS_OPENACC
+            !$acc parallel present(minLevelCell, maxLevelCell) &
+            !$acc   present(layerThicknessTend) &
+            !$acc   present(layerThicknessCur) &
+            !$acc   present(minLevelEdgeBot, maxLevelEdgeTop) &
+            !$acc   present(layerThickEdgeFlux) &
+            !$acc   present(activeTracerHorizontalAdvectionEdgeFlux) &
+            !$acc   present(layerThicknessNew) &
+            !$acc   present(activeTracerHorizontalAdvectionTendency) &
+            !$acc   present(activeTracerVerticalAdvectionTendency) &
+            !$acc   present(activeTracerHorMixTendency) &
+            !$acc   present(activeTracerSurfaceFluxTendency) &
+            !$acc   present(temperatureShortWaveTendency) &
+            !$acc   present(activeTracerNonLocalTendency)
+#endif
+
+#ifdef MPAS_OPENACC
+            !$acc loop gang
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
             do iCell = 1, nCellsAll
-!$acc loop vector
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h_{n+1}
                layerThicknessNew(k,iCell) = &
@@ -2085,32 +2256,43 @@ module ocn_time_integration_si
                                   dt*layerThicknessTend(k,iCell)
             end do
             end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             if(config_enable_nonhydrostatic_mode) then
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
+#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime) private(k)
+#endif
                do iCell=1,nCells
                   do k=1,maxLevelCell(iCell)
                      vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell) + dt*vertVelocityNonhydroTend(k,iCell)
                   end do
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             end if
 
             if (config_compute_active_tracer_budgets) then
+
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
                do iEdge = 1, nEdgesAll
-!$acc loop vector
+#ifdef MPAS_OPENACC
+               !$acc loop seq
+#endif
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
                   do iTracer = 1, size(activeTracerHorizontalAdvectionEdgeFlux,1)
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) / &
@@ -2118,47 +2300,84 @@ module ocn_time_integration_si
                   enddo
                enddo
                enddo
-!$acc end parallel
+#ifndef MPAS_OPENACC
                !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
                do iCell = 1, nCellsAll
-!$acc loop vector
                do k= minLevelCell(iCell), maxLevelCell(iCell)
-               do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
-                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
-                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+                  do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
+                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
+                               layerThicknessNew(k,iCell)
+
+                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
+                               layerThicknessNew(k,iCell)
+
+                     activeTracerHorMixTendency(iTracer,k,iCell) = &
+                     activeTracerHorMixTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+
+                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
+                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+
+                     activeTracerNonLocalTendency(iTracer,k,iCell) = &
+                     activeTracerNonLocalTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+                  end do
+#else
+                  activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
+                  activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
-                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
+                  activeTracerVerticalAdvectionTendency(:,k,iCell) = &
+                  activeTracerVerticalAdvectionTendency(:,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerHorMixTendency(iTracer,k,iCell) = &
-                  activeTracerHorMixTendency(iTracer,k,iCell) / &
+                  activeTracerHorMixTendency(:,k,iCell) = &
+                  activeTracerHorMixTendency(:,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
-                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
+                  activeTracerSurfaceFluxTendency(:,k,iCell) = &
+                  activeTracerSurfaceFluxTendency(:,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerNonLocalTendency(iTracer,k,iCell) = &
-                  activeTracerNonLocalTendency(iTracer,k,iCell) / &
+                  activeTracerNonLocalTendency(:,k,iCell) = &
+                  activeTracerNonLocalTendency(:,k,iCell) / &
                              layerThicknessNew(k,iCell)
-               end do
+#endif
 
                   temperatureShortWaveTendency(k,iCell) = &
                   temperatureShortWaveTendency(k,iCell) / &
                              layerThicknessNew(k,iCell)
                end do
                end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             endif
 
+#ifdef MPAS_OPENACC
+            !$acc end parallel
+#endif
+
+! This tracer block is still computed on the CPU
+#ifdef MPAS_OPENACC
+            !$acc update host(layerThicknessNew)
+            !$acc update host(layerThicknessCur, layerThicknessTend)
+            !$acc update host(activeTracersNew)
+            !$acc update host(tracersSurfaceValue)
+#endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &
@@ -2169,68 +2388,66 @@ module ocn_time_integration_si
                                 configName, config_use_tracerGroup)
 
                   if ( config_use_tracerGroup ) then
-                     call mpas_pool_get_array_gpu(tracersPool, &
+                     call mpas_pool_get_array(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupCur, 1)
-                     call mpas_pool_get_array_gpu(tracersPool, &
+                     call mpas_pool_get_array(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupNew, 2)
 
                      modifiedGroupName = &
                              trim(groupItr % memberName) // 'Tend'
-                     call mpas_pool_get_array_gpu(tracersTendPool, &
+                     call mpas_pool_get_array(tracersTendPool, &
                                               modifiedGroupName, &
                                               tracersGroupTend)
 
+#ifndef MPAS_OPENACC
                      !$omp parallel
                      !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
                      do iCell = 1, nCellsAll
-!$acc loop vector
                      do k = minLevelCell(iCell), maxLevelCell(iCell)
-                     do iTracer = 1, size(tracersGroupNew,1)
-                        tracersGroupNew(iTracer,k,iCell) = &
-                       (tracersGroupCur(iTracer,k,iCell) * &
+                        tracersGroupNew(:,k,iCell) = &
+                       (tracersGroupCur(:,k,iCell) * &
                         layerThicknessCur(k,iCell) + dt* &
-                       tracersGroupTend(iTracer,k,iCell))/ &
+                       tracersGroupTend(:,k,iCell))/ &
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-                     end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
+#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
                          'activeTracers' ) then
+#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
                         do iCell = 1, nCellsAll
-!$acc loop vector
                         do k = minLevelCell(iCell), maxLevelCell(iCell)
                            tracersGroupNew(indexSalinity,k,iCell) = &
                            max(0.001_RKIND,  &
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
+#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
                      if (trim(groupItr % memberName) == &
                          'debugTracers' .and. &
                          config_reset_debugTracers_near_surface) then
-!NV!                    !!! NOT EXECUTING !!!
-                        write(*,*) "config_reset_debugTracers_near_surface NOT EXECUTING"
 
+#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k, lat)
+#endif
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
@@ -2273,19 +2490,38 @@ module ocn_time_integration_si
                               end do
                            end if
                         end do ! cells
+#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
+#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer
             end do ! tracer group
 
+#ifdef MPAS_OPENACC
+            !$acc update device(layerThicknessNew)
+            !$acc update device(activeTracersNew)
+#endif
+
             if (config_use_freq_filtered_thickness) then
-!NV!           !!! NOT EXECUTING !!!
-               write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
+#ifdef MPAS_OPENACC
+               !$acc parallel present(minLevelCell, maxLevelCell) &
+               !$acc   present(lowFreqDivergenceNew) &
+               !$acc   present(lowFreqDivergenceCur) &
+               !$acc   present(lowFreqDivergenceTend)
+#endif
+
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
+#endif
                do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
@@ -2296,8 +2532,14 @@ module ocn_time_integration_si
                   lowFreqDivergenceTend(k,iCell)
                end do
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
+
+#ifdef MPAS_OPENACC
+               !$acc end parallel
+#endif
 
             end if
 
@@ -2317,12 +2559,24 @@ module ocn_time_integration_si
             ! so normalBaroclinicVelocity does not have to be
             ! recomputed here.
 
+#ifdef MPAS_OPENACC
+            !$acc parallel present(minLevelEdgeBot, maxLevelEdgeTop) &
+            !$acc   present(normalVelocityNew) &
+            !$acc   present(normalBarotropicVelocityNew) &
+            !$acc   present(normalBaroclinicVelocityNew) &
+            !$acc   present(normalBaroclinicVelocityCur)
+#endif
+
+#ifdef MPAS_OPENACC
+            !$acc loop gang
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-!$acc parallel
-!$acc loop gang worker
+#endif
             do iEdge = 1, nEdgesAll
-!$acc loop vector
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
                                normalBarotropicVelocityNew(iEdge) + &
@@ -2330,12 +2584,81 @@ module ocn_time_integration_si
                                normalBaroclinicVelocityCur(k,iEdge)
             end do
             end do ! iEdges
-!$acc end parallel
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
+
+#ifdef MPAS_OPENACC
+            !$acc end parallel
+#endif
 
          endif ! splitImplicitStep
 
+#ifdef MPAS_OPENACC
+         !$acc exit data copyout(layerThicknessNew)
+         !$acc exit data copyout(normalVelocityNew)
+         !$acc exit data delete(normalBarotropicVelocityNew, &
+         !$acc                  normalBaroclinicVelocityNew)
+         !$acc exit data copyout(activeTracersNew)
+         !$acc update host(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness) then
+            !$acc exit data copyout(lowFreqDivergenceNew)
+            !$acc exit data delete(lowFreqDivergenceCur)
+            !$acc exit data delete(lowFreqDivergenceTend)
+         endif
+         if (splitImplicitStep < numTSIterations) then
+            if (config_use_gm) then
+               !$acc update host(vertGMBolusVelocityTop)
+            end if
+            if (config_submesoscale_enable) then
+               !$acc update host(vertMLEBolusVelocityTop)
+            end if
+            !$acc exit data delete (atmosphericPressure, seaIcePressure)
+            !$acc exit data copyout(sshNew)
+            !$acc update host(layerThickEdgeMean)
+            !$acc update host(relativeVorticity, circulation)
+            !$acc update host(vertTransportVelocityTop, &
+            !$acc             relativeVorticityCell, &
+            !$acc             divergence, &
+            !$acc             kineticEnergyCell, &
+            !$acc             tangentialVelocity, &
+            !$acc             vertVelocityTop)
+            !$acc update host(normRelVortEdge, normPlanetVortEdge, &
+            !$acc             normalizedRelativeVorticityCell)
+            !$acc update host (surfacePressure)
+            !$acc update host(zMid, zTop)
+            !$acc update host(tracersSurfaceValue)
+            !$acc update host(normalVelocitySurfaceLayer)
+            !$acc update host(density, potentialDensity, displacedDensity)
+            !$acc update host(thermExpCoeff,  &
+            !$acc&            salineContractCoeff)
+            !$acc update host(montgomeryPotential, pressure)
+            if (landIcePressureOn) then
+               !$acc exit data delete(landIcePressure)
+               !$acc exit data delete(landIceDraft)
+            endif
+            if (config_use_freq_filtered_thickness) then
+               !$acc exit data copyout(highFreqThicknessNew)
+               !$acc exit data delete(highFreqThicknessCur)
+            endif
+            if ( associated(frazilSurfacePressure) ) then
+               !$acc exit data delete(frazilSurfacePressure)
+            endif
+         elseif (splitImplicitStep == numTSIterations) then
+            !$acc exit data delete(layerThicknessCur, layerThicknessTend)
+            !$acc exit data delete(normalBaroclinicVelocityCur)
+            if (config_compute_active_tracer_budgets) then
+               !$acc update host(activeTracerHorizontalAdvectionEdgeFlux)
+               !$acc update host(activeTracerHorizontalAdvectionTendency)
+               !$acc update host(activeTracerVerticalAdvectionTendency)
+               !$acc update host(activeTracerHorMixTendency)
+               !$acc update host(activeTracerSurfaceFluxTendency)
+               !$acc update host(temperatureShortWaveTendency)
+               !$acc update host(activeTracerNonLocalTendency)
+            endif
+         endif
+#endif
 
          call mpas_timer_stop('si loop fini')
          call mpas_timer_stop('si loop')
@@ -2365,12 +2688,78 @@ module ocn_time_integration_si
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.
-      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
+      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
+      !$acc enter data copyin(sshNew)
+      !$acc enter data copyin(activeTracersNew)
+      !$acc update device(tracersSurfaceValue)
+      if ( associated(frazilSurfacePressure) ) then
+         !$acc enter data copyin(frazilSurfacePressure)
+      endif
+      if (landIcePressureOn) then
+         !$acc enter data copyin(landIcePressure)
+         !$acc enter data copyin(landIceDraft)
+      endif
+#endif
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-      call ocn_vmix_implicit_gpu(dt, meshPool, statePool, forcingPool, &
+#ifdef MPAS_OPENACC
+      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
+      !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host (vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host (vertMLEBolusVelocityTop)
+      end if
+      !$acc update host(vertTransportVelocityTop, &
+      !$acc             relativeVorticityCell, &
+      !$acc             divergence, &
+      !$acc             kineticEnergyCell, &
+      !$acc             tangentialVelocity, &
+      !$acc             vertVelocityTop)
+      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
+      !$acc             normalizedRelativeVorticityCell)
+      !$acc update host (surfacePressure)
+      !$acc update host(zMid, zTop)
+      !$acc exit data copyout(sshNew)
+      !$acc exit data delete(activeTracersNew)
+      !$acc update host(tracersSurfaceValue)
+      !$acc update host(normalVelocitySurfaceLayer)
+      !$acc exit data delete (atmosphericPressure, seaIcePressure)
+      !$acc update host(density, potentialDensity, displacedDensity)
+      !$acc update host(thermExpCoeff,  &
+      !$acc&            salineContractCoeff)
+      !$acc update host(montgomeryPotential, pressure)
+      !$acc update host(RiTopOfCell, &
+      !$acc             BruntVaisalaFreqTop)
+      !$acc update host(tracersSurfaceLayerValue, &
+      !$acc             indexSurfaceLayerDepth, &
+      !$acc             normalVelocitySurfaceLayer, &
+      !$acc             sfcFlxAttCoeff, &
+      !$acc             surfaceFluxAttenuationCoefficientRunoff)
+      if ( associated(frazilSurfacePressure) ) then
+         !$acc exit data delete(frazilSurfacePressure)
+      endif
+      if (landIcePressureOn) then
+         !$acc exit data delete(landIcePressure)
+         !$acc exit data delete(landIceDraft)
+      endif
+      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
+#endif
+
+      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
 
       ! Update halo on u and tracers, which were just updated for
@@ -2388,8 +2777,6 @@ module ocn_time_integration_si
       call mpas_timer_stop('si vmix halos normalVelFld')
 
       if(config_enable_nonhydrostatic_mode) then
-!NV!        !!! NOT EXECUTING !!!
-            write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroNew, 2)
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroCur, 1)
             call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureNew, 2)
@@ -2416,8 +2803,6 @@ module ocn_time_integration_si
 
             ! Reset iAge to zero where mask == 0
             if (config_use_idealAgeTracers.and.trim(groupItr%memberName) == 'idealAgeTracers') then
-!NV!            !!! NOT EXECUTING !!!
-                write(*,*) "config_use_idealAgeTracers NOT EXECUTING"
                 call mpas_pool_get_array(tracersPool, &
                                          groupItr%memberName, &
                                          tracersGroupNew, 2)
@@ -2428,13 +2813,17 @@ module ocn_time_integration_si
                                          'idealAgeTracersIdealAgeMask', &
                                           tracerGroupIdealAgeMask)
 
+#ifndef MPAS_OPENACC
                 !$omp parallel
                 !$omp do schedule(runtime)
+#endif
                 do iCell = 1, nCellsOwned
                    tracersGroupNew(1,1,iCell) = tracerGroupIdealAgeMask(1,iCell)*tracersGroupNew(1,1,iCell)
                 end do ! cells
+#ifndef MPAS_OPENACC
                 !$omp end do
                 !$omp end parallel
+#endif
              endif
 
             ! Halo update on all tracer groups
@@ -2448,8 +2837,6 @@ module ocn_time_integration_si
       call mpas_timer_stop("si implicit vert mix")
 
       if ( configVertAdvMethod == vertAdvRemap ) then
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "configVertAdvMethod == vertAdvRemap NOT EXECUTING"
 
          call mpas_timer_start("vertical remap")
 
@@ -2468,44 +2855,87 @@ module ocn_time_integration_si
 
       call mpas_timer_start('si fini')
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
+      if (config_prescribe_velocity) then
+         !$acc enter data copyin(normalVelocityCur) 
+      endif
+      if (config_prescribe_thickness) then
+         !$acc enter data copyin(layerThicknessCur)
+      endif
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
+      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
+      !$acc enter data copyin(sshNew)
+      !$acc enter data copyin(activeTracersNew)
+      !$acc update device(tracersSurfaceValue)
+      if ( associated(frazilSurfacePressure) ) then
+         !$acc enter data copyin(frazilSurfacePressure)
+      endif
+      if (landIcePressureOn) then
+         !$acc enter data copyin(landIcePressure)
+         !$acc enter data copyin(landIceDraft)
+      endif
+#endif
 
       if (config_prescribe_velocity) then
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "config_prescribe_velocity NOT EXECUTING"
+#ifdef MPAS_OPENACC
+         !$acc parallel loop collapse(2) present(normalVelocityNew, normalVelocityCur)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
+#endif
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
          end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       end if
 
       if (config_prescribe_thickness) then
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "config_prescribe_thickness NOT EXECUTING"
+#ifdef MPAS_OPENACC
+         !$acc parallel loop collapse(2) present(layerThicknessNew, layerThicknessCur)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
+#endif
          do iCell = 1, nCellsAll
          do k=1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       end if
 
-      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice
-      call ocn_effective_density_in_land_ice_update_gpu(forcingPool, &
+      call ocn_effective_density_in_land_ice_update(forcingPool, &
                                                     statePool, err)
 
-      call mpas_timer_start('si final mpas reconstruct gpu', .false.)
+      call mpas_timer_start('si final mpas reconstruct', .false.)
+
+#ifdef MPAS_OPENACC
+      !$acc enter data create(velocityX, velocityY, velocityZ)
+      !$acc enter data create(velocityZonal, velocityMeridional)
+      !$acc enter data create(gradSSHX, gradSSHY, gradSSHZ)
+      !$acc enter data create(gradSSHZonal, gradSSHMeridional)
+      !$acc enter data create(surfaceVelocity, SSHGradient)
+#endif
 
       call mpas_reconstruct_gpu(meshPool, normalVelocityNew,       &
                                 velocityX, velocityY, velocityZ,   &
@@ -2517,12 +2947,16 @@ module ocn_time_integration_si
                                 gradSSHZonal, gradSSHMeridional, &
                                 includeHalos = .true.)
 
-      call mpas_timer_stop('si final mpas reconstruct gpu')
+      call mpas_timer_stop('si final mpas reconstruct')
 
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop present(surfaceVelocity, velocityZonal, velocityMeridional, &
+      !$acc   SSHGradient, gradSSHZonal, gradSSHMeridional)
+#else
       !$omp parallel
       !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
+#endif
       do iCell = 1, nCellsAll
          surfaceVelocity(indexSurfaceVelocityZonal,iCell) = &
                                    velocityZonal(minLevelCell(iCell),iCell)
@@ -2533,19 +2967,73 @@ module ocn_time_integration_si
          SSHGradient(indexSSHGradientMeridional,iCell) = &
                                                gradSSHMeridional(iCell)
       end do
-!$acc end parallel
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
-      call ocn_time_average_coupled_accumulate_gpu(statePool,forcingPool,2)
+#ifdef MPAS_OPENACC
+      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
+      !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host(vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host(vertMLEBolusVelocityTop)
+      end if
+      !$acc update host(vertTransportVelocityTop, &
+      !$acc             relativeVorticityCell, &
+      !$acc             divergence, &
+      !$acc             kineticEnergyCell, &
+      !$acc             tangentialVelocity, &
+      !$acc             vertVelocityTop)
+      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
+      !$acc             normalizedRelativeVorticityCell)
+      !$acc update host (surfacePressure)
+      !$acc update host(zMid, zTop)
+      !$acc exit data copyout(sshNew)
+      !$acc exit data delete(activeTracersNew)
+      !$acc update host(tracersSurfaceValue)
+      !$acc update host(normalVelocitySurfaceLayer)
+      !$acc exit data delete (atmosphericPressure, seaIcePressure)
+      if ( associated(frazilSurfacePressure) ) then
+         !$acc exit data delete(frazilSurfacePressure)
+      endif
+      if (landIcePressureOn) then
+         !$acc exit data delete(landIcePressure)
+         !$acc exit data delete(landIceDraft)
+      endif
+      !$acc exit data copyout(layerThicknessNew, normalVelocityNew)
+      !$acc update host(density, potentialDensity, displacedDensity)
+      !$acc update host(thermExpCoeff,  &
+      !$acc&            salineContractCoeff)
+      !$acc update host(montgomeryPotential, pressure)
+      !$acc update host(RiTopOfCell, &
+      !$acc             BruntVaisalaFreqTop)
+      !$acc update host(tracersSurfaceLayerValue, &
+      !$acc             indexSurfaceLayerDepth, &
+      !$acc             normalVelocitySurfaceLayer, &
+      !$acc             sfcFlxAttCoeff, &
+      !$acc             surfaceFluxAttenuationCoefficientRunoff)
+      if (config_prescribe_velocity) then
+         !$acc exit data delete(normalVelocityCur)
+      endif
+      if (config_prescribe_thickness) then
+         !$acc exit data delete(layerThicknessCur)
+      endif
+      !$acc exit data copyout(velocityX, velocityY, velocityZ)
+      !$acc exit data copyout(gradSSHX, gradSSHY, gradSSHZ)
+      !$acc exit data copyout(velocityZonal, velocityMeridional)
+      !$acc exit data copyout(gradSSHZonal, gradSSHMeridional)
+      !$acc exit data copyout(surfaceVelocity, SSHGradient)
+#endif
+      call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
 
       if (config_use_GM .or. config_submesoscale_enable) then
-         call ocn_reconstruct_eddy_vectors_gpu(meshPool)
+         call ocn_reconstruct_eddy_vectors(meshPool)
       end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
          call mpas_timer_start("si effective density halo")
          call mpas_pool_get_field(statePool, &
                                  'effectiveDensityInLandIce', &
@@ -2557,8 +3045,6 @@ module ocn_time_integration_si
 
       call mpas_timer_stop('si fini')
       call mpas_timer_stop("si timestep")
-
-!!!$acc update host(pressure,thermExpCoeff,salineContractCoeff,zMid,density,potentialDensity)
 
    end subroutine ocn_time_integrator_si
 
@@ -2642,9 +3128,6 @@ module ocn_time_integration_si
       'MPAS was not compiled with LAPACK/BLAS. LAPACK required for SI' &
       , MPAS_LOG_CRIT)
 #endif
-#ifdef USE_CUBLAS
-       istat = cublasCreate(h)
-#endif
 
       !*** Set mask for using velocity correction
       if (config_vel_correction) then
@@ -2697,31 +3180,29 @@ module ocn_time_integration_si
       call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', &
                                                         nEdgesArray)
 
-      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
+      call mpas_pool_get_array(statePool, 'layerThickness', &
                                            layerThickness, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
                                            normalVelocity, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocity, 1)
-      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocity, 1)
 
-      call mpas_pool_get_array_gpu(meshPool, 'refBottomDepth', &
+      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
                                           refBottomDepth)
-      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', &
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', &
                                           cellsOnEdge)
-      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', &
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
                                           minLevelEdgeBot)
-      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', &
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
                                           maxLevelEdgeTop)
-      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array_gpu(meshPool, 'bottomDepth', bottomDepth)
-      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
-      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, 2)
-!$acc update host(layerThickness,normalVelocity,normalBarotropicVelocity,normalBaroclinicVelocity,&
-!$acc             refBottomDepth,cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,minLevelCell,maxLevelCell,bottomDepth,areaCell,ssh)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
 
       nCells = nCellsArray(config_num_halos)
       nEdges = nEdgesArray(config_num_halos+1)
@@ -2831,6 +3312,7 @@ module ocn_time_integration_si
          tolerance_inner  = config_btr_si_tolerance * area_mean
       endif
 
+
       ! Detection of ISMF (Temporariliy implemented. 
       !                    This will be revised in next SI version)
       ! If ISMF is detected, the split-implicit barotropic mode solver
@@ -2908,7 +3390,6 @@ module ocn_time_integration_si
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta
 
-!$acc update device(normalBarotropicVelocity,normalBaroclinicVelocity,normalVelocity,zTop,ssh)
    end subroutine ocn_time_integration_si_init
 
 !***********************************************************************
@@ -2972,8 +3453,7 @@ module ocn_time_integration_si
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_array_gpu(meshPool, 'indexToCellID', globalCellId)
-!$acc update host(globalCellId)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', globalCellId)
 
       nCells   = nCellsOwned
       nEdges   = nEdgesOwned
@@ -3021,7 +3501,6 @@ module ocn_time_integration_si
       ! Restricted Additive Schwarz preconditioner --------------------!
       if ( trim(config_btr_si_preconditioner) == 'ras' ) then
 
-         write(*,*) "Generating ras preconditioner NOT EXECUTING"
          nPrecVec = nCellsHalo2nd ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
                                   ! Packed size of preconditiong matrix
@@ -3081,12 +3560,10 @@ module ocn_time_integration_si
 #endif
          prec_ivmat(:) = -prec_ivmat(:)
 
-!$acc update device(prec_ivmat)
          ! Block-Jacobi preconditioner --------------------------------!
       elseif ( trim(config_btr_si_preconditioner) == &
                                         'block_jacobi' ) then
 
-         write(*,*) "Generating block_jacobi preconditioner NOT EXECUTING"
          nPrecVec = nCells        ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
                                   ! Packed size of preconditiong matrix
@@ -3145,7 +3622,6 @@ module ocn_time_integration_si
 #endif
          prec_ivmat(:) = -prec_ivmat(:)
 
-!$acc update device(prec_ivmat)
       ! Jacobi preconditioner -----------------------------------------!
       else if ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
 
@@ -3185,20 +3661,16 @@ module ocn_time_integration_si
 
          end do ! iCell
 
-!$acc update device(prec_ivmat)
       ! No preconditioner ---------------------------------------------!
       else if ( trim(config_btr_si_preconditioner) == 'none' ) then
 
-         write(*,*) "Not generating any preconditioner NOT EXECUTING"
          nPrecVec = nCells ! length of preconditioning vector
 
          allocate(prec_ivmat(1))
          prec_ivmat(:) = 1.0_RKIND
 
-!$acc update device(prec_ivmat)
       else
 
-         write(*,*) "Generating else NOT EXECUTING"
          call mpas_log_write( &
          'Incorrect choice for config_btr_si_preconditioner: ' &
          // trim(config_btr_si_preconditioner) //              &
@@ -3206,8 +3678,6 @@ module ocn_time_integration_si
          MPAS_LOG_CRIT)
 
       endif ! config_btr_si_preconditioner
-
-!$acc update device(prec_ivmat)
 
    end subroutine ocn_time_integrator_si_preconditioner 
 
@@ -3240,10 +3710,12 @@ module ocn_time_integration_si
 
       integer :: iEdge, cell1, cell2, i, iCell
  
+#ifndef MPAS_OPENACC
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdge, &
       !$omp         thicknessSum,sshDiff,fluxAx,sshArea )
+#endif
       do iCell = 1, nPrecVec
          sshTendAx = 0.0_RKIND
 
@@ -3279,77 +3751,12 @@ module ocn_time_integration_si
          SIvec_out(iCell) = -sshArea - sshTendAx
 
       end do ! iCell
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
       
    end subroutine si_matvec_mul
-
-   subroutine si_matvec_mul_gpu(SIvec_in,bottomDepthEdge,SIvec_out,ssh) 
-
-      real(kind=RKIND),dimension(:),intent(in)  :: &
-          SIvec_in,      &! Input SI vector
-          ssh,           &! Intermediate ssh
-          bottomDepthEdge ! Bottom Depth at Edge
-
-      real(kind=RKIND),dimension(:),intent(out) :: &
-          SIvec_out  ! Output SI vector
-
-      real(kind=RKIND) :: sshTendAx, sshEdge, thicknessSum, sshDiff
-      real(kind=RKIND) :: fluxAx, sshArea
-
-      integer :: iEdge, cell1, cell2, i, iCell
-
-!$acc data present(nEdgesOnCell,edgesOnCell,maxLevelEdgeTop,cellsOnEdge,dcEdge,edgeSignOnCell,dvEdge,areaCell,&
-!$acc              ssh,bottomDepthEdge,SIvec_in,SIvec_out) 
-      !$omp parallel
-      !$omp do schedule(runtime) &
-      !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdge, &
-      !$omp         thicknessSum,sshDiff,fluxAx,sshArea )
-!$acc parallel
-!$acc loop gang vector private(sshTendAx,iEdge,cell1,cell2,sshEdge,thicknessSum,sshDiff,fluxAx,sshArea)
-      do iCell = 1, nPrecVec
-         sshTendAx = 0.0_RKIND
-!$acc loop seq
-         do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-!NV!            if (maxLevelEdgeTop(iEdge).eq.0) cycle
-            if (maxLevelEdgeTop(iEdge).ne.0) then
-
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-
-            ! Interpolation sshEdge
-            sshEdge = 0.5_RKIND * (  ssh(cell1)   &
-                                   + ssh(cell2) )
-
-            ! method 1, matches method 0 without pbcs,
-            ! works with pbcs.
-            thicknessSum = si_ismf * sshEdge    &
-                         + bottomDepthEdge(iEdge)
-
-            ! nabla (ssh^0)
-            sshDiff = (SIvec_in(cell2)-SIvec_in(cell1)) &
-                    / dcEdge(iEdge)
-
-            fluxAx = thicknessSum * sshDiff
-
-            sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                      * fluxAx * dvEdge(iEdge)
-            endif
-         end do ! i
-
-         sshArea = R1_alpha1s_g_dts * SIvec_in(iCell) &
-                    * areaCell(iCell)
-
-         SIvec_out(iCell) = -sshArea - sshTendAx
-
-      end do ! iCell
-!$acc end parallel
-      !$omp end do
-      !$omp end parallel
-!$acc end data
-      
-   end subroutine si_matvec_mul_gpu
 
 !***********************************************************************
 !
@@ -3403,86 +3810,6 @@ module ocn_time_integration_si
       end if
    end subroutine si_precond 
 
-   subroutine si_precond_gpu(SIvec_in,SIvec_out)
-
-      real(kind=RKIND), dimension(:), intent(in)  :: SIvec_in
-                                        ! Input SI vector
-
-      real(kind=RKIND), dimension(:), intent(out) :: SIvec_out
-                                        ! SI vector to be preconditioned
-      integer :: i
-
-!$acc data present(prec_ivmat,SIvec_in,SIvec_out)
-
-      ! Preconditioning --------------------------------------------!
-      if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-         write(*,*) "config_btr_si_preconditioner ras NOT EXECUTING"
-         ! RAS preconditioning: Use BLAS for the symmetric 
-         !                      matrix-vector multiplication
-!NV!#ifdef USE_LAPACK
-!NV!      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-!NV!                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-!NV!                 SIvec_out(1:nPrecVec), 1)
-!NV!#endif
-
-#ifdef USE_CUBLAS
-!$acc host_data use_device(prec_ivmat,SIvec_in,SIvec_out)
-         call cublasDspmv('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-                          SIvec_out(1:nPrecVec), 1)
-!$acc end host_data
-#else
-#ifdef USE_LAPACK
-      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-                 SIvec_out(1:nPrecVec), 1)
-#endif
-#endif
-      elseif ( trim(config_btr_si_preconditioner) == &
-                                        'block_jacobi' ) then
-      write(*,*) "config_btr_si_preconditioner block_jacobi NOT EXECUTING"
-         ! Block-Jacobi preconditioning: Use BLAS for the symmetric 
-         !                               matrix-vector multiplication
-!NV!#ifdef USE_LAPACK
-!NV!      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-!NV!                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-!NV!                 SIvec_out(1:nPrecVec), 1)
-!NV!#endif
-
-#ifdef USE_CUBLAS
-!$acc host_data use_device(prec_ivmat,SIvec_in,SIvec_out)
-          call cublasDspmv('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-                          SIvec_out(1:nPrecVec), 1)
-!$acc end host_data
-#else
-#ifdef USE_LAPACK
-      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
-                 SIvec_out(1:nPrecVec), 1)
-#endif
-#endif
-      elseif ( trim(config_btr_si_preconditioner) == &
-                                              'jacobi' ) then
-!NV!         write(*,*) "config_btr_si_preconditioner block NOT EXECUTING"
-         ! Jacobi preconditioning
-!$acc parallel
-!$acc loop gang vector
-         do i = 1, nPrecVec
-             SIvec_out(i) = SIvec_in(i) &
-                                   * prec_ivmat(i)
-         enddo
-!$acc end parallel
-      elseif ( trim(config_btr_si_preconditioner) == &
-                                                'none' ) then
-         write(*,*) "config_btr_si_preconditioner none NOT EXECUTING"
-         ! No preconditioning
-         SIvec_out(1:nPrecVec) = SIvec_in(1:nPrecVec)
-      end if
-
-!$acc end data
-   end subroutine si_precond_gpu 
-
 !***********************************************************************
 !
 !  routine si_global_reduction
@@ -3533,8 +3860,10 @@ module ocn_time_integration_si
    
          if ( config_btr_si_partition_match_mode ) then
     
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
+#endif
             ! Reproducible sum of multiple fields over products
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r0
@@ -3543,8 +3872,10 @@ module ocn_time_integration_si
                reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
         
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3577,8 +3908,10 @@ module ocn_time_integration_si
          if ( config_btr_si_partition_match_mode ) then
    
             ! Reproducible sum of multiple fields over products
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
+#endif
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r1
                reprodSum1(iCell,2) = SIvec_2(iCell) !w1
@@ -3588,8 +3921,10 @@ module ocn_time_integration_si
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
                reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
       
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3630,8 +3965,10 @@ module ocn_time_integration_si
 
             ! Reproducible sum of multiple fields over products
  
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
+#endif
             do iCell = 1,nCellsOwned
                globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -3639,8 +3976,10 @@ module ocn_time_integration_si
                globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
                globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             SIcst_allreduce_global2(:) =                   &
                mpas_global_sum_nfld(globalReprodSum2fld1, &
@@ -3675,8 +4014,10 @@ module ocn_time_integration_si
  
             ! Reproducible sum of multiple fields over products
              
+#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
+#endif
             do iCell = 1,nCellsOwned
                globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -3698,8 +4039,10 @@ module ocn_time_integration_si
                globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
                globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
     
             SIcst_allreduce_global9(:) =                   &
                mpas_global_sum_nfld(globalReprodSum9fld1, &
@@ -3770,311 +4113,6 @@ module ocn_time_integration_si
    
    end subroutine si_global_reduction 
 
-   subroutine si_global_reduction_gpu(localProd,globalProd,       & 
-                             reprodSum1,reprodSum2,           &
-                             si_algorithm,nfld,domain,        &
-                             SIvec_1,SIvec_2,SIvec_3,SIvec_4, &
-                             SIvec_5,SIvec_6,SIvec_7,SIvec_8)  
-
-      type (domain_type), intent(in) :: &
-         domain  !< [inout] model state to advance forward
-
-      real(kind=RKIND), dimension(:), intent(in) :: &
-         SIvec_1,SIvec_2 ! SI vectors
-      real(kind=RKIND), dimension(:), intent(in), optional :: &
-         SIvec_3,SIvec_4,SIvec_5,SIvec_6,SIvec_7,SIvec_8 ! SI vectors
-
-      character(*), intent(in) :: si_algorithm ! Solver algorithm
-
-      integer, intent(in) :: nfld ! Number of reductions
-
-      real(kind=RKIND), dimension(:,:), intent(out) :: &
-         reprodSum1,reprodSum2 ! Array for reprod. global summation
-
-      real(kind=RKIND), dimension(:), intent(out) :: &
-         localProd,globalProd ! Array for global summation
-
-      real(kind=RKIND) :: &
-         SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0,SIcst_r00r0,SIcst_r00w0, &
-         SIcst_r00s0,SIcst_r00z0,SIcst_q0y0,SIcst_y0y0,SIcst_r00q0,  &
-         SIcst_r00y0,SIcst_r00t0,SIcst_r00v0,SIcst_q0q0
-
-      real(kind=RKIND) :: &
-         tmp2(2), tmp3(3) 
-
-      integer :: iCell
-
-      if ( si_algorithm == 'scg' .and. nfld == 2 ) then !!!
-   
-         if ( config_btr_si_partition_match_mode ) then
-!NV!        !!! NOT EXECUTING !!!
-            write(*,*) "config_btr_si_partition_match_mode NOT EXECUTING"    
-            !$omp parallel
-            !$omp do schedule(runtime)
-            ! Reproducible sum of multiple fields over products
-            do iCell = 1,nCellsOwned
-               reprodSum1(iCell,1) = SIvec_1(iCell) !r0
-               reprodSum1(iCell,2) = SIvec_2(iCell) !w0
-    
-               reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
-               reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
-            end do
-            !$omp end do
-            !$omp end parallel
-        
-            globalProd(:) = 0.0_RKIND
-            globalProd(:) =                   &
-               mpas_global_sum_nfld(reprodSum1, &
-                                    reprodSum2, &
-                                    domain%dminfo%comm)
-         else
-
-!NV!        !!! EXECUTING !!!
-
-!$acc data present(SIvec_1,SIvec_2,SIvec_3,localProd,globalProd) create(tmp2)
-
-!$acc serial
-            SIcst_r0rh0 = 0.0_RKIND
-            SIcst_w0rh0 = 0.0_RKIND
-!$acc end serial
-
-!$acc parallel
-!$acc loop gang vector private(SIcst_r0rh0,SIcst_w0rh0) reduction(+:SIcst_r0rh0,SIcst_w0rh0)
-            do iCell = 1, nCellsOwned
-               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
-                                         * SIvec_3(iCell)
-               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
-                                         * SIvec_3(iCell)
-            end do ! iCell
-!$acc end parallel
-
-!$acc serial
-            localProd(1) = SIcst_r0rh0
-            localProd(2) = SIcst_w0rh0
-!$acc end serial
-    
-            ! Global sum across CPUs
-            call mpas_dmpar_sum_real_array_gpu(domain % dminfo, nfld,      &
-                                           localProd,  &
-                                           globalProd)
-
-!$acc end data
-         endif
-   
-      elseif ( si_algorithm == 'scg' .and. nfld == 3 ) then !!!
-         if ( config_btr_si_partition_match_mode ) then
-!NV!        !!! NOT EXECUTING !!!
-            write(*,*) "config_btr_si_partition_match_mode NOT EXECUTING"
-   
-            ! Reproducible sum of multiple fields over products
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1,nCellsOwned
-               reprodSum1(iCell,1) = SIvec_1(iCell) !r1
-               reprodSum1(iCell,2) = SIvec_2(iCell) !w1
-               reprodSum1(iCell,3) = SIvec_1(iCell) !r1
-      
-               reprodSum2(iCell,1) = SIvec_3(iCell) !rh1
-               reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
-               reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
-            end do
-            !$omp end do
-            !$omp end parallel
-      
-            globalProd(:) = 0.0_RKIND
-            globalProd(:) =                   &
-               mpas_global_sum_nfld(reprodSum1, &
-                                    reprodSum2, &
-                                    domain%dminfo%comm)
-         else
-   
-!NV!        !!! EXECUTING !!!
-
-!$acc data present(SIvec_1,SIvec_2,SIvec_3,localProd,globalProd)
-
-!$acc serial
-            SIcst_r0rh0 = 0.0_RKIND
-            SIcst_w0rh0 = 0.0_RKIND
-            SIcst_r0r0 = 0.0_RKIND
-!$acc end serial
-         
-!$acc parallel
-!$acc loop gang vector private(SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0) reduction(+:SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0)
-            do iCell = 1,nCellsOwned
-               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
-                                         * SIvec_3(iCell) ! s1
-         
-               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
-                                         * SIvec_3(iCell) ! z1
-   
-               SIcst_r0r0 = SIcst_r0r0  + SIvec_1(iCell) &
-                                         * SIvec_1(iCell) ! z1
-            end do
-!$acc end parallel
-      
-!$acc serial
-            localProd(1) = SIcst_r0rh0
-            localProd(2) = SIcst_w0rh0
-            localProd(3) = SIcst_r0r0
-!$acc end serial
-         
-            ! Global sum across CPUs
-            call mpas_dmpar_sum_real_array_gpu(domain % dminfo, nfld,      &
-                                           localProd,  &
-                                           globalProd)
-!$acc end data
-   
-         endif
-   
-      elseif ( si_algorithm == 'sbicg' .and. nfld == 2 ) then !!!
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "si_algorithm == 'sbicg' .and. nfld == 2 NOT EXECUTING"
-         if ( config_btr_si_partition_match_mode ) then
-
-            ! Reproducible sum of multiple fields over products
- 
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1,nCellsOwned
-               globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
-               globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
-
-               globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
-               globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
-            end do
-            !$omp end do
-            !$omp end parallel
-
-            SIcst_allreduce_global2(:) =                   &
-               mpas_global_sum_nfld(globalReprodSum2fld1, &
-                                    globalReprodSum2fld2, &
-                                    domain%dminfo%comm)
-
-         else
-
-            SIcst_r00r0 = 0.0_RKIND
-            SIcst_r00w0 = 0.0_RKIND
-   
-            do iCell = 1, nCellsOwned
-               SIcst_r00r0 = SIcst_r00r0 + SIvec_1(iCell) &
-                                         * SIvec_2(iCell)
-               SIcst_r00w0 = SIcst_r00w0 + SIvec_1(iCell) &
-                                         * SIvec_3(iCell)
-            end do ! iCell
-   
-            SIcst_allreduce_local2(1) = SIcst_r00r0
-            SIcst_allreduce_local2(2) = SIcst_r00w0
-   
-            ! Global sum across CPUs
-            call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
-                                           SIcst_allreduce_local2,  &
-                                           SIcst_allreduce_global2)
-
-         endif
-
-      elseif ( si_algorithm == 'sbicg' .and. nfld == 9 ) then !!!
-!NV!     !!! NOT EXECUTING !!!
-         write(*,*) "si_algorithm == 'sbicg' .and. nfld == 9 NOT EXECUTING"
-
-         if ( config_btr_si_partition_match_mode ) then
- 
-            ! Reproducible sum of multiple fields over products
-             
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1,nCellsOwned
-               globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,3) = SIvec_2(iCell) !q0
-               globalReprodSum9fld1(iCell,4) = SIvec_3(iCell) !y0
-               globalReprodSum9fld1(iCell,5) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,6) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,7) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,8) = SIvec_1(iCell) !r00
-               globalReprodSum9fld1(iCell,9) = SIvec_2(iCell) !q0
-    
-               globalReprodSum9fld2(iCell,1) = SIvec_4(iCell) !s1
-               globalReprodSum9fld2(iCell,2) = SIvec_5(iCell) !z1
-               globalReprodSum9fld2(iCell,3) = SIvec_3(iCell) !y0
-               globalReprodSum9fld2(iCell,4) = SIvec_3(iCell) !y0
-               globalReprodSum9fld2(iCell,5) = SIvec_2(iCell) !q0
-               globalReprodSum9fld2(iCell,6) = SIvec_3(iCell) !y0
-               globalReprodSum9fld2(iCell,7) = SIvec_6(iCell) !t0
-               globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
-               globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
-            end do
-            !$omp end do
-            !$omp end parallel
-    
-            SIcst_allreduce_global9(:) =                   &
-               mpas_global_sum_nfld(globalReprodSum9fld1, &
-                                    globalReprodSum9fld2, &
-                                    domain%dminfo%comm)
-    
-         else
- 
-            SIcst_r00s0 = 0.0_RKIND
-            SIcst_r00z0 = 0.0_RKIND
-            SIcst_q0y0  = 0.0_RKIND
-            SIcst_y0y0  = 0.0_RKIND
-            SIcst_r00q0 = 0.0_RKIND
-            SIcst_r00y0 = 0.0_RKIND
-            SIcst_r00t0 = 0.0_RKIND
-            SIcst_r00v0 = 0.0_RKIND
-            SIcst_q0q0  = 0.0_RKIND
-       
-            do iCell = 1,nCellsOwned
-               SIcst_r00s0 = SIcst_r00s0 + SIvec_1(iCell) &
-                                         * SIvec_4(iCell) ! s1
-       
-               SIcst_r00z0 = SIcst_r00z0 + SIvec_1(iCell) &
-                                         * SIvec_5(iCell) ! z1
-       
-               SIcst_q0y0  = SIcst_q0y0  + SIvec_2(iCell)  &
-                                         * SIvec_3(iCell)
-       
-               SIcst_y0y0  = SIcst_y0y0  + SIvec_3(iCell)  &
-                                         * SIvec_3(iCell)
-       
-               SIcst_r00q0 = SIcst_r00q0 + SIvec_1(iCell) &
-                                         * SIvec_2(iCell)
-       
-               SIcst_r00y0 = SIcst_r00y0 + SIvec_1(iCell) &
-                                         * SIvec_3(iCell)
-       
-               SIcst_r00t0 = SIcst_r00t0 + SIvec_1(iCell) &
-                                         * SIvec_6(iCell)
-       
-               SIcst_r00v0 = SIcst_r00v0 + SIvec_1(iCell) &
-                                         * SIvec_7(iCell)
-       
-               SIcst_q0q0 = SIcst_q0q0   + SIvec_2(iCell) &
-                                         * SIvec_2(iCell)
-            end do
-    
-            SIcst_allreduce_local9(1) = SIcst_r00s0
-            SIcst_allreduce_local9(2) = SIcst_r00z0
-            SIcst_allreduce_local9(3) = SIcst_q0y0 
-            SIcst_allreduce_local9(4) = SIcst_y0y0 
-            SIcst_allreduce_local9(5) = SIcst_r00q0
-            SIcst_allreduce_local9(6) = SIcst_r00y0
-            SIcst_allreduce_local9(7) = SIcst_r00t0
-            SIcst_allreduce_local9(8) = SIcst_r00v0
-            SIcst_allreduce_local9(9) = SIcst_q0q0
-       
-            ! Global sum across CPUs
-            call mpas_timer_start("si reduction iter")
-            call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
-                                           SIcst_allreduce_local9,  &
-                                           SIcst_allreduce_global9)
-            call mpas_timer_stop("si reduction iter")
-    
-         endif
-
-      endif !!!
-   
-   end subroutine si_global_reduction_gpu 
-
 !***********************************************************************
 !
 !  routine si_solver_scg
@@ -4126,8 +4164,10 @@ module ocn_time_integration_si
 
          iter = iter + 1
 
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
+#endif
          do iCell = 1, nPrecVec
             SIvec_z1(iCell) = SIvec_rh0(iCell) &
                             + SIcst_beta0 * SIvec_z0(iCell)
@@ -4141,8 +4181,10 @@ module ocn_time_integration_si
             SIvec_r1(iCell) = SIvec_r0(iCell) &
                             - SIcst_alpha0 * SIvec_s1(iCell)
          end do ! iCell
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
   
          ! Preconditioning -----------------------------------------!
          call si_precond(SIvec_r1,SIvec_rh1)
@@ -4178,8 +4220,10 @@ module ocn_time_integration_si
                       /(SIcst_omega0 - SIcst_beta1*SIcst_gamma1 &
                                      / SIcst_alpha0 )
 
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
+#endif
          do iCell = 1,nPrecVec
             SIvec_r0(iCell)  = SIvec_r1(iCell)
             SIvec_s0(iCell)  = SIvec_s1(iCell)
@@ -4187,8 +4231,10 @@ module ocn_time_integration_si
             SIvec_z0(iCell)  = SIvec_z1(iCell)
             SIvec_rh0(iCell) = SIvec_rh1(iCell)
          end do ! iCell
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
 
          SIcst_beta0  = SIcst_beta1
          SIcst_alpha0 = SIcst_alpha1
@@ -4214,144 +4260,6 @@ module ocn_time_integration_si
       !-------------------------------------------------------------!
      
    end subroutine si_solver_scg 
-
-   subroutine si_solver_scg_gpu(domain,sshSolved,ssh,bottomDepthEdge, & 
-                            tolerance,SIcst_alpha0,SIcst_beta0,   &
-                            SIcst_gamma0)
-
-      type (domain_type), intent(inout) :: &
-         domain  !< [inout] model state to advance forward
-
-      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
-         ssh                                    ! Intermediate ssh
-
-      real(kind=RKIND), dimension(:), pointer, intent(inout) :: &
-         sshSolved                              ! ssh to be solved
-
-      real(kind=RKIND), dimension(:), intent(inout) :: &
-         bottomDepthEdge                        ! Bottome depth at Edge
-
-      real(kind=RKIND), intent(in) :: tolerance ! Tolerance of solver
-
-      real(kind=RKIND), intent(inout) :: &
-         SIcst_alpha0,SIcst_beta0,SIcst_gamma0  ! Initial reductions
-
-      real(kind=RKIND) :: &
-         SIcst_beta1,SIcst_alpha1,SIcst_gamma1,resid,SIcst_omega0, &
-         SIcst_r0rh0_global,SIcst_w0rh0_global
-
-      integer :: iter, iCell
-
-      iter = 0
-      resid = (tolerance+100.0)**2.0
-
-!$acc data present(SIvec_z1,SIvec_rh0,SIvec_z0,SIvec_s1,SIvec_w0,SIvec_s0,SIvec_r1,SIvec_r0,SIvec_rh1,SIvec_w1,&
-!$acc               sshSolved,bottomDepthEdge,ssh,SIcst_allreduce_local3,SIcst_allreduce_global3)
-
-      !-------------------------------------------------------------!
-      do while ( dsqrt(resid) > tolerance )
-      !-------------------------------------------------------------!
-
-         iter = iter + 1
-
-         !$omp parallel
-         !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
-         do iCell = 1, nPrecVec
-            SIvec_z1(iCell) = SIvec_rh0(iCell) &
-                            + SIcst_beta0 * SIvec_z0(iCell)
-
-            SIvec_s1(iCell) = SIvec_w0(iCell) &
-                            + SIcst_beta0 * SIvec_s0(iCell)
-
-            sshSolved(iCell) = sshSolved(iCell) &
-                            + SIcst_alpha0 * SIvec_z1(iCell)
-
-            SIvec_r1(iCell) = SIvec_r0(iCell) &
-                            - SIcst_alpha0 * SIvec_s1(iCell)
-         end do ! iCell
-!$acc end parallel
-         !$omp end do
-         !$omp end parallel
-  
-         ! Preconditioning -----------------------------------------!
-!NV!     ON CPU
-         call si_precond_gpu(SIvec_r1,SIvec_rh1)
-  
-         call mpas_timer_start("si halo iter")
-         call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh1')
-         call mpas_timer_stop("si halo iter")
-  
-  
-         ! SpMV ----------------------------------------------------!
-         call si_matvec_mul_gpu(SIvec_rh1,bottomDepthEdge,SIvec_w1,ssh)
-  
-         ! Reduction -----------------------------------------------!
-
-         call mpas_timer_start("si reduction iter")
-         call si_global_reduction_gpu(SIcst_allreduce_local3,&
-                             SIcst_allreduce_global3,    &
-                             globalReprodSum3fld1,       &
-                             globalReprodSum3fld2,       &
-                             si_algorithm,3,domain,      &
-                             SIvec_r1,SIvec_w1,SIvec_rh1)
-!$acc update host(SIcst_allreduce_local3,SIcst_allreduce_global3)
-         call mpas_timer_stop("si reduction iter")
- 
-         SIcst_r0rh0_global = SIcst_allreduce_global3(1) 
-         SIcst_w0rh0_global = SIcst_allreduce_global3(2)
-                      resid = SIcst_allreduce_global3(3)
-
-         ! Omega0
-         SIcst_gamma1 = SIcst_r0rh0_global
-         SIcst_omega0 = SIcst_w0rh0_global
-         SIcst_beta1  = SIcst_gamma1 / SIcst_gamma0
-         SIcst_alpha1 = SIcst_gamma1                            &
-                      /(SIcst_omega0 - SIcst_beta1*SIcst_gamma1 &
-                                     / SIcst_alpha0 )
-
-         !$omp parallel
-         !$omp do schedule(runtime)
-!$acc parallel
-!$acc loop gang vector
-         do iCell = 1,nPrecVec
-            SIvec_r0(iCell)  = SIvec_r1(iCell)
-            SIvec_s0(iCell)  = SIvec_s1(iCell)
-            SIvec_w0(iCell)  = SIvec_w1(iCell)
-            SIvec_z0(iCell)  = SIvec_z1(iCell)
-            SIvec_rh0(iCell) = SIvec_rh1(iCell)
-         end do ! iCell
-!$acc end parallel
-         !$omp end do
-         !$omp end parallel
-
-         SIcst_beta0  = SIcst_beta1
-         SIcst_alpha0 = SIcst_alpha1
-         SIcst_gamma0 = SIcst_gamma1
-
-         if ( iter > int(mean_num_cells*5) ) then
-            call mpas_log_write(&
-            '******************************************************')
-            call mpas_log_write(&
-            'Iteration number exceeds Max. #iteration: PROGRAM STOP')
-            call mpas_log_write(&
-            'Current #Iteration = $i ', intArgs=(/ iter /) )
-            call mpas_log_write(&
-            'Max.    #Iteration = $i ', &
-            intArgs=(/ int(mean_num_cells*5) /) )
-            call mpas_log_write(&
-            '******************************************************')
-            call mpas_log_write('',MPAS_LOG_CRIT)
-         endif
-
-      !-------------------------------------------------------------!
-      end do ! do iter
-      !-------------------------------------------------------------!i
-
-!$acc end data
-     
-   end subroutine si_solver_scg_gpu 
 
 !***********************************************************************
 !
@@ -4410,8 +4318,10 @@ module ocn_time_integration_si
  
          iter = iter + 1
  
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
+#endif
          do iCell = 1, nPrecVec
             SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                              * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -4438,8 +4348,10 @@ module ocn_time_integration_si
             SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                  * SIvec_z1(iCell)
          end do ! iCell
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
  
          ! Preconditioning -----------------------------------------!
  
@@ -4484,8 +4396,10 @@ module ocn_time_integration_si
                - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
  
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
+#endif
          do iCell = 1,nPrecVec
             sshSolved(iCell) = sshSolved(iCell)           &
                                   + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -4502,8 +4416,10 @@ module ocn_time_integration_si
                              * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                  * SIvec_v0(iCell))
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
  
          ! Preconditioning -----------------------------------------!
  
@@ -4532,8 +4448,10 @@ module ocn_time_integration_si
                                                      * SIcst_r00z0_global )
          SIcst_rho0 = SIcst_rho1
  
+#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime)
+#endif
          do iCell = 1,nPrecVec
            SIvec_r0(iCell) = SIvec_r1(iCell)
            SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -4547,8 +4465,10 @@ module ocn_time_integration_si
            SIvec_wh0(iCell) = SIvec_wh1(iCell)
            SIvec_zh0(iCell) = SIvec_zh1(iCell)
         end do ! iCell
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
         if ( iter > int(mean_num_cells*5) ) then
            call mpas_log_write(&

--- a/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -56,7 +56,9 @@ module ocn_time_integration_si
    use ocn_surface_land_ice_fluxes
    use ocn_transport_tests
 
-   use cublas
+#ifdef USE_CUBLAS
+    use cublas
+#endif
 
    implicit none
    private
@@ -135,7 +137,9 @@ module ocn_time_integration_si
       ncpus,            &! Total number of cores
       nSiLargeIter       ! #iteration for the barotropic system
    character(len=5) :: si_algorithm ! Name of the iterative solver algorithm
-   type(cublasHandle) :: h
+#ifdef USE_CUBLAS
+    type(cublasHandle) :: h
+#endif
    integer :: istat
 !$acc declare create(prec_ivmat,SIcst_allreduce_local2,SIcst_allreduce_global2,SIcst_allreduce_local3,SIcst_allreduce_global3,&
 !$acc                SIcst_allreduce_local9,SIcst_allreduce_global9,globalReprodSum2fld1,globalReprodSum2fld2,globalReprodSum3fld1,&
@@ -2638,7 +2642,9 @@ module ocn_time_integration_si
       'MPAS was not compiled with LAPACK/BLAS. LAPACK required for SI' &
       , MPAS_LOG_CRIT)
 #endif
-      istat = cublasCreate(h)
+#ifdef USE_CUBLAS
+       istat = cublasCreate(h)
+#endif
 
       !*** Set mask for using velocity correction
       if (config_vel_correction) then
@@ -3425,6 +3431,12 @@ module ocn_time_integration_si
                           SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
                           SIvec_out(1:nPrecVec), 1)
 !$acc end host_data
+#else
+#ifdef USE_LAPACK
+      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                 SIvec_out(1:nPrecVec), 1)
+#endif
 #endif
       elseif ( trim(config_btr_si_preconditioner) == &
                                         'block_jacobi' ) then
@@ -3443,6 +3455,12 @@ module ocn_time_integration_si
                           SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
                           SIvec_out(1:nPrecVec), 1)
 !$acc end host_data
+#else
+#ifdef USE_LAPACK
+      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                 SIvec_out(1:nPrecVec), 1)
+#endif
 #endif
       elseif ( trim(config_btr_si_preconditioner) == &
                                               'jacobi' ) then

--- a/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -196,6 +196,7 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp, &
          bottomDepthEdge
+!$acc declare create(uTemp,bottomDepthEdge,btrvel_temp)
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -337,42 +338,43 @@ module ocn_time_integration_split
 
       !*** Retrieve state variables at two time levels
       if(config_enable_nonhydrostatic_mode) then
+         write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
          call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroCur, 1)
          call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', vertVelocityNonhydroNew, 2)
          call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureNew, 2)
          call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureCur, 1)
       end if
 
-      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityCur, 1)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityCur, 1)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                            normalVelocityCur, 1)
 
-      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityNew, 2)
-      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                            normalBarotropicVelocityNew, 2)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                            normalVelocityNew, 2)
 
-      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-      call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', sshNew, 2)
 
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThicknessCur, 1)
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThicknessNew, 2)
 
-      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
                                            highFreqThicknessCur, 1)
-      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'highFreqThickness', &
                                            highFreqThicknessNew, 2)
 
-      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceCur, 1)
-      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+      call mpas_pool_get_array_gpu(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceNew, 2)
 
       call mpas_pool_get_dimension_scalar(tracersPool, 'index_salinity', &
@@ -382,44 +384,30 @@ module ocn_time_integration_split
 
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
-      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
-      call mpas_pool_get_array(tendPool, 'ssh', &
+      call mpas_pool_get_array_gpu(tendPool, 'ssh', &
                                           sshTend)
-      call mpas_pool_get_array(tendPool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(tendPool, 'layerThickness', &
                                           layerThicknessTend)
-      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', &
                                           normalVelocityTend)
       call mpas_pool_get_array(tendPool, 'highFreqThickness', &
                                           highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', &
                                           lowFreqDivergenceTend)
 
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracersNew, 2)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
       if (config_transport_tests_flow_id > 0) then
+        write(*,*) "config_transport_tests_flow_id NOT EXECUTING"
         ! This is a transport test. Write advection velocity from prescribed
         ! flow field.
         call ocn_transport_test_velocity(meshPool, daysSinceStartOfSim, &
           0.5*dt, normalVelocityCur)
       endif
-
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc   sshCur, layerThicknessCur, sshSubcycleCur, sshSubcycleNew)
-      !$acc enter data create(normalBaroClinicVelocityCur, normalVelocityNew, &
-      !$acc   normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
-      if (associated(highFreqThicknessNew)) then
-         !$acc enter data copyin(highFreqThicknessCur)
-         !$acc enter data create(highFreqThicknessNew)
-      endif
-      if (associated(lowFreqDivergenceNew)) then
-         !$acc enter data copyin(lowFreqDivergenceCur)
-         !$acc enter data create(lowFreqDivergenceNew)
-      endif
-#endif
 
       ! Initialize * variables that are used to compute baroclinic
       ! tendencies below.
@@ -434,19 +422,16 @@ module ocn_time_integration_split
       ! variable subtracts out the barotropic component from the
       ! baroclinic.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel present(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc    sshCur, layerThicknessCur, normalBaroClinicVelocityCur, &
-      !$acc    normalVelocityNew, normalBaroclinicVelocityNew, sshNew, &
-      !$acc    layerThicknessNew, minLevelCell, maxLevelCell)
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc loop collapse(2)
-#else
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              normalBaroclinicVelocityCur,normalVelocityCur,normalBarotropicVelocityCur,&
+!$acc              normalVelocityNew,normalBaroclinicVelocityNew,sshNew,sshCur,layerThicknessNew,&
+!$acc              layerThicknessCur,highFreqThicknessNew,highFreqThicknessCur,lowFreqDivergenceNew,&
+!$acc              lowFreqDivergenceCur)
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel vector_length(1024)
+!$acc loop gang vector collapse(2)
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
 
@@ -460,160 +445,111 @@ module ocn_time_integration_split
          normalBaroclinicVelocityCur(k,iEdge)
       end do
       end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc loop gang
-#else
       !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker 
       do iCell = 1, nCellsAll
          sshNew(iCell) = sshCur(iCell)
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
+!$acc loop vector
          do k = 1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc end parallel
-#else
+!$acc end parallel
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr))
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
                                      tracersGroupCur, 1)
-            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+            call mpas_pool_get_array_gpu(tracersPool, groupItr%memberName,&
                                      tracersGroupNew, 2)
 
             if ( associated(tracersGroupCur) .and. &
                  associated(tracersGroupNew) ) then
 
-#ifdef MPAS_OPENACC
-               !$acc enter data create(tracersGroupNew)
-               !$acc enter data copyin(tracersGroupCur)
-               !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
-               !$acc    tracersGroupNew, tracersGroupCur)
-#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iCell = 1, nCellsAll
+!$acc loop vector
                do k = minLevelCell(iCell), maxLevelCell(iCell)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                   do iTracer = 1,size(tracersGroupCur,1)
                      tracersGroupNew(iTracer,k,iCell) = &
                      tracersGroupCur(iTracer,k,iCell)
                   end do
                end do
                end do
-#ifdef MPAS_OPENACC
-               !$acc exit data copyout(tracersGroupNew)
-               !$acc exit data delete(tracersGroupCur)
-#else
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
             end if
          end if
       end do
 
       if (associated(highFreqThicknessNew)) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang &
-         !$acc    present(highFreqThicknessCur, highFreqThicknessNew)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
          do k = 1,nVertLevels
             highFreqThicknessNew(k,iCell) = &
             highFreqThicknessCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       if (associated(lowFreqDivergenceNew)) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang &
-         !$acc    present(lowFreqDivergenceCur, lowFreqDivergenceNew)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
          do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-         !$acc loop vector
-#endif
          do k = 1,nVertLevels
             lowFreqDivergenceNew(k,iCell) = &
             lowFreqDivergenceCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
          !$omp end do
          !$omp end parallel
-#endif
       endif
 
       if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCellsAll
             do k = 2, maxLevelCell(iCell)
                vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell)
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
+
+!$acc end data
 
       call mpas_timer_stop("se prep")
 
-      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
       if (landIcePressureOn) then 
-         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+!NV!     !!! WORKING !!!
+         call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
       endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
-      !$acc    sshCur, layerThicknessCur)
-      !$acc exit data copyout(normalBaroClinicVelocityCur, normalVelocityNew, &
-      !$acc    normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
-      if (associated(highFreqThicknessNew)) then
-         !$acc exit data delete(highFreqThicknessCur)
-         !$acc exit data copyout(highFreqThicknessNew)
-      endif
-      if (associated(lowFreqDivergenceNew)) then
-         !$acc exit data delete(lowFreqDivergenceCur)
-         !$acc exit data copyout(lowFreqDivergenceNew)
-      endif
-#endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! BEGIN large outer timestep iteration loop
@@ -632,20 +568,12 @@ module ocn_time_integration_split
 
          stage1_tend_time = min(splitExplicitStep,2)
 
-         call mpas_pool_get_array(statePool, 'normalVelocity', &
+         call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                            normalVelocityCur, stage1_tend_time)
-
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update device(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
-            !$acc enter data create(highFreqThicknessNew)
-            !$acc enter data copyin(highFreqThicknessCur, highFreqThicknessTend)
-         endif
-#endif
 
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
+!NV!        !!! WORKING !!!
             call mpas_timer_start("se halo diag obd")
             call mpas_dmpar_field_halo_exch(domain,'boundaryLayerDepth')
             call mpas_timer_stop("se halo diag obd")
@@ -657,6 +585,7 @@ module ocn_time_integration_split
          call mpas_dmpar_field_halo_exch(domain, &
                                  'normalizedRelativeVorticityEdge')
          if (config_mom_del4 > 0.0_RKIND) then
+!NV!        !!! WORKING !!!
             call mpas_dmpar_field_halo_exch(domain, 'divergence')
             call mpas_dmpar_field_halo_exch(domain, 'relativeVorticity')
          end if
@@ -668,6 +597,8 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          if (config_use_freq_filtered_thickness) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
 
             call mpas_timer_start("se freq-filtered-thick computations")
 
@@ -683,17 +614,9 @@ module ocn_time_integration_split
 
             call mpas_timer_stop("se freq-filtered-thick halo update")
 
-#ifdef MPAS_OPENACC
-            !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
-            !$acc    highFreqThicknessNew, highFreqThicknessCur, highFreqThicknessTend)
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
             do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h^{hf}_{n+1}
                highFreqThicknessNew(k,iCell) = &
@@ -701,10 +624,8 @@ module ocn_time_integration_split
                highFreqThicknessTend(k,iCell)
             end do
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
 
          endif ! freq filtered thickness
 
@@ -712,8 +633,8 @@ module ocn_time_integration_split
          call mpas_timer_start("se bcl vel")
          call mpas_timer_start('se bcl vel tend')
 
-         call mpas_pool_get_array(statePool, 'normalVelocity', &
-                           normalVelocityCur, stage1_tend_time)
+!NV!         call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+!NV!                           normalVelocityCur, stage1_tend_time)
          call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', &
                            vertVelocityNonhydroCur, stage1_tend_time)
 
@@ -722,31 +643,19 @@ module ocn_time_integration_split
          ! Use the most recent time level available.
 
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, &
                  sshCur, dt, vertAleTransportTop, &
                  err, highFreqThicknessNew)
-#ifdef MPAS_OPENACC
-            !$acc exit data delete(highFreqThicknessNew)
-#endif
          else
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, &
                  sshCur, dt, vertAleTransportTop, err)
          endif
 
-#ifdef MPAS_OPENACC
-         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update host(vertAleTransportTop)
-         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
-            !$acc exit data copyout(highFreqThicknessNew)
-            !$acc exit data delete(highFreqThicknessCur, highFreqThicknessTend)
-         endif
-#endif
-
-         call ocn_tend_vel(domain, tendPool, statePool, forcingPool, &
+         call ocn_tend_vel_gpu(domain, tendPool, statePool, forcingPool, &
                            stage1_tend_time, domain % dminfo, dt)
 
          call mpas_timer_stop('se bcl vel tend')
@@ -761,7 +670,7 @@ module ocn_time_integration_split
 
             ! Put f*normalBaroclinicVelocity^{perp} in
             ! normalVelocityNew as a work variable
-            call ocn_fuperp(statePool, meshPool, 2)
+            call ocn_fuperp_gpu(statePool, meshPool, 2)
 
             !TODO: look at loop optimizations here
             ! Only need to loop over owned cells, since there is a halo
@@ -769,19 +678,25 @@ module ocn_time_integration_split
 
             allocate(uTemp(nVertLevels,nEdgesOwned))
 
-#ifndef MPAS_OPENACC
+!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,dcEdge,nEdgesHalo,&
+!$acc              normalBaroclinicVelocityCur,normalVelocityTend,normalVelocityNew,sshNew,&
+!$acc              layerThickEdgeFlux,barotropicForcing,normalBaroclinicVelocityNew,uTemp,bottomDepthEdge)
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k, cell1, cell2, uTemp, &
             !$omp         normalThicknessFluxSum, thicknessSum)
-#endif
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,normalThicknessFluxSum,thicknessSum)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-               uTemp(:,iEdge) = 0.0_RKIND
+!$acc loop vector
+               do k = 1, nVertLevels
+                  uTemp(k,iEdge) = 0.0_RKIND
+               enddo
+!$acc loop vector
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-
                   ! normalBaroclinicVelocityNew =
                   ! normalBaroclinicVelocityOld +
                   !                dt*(-f*normalBaroclinicVelocityPerp
@@ -803,7 +718,7 @@ module ocn_time_integration_split
                normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
                                         uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-
+!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                  layerThickEdgeFlux(k,iEdge)*uTemp(k,iEdge)
@@ -812,7 +727,7 @@ module ocn_time_integration_split
                enddo
                barotropicForcing(iEdge) = splitFact* &
                               normalThicknessFluxSum/thicknessSum/dt
-
+!$acc loop vector
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
                   !{\bf u}'_{k,n+1} =
@@ -825,20 +740,21 @@ module ocn_time_integration_split
                          dt * barotropicForcing(iEdge))
 
                enddo
-
             enddo ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
 
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1, cell2, k, thicknessSum)
-#endif
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,thicknessSum)
             do iEdge = 1, nEdgesHalo(config_num_halos+1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+!$acc loop seq
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
@@ -846,10 +762,10 @@ module ocn_time_integration_split
                bottomDepthEdge(iEdge) = thicknessSum &
                   - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
+!$acc end data
 
             deallocate(uTemp)
 
@@ -883,6 +799,8 @@ module ocn_time_integration_split
 
          ! unsplit_explicit option
          if (unsplit) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "unsplit NOT EXECUTING"
 
             call mpas_timer_start('btr vel ue')
 
@@ -891,10 +809,8 @@ module ocn_time_integration_split
             !    normalBarotropicVelocitySubcycle=0, and
             !    uNew=normalBaroclinicVelocityNew
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
             do iEdge = 1, nEdgesAll
                normalBarotropicVelocityNew(iEdge) = 0.0_RKIND
                do k = 1, nVertLevels
@@ -908,31 +824,25 @@ module ocn_time_integration_split
 
                enddo ! vertical
             end do  ! iEdge
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
 
             !add GM and MLE (submesoscale) velocities if requested
             call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdgesAll, &
                                              nVertLevels)
             call ocn_MLE_add_to_transport_vel(normalTransportvelocity, nEdgesAll)
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k)
-#endif
             do iEdge=1, nEdgesAll
                do k = 1, nVertLevels
                   normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)* &
                                   normalTransportVelocity(k,iEdge)
                end do
             end do
-#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
-#endif
 
             call mpas_timer_stop('btr vel ue')
 
@@ -941,40 +851,39 @@ module ocn_time_integration_split
             ! Initialize variables for barotropic subcycling
             call mpas_timer_start('btr vel se init')
 
-            call mpas_pool_get_array(statePool, 'sshSubcycle', &
+            call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                      sshSubcycleCur, oldBtrSubcycleTime)
-            call mpas_pool_get_array(statePool, &
+            call mpas_pool_get_array_gpu(statePool, &
                                  'normalBarotropicVelocitySubcycle', &
                                   normalBarotropicVelocitySubcycleCur, &
                                   oldBtrSubcycleTime)
 
             if (config_filter_btr_mode) then
-#ifndef MPAS_OPENACC
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_filter_btr_mode NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime)
-#endif
                do iEdge = 1, nEdgesAll
                   barotropicForcing(iEdge) = 0.0_RKIND
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
             endif
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector 
             do iCell = 1, nCellsAll
                ! sshSubcycleOld = sshOld
                sshSubcycleCur(iCell) = sshCur(iCell)
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
 
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
             do iEdge = 1, nEdgesAll
 
                ! normalBarotropicVelocitySubcycleOld =
@@ -990,10 +899,9 @@ module ocn_time_integration_split
                ! barotropicThicknessFlux = 0
                barotropicThicknessFlux(iEdge) = 0.0_RKIND
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             call mpas_timer_stop('btr vel se init')
 
@@ -1004,7 +912,12 @@ module ocn_time_integration_split
             ! Allocate subcycled scratch fields before starting
             ! subcycle loop
             allocate(btrvel_temp(nEdgesAll+1))
-            btrvel_temp(:) = 0.0_RKIND
+!$acc parallel
+!$acc loop gang vector
+            do j = 1, nEdgesAll+1
+               btrvel_temp(j) = 0.0_RKIND
+            enddo
+!$acc end parallel
 
             cellHaloComputeCounter = 0
             edgeHaloComputeCounter = 0
@@ -1034,15 +947,15 @@ module ocn_time_integration_split
                if (config_btr_gam1_velWt1 > 1.0e-12_RKIND) then
                   uPerpTime = oldBtrSubcycleTime
 
-                  call mpas_pool_get_array(statePool, &
+                  call mpas_pool_get_array_gpu(statePool, &
                                  'normalBarotropicVelocitySubcycle', &
                                   normalBarotropicVelocitySubcycleCur, &
                                   uPerpTime)
-                  call mpas_pool_get_array(statePool, &
+                  call mpas_pool_get_array_gpu(statePool, &
                                  'normalBarotropicVelocitySubcycle', &
                                   normalBarotropicVelocitySubcycleNew, &
                                   newBtrSubcycleTime)
-                  call mpas_pool_get_array(statePool, 'sshSubcycle', &
+                  call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                   sshSubcycleCur, oldBtrSubcycleTime)
 
                   ! TODO: Modify this to eliminate pointer reassigning
@@ -1053,6 +966,8 @@ module ocn_time_integration_split
                   ! tidal potential terms are included in the grad
                   ! operator inside the edge loop.
                   if (config_use_tidal_potential_forcing) then
+!NV!                 !!! NOT EXECUTING !!!
+                     write(*,*) "config_use_tidal_potential_forcing NOT EXECUTING"
                      call mpas_pool_get_array(forcingPool, &
                                            'sshSubcycleCurWithTides', &
                                             sshSubcycleCurWithTides)
@@ -1060,10 +975,8 @@ module ocn_time_integration_split
                                              'tidalPotentialEta', &
                                               tidalPotentialEta)
 
-#ifndef MPAS_OPENACC
                      !$omp parallel
                      !$omp do schedule(runtime)
-#endif
                      do iCell = 1, nCellsAll
                         sshSubcycleCurWithTides(iCell) = &
                                  sshSubcycleCur(iCell) - &
@@ -1072,12 +985,10 @@ module ocn_time_integration_split
                            (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleCur(iCell)
                      end do
-#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
-#endif
 
-                     call mpas_pool_get_array(forcingPool, &
+                     call mpas_pool_get_array_gpu(forcingPool, &
                                           'sshSubcycleCurWithTides', &
                                            sshSubcycleCur)
 
@@ -1089,12 +1000,12 @@ module ocn_time_integration_split
                      nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
                   endif
 
-#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(i, cell1, cell2, eoe, CoriolisTerm, &
                   !$omp         temp_mask)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2,CoriolisTerm,eoe)
                   do iEdge = 1, nEdges
 
                      temp_mask = edgeMask(1, iEdge)
@@ -1104,6 +1015,7 @@ module ocn_time_integration_split
 
                      ! Compute the barotropic Coriolis term, -f*uPerp
                      CoriolisTerm = 0.0_RKIND
+!$acc loop seq
                      do i = 1, nEdgesOnEdge(iEdge)
                         eoe = edgesOnEdge(i,iEdge)
                         CoriolisTerm = CoriolisTerm + &
@@ -1121,10 +1033,9 @@ module ocn_time_integration_split
                                barotropicForcing(iEdge)))
 
                   end do ! edges
-#ifndef MPAS_OPENACC
+!$acc end parallel
                   !$omp end do
                   !$omp end parallel
-#endif
 
                endif ! config_btr_gam1_velWt1>1.0e-12
 
@@ -1136,17 +1047,17 @@ module ocn_time_integration_split
                ! Barotropic subcycle: SSH PREDICTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-               call mpas_pool_get_array(statePool, 'sshSubcycle', &
+               call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                                     sshSubcycleCur, &
                                                     oldBtrSubcycleTime)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', &
+               call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                                     sshSubcycleNew, &
                                                     newBtrSubcycleTime)
-               call mpas_pool_get_array(statePool, &
+               call mpas_pool_get_array_gpu(statePool, &
                              'normalBarotropicVelocitySubcycle', &
                               normalBarotropicVelocitySubcycleCur, &
                               oldBtrSubcycleTime)
-               call mpas_pool_get_array(statePool, &
+               call mpas_pool_get_array_gpu(statePool, &
                              'normalBarotropicVelocitySubcycle', &
                               normalBarotropicVelocitySubcycleNew, &
                               newBtrSubcycleTime)
@@ -1172,17 +1083,19 @@ module ocn_time_integration_split
                ! config_btr_gam1_velWt1=  0
                !    flux = normalBarotropicVelocityOld*H
 
-#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime) &
                !$omp private(i, iEdge, cell1, cell2, sshEdge, &
                !$omp         thicknessSum, flux)
-#endif
+!$acc parallel
+!$acc loop gang vector private(iEdge,cell1,cell2,sshEdge,thicknessSum,flux)
                do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
+!$acc loop seq
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
-                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
+!NV!                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
+                     if (maxLevelEdgeTop(iEdge).ne.0) then
 
                      cell1 = cellsOnEdge(1, iEdge)
                      cell2 = cellsOnEdge(2, iEdge)
@@ -1203,7 +1116,7 @@ module ocn_time_integration_split
                      sshTend(iCell) = sshTend(iCell) + &
                                       edgeSignOncell(i, iCell)*flux* &
                                       dvEdge(iEdge)
-
+                     endif
                   end do ! edges on cell
 
                   ! SSHnew = SSHold + dt/J*(-div(Flux))
@@ -1211,15 +1124,15 @@ module ocn_time_integration_split
                                         + dt/nBtrSubcycles* &
                                           sshTend(iCell)/areaCell(iCell)
                end do ! cells
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
 
                ! avoid redundant computations when
                ! config_btr_solve_SSH2 is true
                if (config_btr_solve_SSH2) then
-
+!NV!              !!! NOT EXECUTING !!!
+                  write(*,*) "config_btr_solve_SSH2 NOT EXECUTING"
                   ! If config_btr_solve_SSH2=.true.,
                   ! then do NOT accumulate barotropicThicknessFlux
                   ! in this SSH predictor section, because it will be
@@ -1229,14 +1142,14 @@ module ocn_time_integration_split
 
                   ! otherwise, DO accumulate barotropicThicknessFlux
                   ! in this SSH predictor section
-
-#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(cell1, cell2, sshEdge,thicknessSum,flux)
-#endif
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,sshEdge,thicknessSum,flux)
                   do iEdge = 1, nEdges
-                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
+!NV!                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
+                     if (maxLevelEdgeTop(iEdge).ne.0) then
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
 
@@ -1253,11 +1166,11 @@ module ocn_time_integration_split
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
+                     endif
                   end do ! edges
-#ifndef MPAS_OPENACC
+!$acc end parallel
                   !$omp end do
                   !$omp end parallel
-#endif
 
                endif
 
@@ -1271,18 +1184,18 @@ module ocn_time_integration_split
                do BtrCorIter = 1, config_n_btr_cor_iter
                   uPerpTime = newBtrSubcycleTime
 
-                  call mpas_pool_get_array(statePool, &
+                  call mpas_pool_get_array_gpu(statePool, &
                                  'normalBarotropicVelocitySubcycle', &
                                   normalBarotropicVelocitySubcycleCur, &
                                   oldBtrSubcycleTime)
-                  call mpas_pool_get_array(statePool, &
+                  call mpas_pool_get_array_gpu(statePool, &
                                  'normalBarotropicVelocitySubcycle', &
                                   normalBarotropicVelocitySubcycleNew, &
                                   newBtrSubcycleTime)
-                  call mpas_pool_get_array(statePool, 'sshSubcycle', &
+                  call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                                        sshSubcycleCur,&
                                                     oldBtrSubcycleTime)
-                  call mpas_pool_get_array(statePool, 'sshSubcycle', &
+                  call mpas_pool_get_array_gpu(statePool, 'sshSubcycle', &
                                                        sshSubcycleNew,&
                                                     newBtrSubcycleTime)
 
@@ -1294,6 +1207,8 @@ module ocn_time_integration_split
                   ! the work arrays so the tidal potential terms are
                   ! included in the grad operator inside the edge loop.
                   if (config_use_tidal_potential_forcing) then
+!NV!                 !!! NOT EXECUTING !!!
+                     write(*,*) "config_use_tidal_potential_forcing NOT EXECUTING"
                      call mpas_pool_get_array(forcingPool, &
                                            'sshSubcycleCurWithTides',  &
                                             sshSubcycleCurWithTides)
@@ -1304,10 +1219,8 @@ module ocn_time_integration_split
                                              'tidalPotentialEta',  &
                                               tidalPotentialEta)
 
-#ifndef MPAS_OPENACC
                      !$omp parallel
                      !$omp do schedule(runtime)
-#endif
                      do iCell = 1, nCellsAll
                         sshSubcycleCurWithTides(iCell) = &
                                  sshSubcycleCur(iCell) - &
@@ -1323,12 +1236,10 @@ module ocn_time_integration_split
                            (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleNew(iCell)
                      end do
-#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
-#endif
 
-                     call mpas_pool_get_array(forcingPool, &
+                     call mpas_pool_get_array_gpu(forcingPool, &
                                     'sshSubcycleCurWithTides',  &
                                      sshSubcycleCur)
                      call mpas_pool_get_array(forcingPool, &
@@ -1341,18 +1252,17 @@ module ocn_time_integration_split
                   nEdges = nEdgesHalo(min(edgeHaloComputeCounter, &
                                           config_num_halos))
 
-#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
                   do iEdge = 1, nEdges+1
                      btrvel_temp(iEdge) = &
                          normalBarotropicVelocitySubcycleNew(iEdge)
                   end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                   !$omp end do
                   !$omp end parallel
-#endif
 
                   if (edgeHaloComputeCounter <= 1) then
                      nEdges = nEdgesOwned
@@ -1360,12 +1270,12 @@ module ocn_time_integration_split
                      nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
                   endif
 
-#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(i, cell1, cell2, eoe, coriolisTerm, &
                   !$omp         sshCell1, sshCell2, temp_mask)
-#endif
+!$acc parallel
+!$acc loop gang vector private(temp_mask,cell1,cell2,CoriolisTerm,eoe,sshCell1,sshCell2)
                   do iEdge = 1, nEdges
 
                      temp_mask = edgeMask(1,iEdge)
@@ -1375,6 +1285,7 @@ module ocn_time_integration_split
 
                      ! Compute the barotropic Coriolis term, -f*uPerp
                      CoriolisTerm = 0.0_RKIND
+!$acc loop seq
                      do i = 1, nEdgesOnEdge(iEdge)
                         eoe = edgesOnEdge(i,iEdge)
                         CoriolisTerm = CoriolisTerm &
@@ -1406,10 +1317,9 @@ module ocn_time_integration_split
                            + barotropicForcing(iEdge)))
 
                   end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                   !$omp end do
                   !$omp end parallel
-#endif
 
                   edgeHaloComputeCounter = edgeHaloComputeCounter - 1
                   if (BtrCorIter >= 1 .or. &
@@ -1423,7 +1333,8 @@ module ocn_time_integration_split
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                if (config_btr_solve_SSH2) then
-
+!NV!              !!! NOT EXECUTING !!!
+                  write(*,*) "config_btr_solve_SSH2 NOT EXECUTING"
                   call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                        sshSubcycleCur,&
                                                     oldBtrSubcycleTime)
@@ -1461,12 +1372,10 @@ module ocn_time_integration_split
                   ! config_btr_gam3_velWt2=  0
                   !    flux = normalBarotropicVelocityOld*H
 
-#ifndef MPAS_OPENACC
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(i, iEdge, cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
-#endif
                   do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
@@ -1508,14 +1417,12 @@ module ocn_time_integration_split
                                         + dt/nBtrSubcycles * &
                                           sshTend(iCell)/areaCell(iCell)
                   end do ! cell loop for ssh
-#ifndef MPAS_OPENACC
                   !$omp end do
 
                   ! compute barotropic thickness flux on edges
                   !$omp do schedule(runtime) &
                   !$omp private(cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
-#endif
                   do iEdge = 1, nEdges
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
@@ -1543,10 +1450,8 @@ module ocn_time_integration_split
                      barotropicThicknessFlux(iEdge) + flux
 
                   end do ! edge barotropic thickness flux
-#ifndef MPAS_OPENACC
                   !$omp end do
                   !$omp end parallel
-#endif
 
                   edgeHaloComputeCounter = config_num_halos + 1
                endif ! config_btr_solve_SSH2
@@ -1556,7 +1461,7 @@ module ocn_time_integration_split
                !                      timestep pointers
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-               call mpas_pool_get_array(statePool, &
+               call mpas_pool_get_array_gpu(statePool, &
                                   'normalBarotropicVelocitySubcycle', &
                                    normalBarotropicVelocitySubcycleNew, &
                                    newBtrSubcycleTime)
@@ -1568,19 +1473,18 @@ module ocn_time_integration_split
                ! iteration is limited to one, this could
                ! be merged with the above code.
 
-#ifndef MPAS_OPENACC
                !$omp parallel
                !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector 
                do iEdge = 1, nEdgesAll
                   normalBarotropicVelocityNew(iEdge) = &
                   normalBarotropicVelocityNew(iEdge) + &
                   normalBarotropicVelocitySubcycleNew(iEdge)
                end do  ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
 
                ! advance time pointers
                oldBtrSubcycleTime = mod(oldBtrSubcycleTime,2)+1
@@ -1599,10 +1503,10 @@ module ocn_time_integration_split
             ! normalBarotropicVelocity, and F
             call mpas_timer_start('btr se norm')
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
             do iEdge = 1, nEdgesOwned
                barotropicThicknessFlux(iEdge) = &
                barotropicThicknessFlux(iEdge) &
@@ -1612,10 +1516,9 @@ module ocn_time_integration_split
                normalBarotropicVelocityNew(iEdge) &
                      / (nBtrSubcycles*config_btr_subcycle_loop_factor + 1)
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             call mpas_timer_stop('btr se norm')
 
@@ -1658,28 +1561,30 @@ module ocn_time_integration_split
             ! velocity for normalVelocityCorrection is
             ! normalBarotropicVelocity +
             ! normalBaroclinicVelocity + uBolus
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
             do iEdge = 1, nEdges
-               uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
-                            + normalBaroclinicVelocityNew(:,iEdge)
+               do k = 1, nVertLevels
+                  uTemp(k,iEdge) = normalBarotropicVelocityNew(iEdge) &
+                               + normalBaroclinicVelocityNew(k,iEdge)
+               enddo
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
-            call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
+            call ocn_GM_add_to_transport_vel_gpu(uTemp, nEdges, &
                                              nVertLevels)
-            call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
+!NV!        !!! NOT EXECUTING !!!
+            call ocn_MLE_add_to_transport_vel_gpu(uTemp, nEdges)
 
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
             do iEdge = 1, nEdges
                do k = 1, nVertLevels
                   normalTransportVelocity(k,iEdge) =  &
@@ -1687,21 +1592,21 @@ module ocn_time_integration_split
                              normalBaroclinicVelocityNew(k,iEdge)
                end do
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
-            call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, &
+
+            call ocn_GM_add_to_transport_vel_gpu(normalTransportVelocity, nEdges, &
                                              nVertLevels)
-            call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
+!NV!        !!! NOT EXECUTING !!!
+            call ocn_MLE_add_to_transport_vel_gpu(normalTransportVelocity, nEdges)
 
-
-#ifndef MPAS_OPENACC
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(k, normalThicknessFluxSum, &
             !$omp         thicknessSum, normalVelocityCorrection)
-#endif
+!$acc parallel
+!$acc loop gang worker private(normalThicknessFluxSum,thicknessSum,normalVelocityCorrection)
             do iEdge = 1, nEdges
 
                ! thicknessSum is initialized outside the loop because
@@ -1712,6 +1617,7 @@ module ocn_time_integration_split
                                         uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
+!$acc loop vector reduction(+:normalThicknessFluxSum,thicknessSum)
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                            layerThickEdgeFlux(k,iEdge)*&
@@ -1724,6 +1630,7 @@ module ocn_time_integration_split
                              ((barotropicThicknessFlux(iEdge) - &
                                normalThicknessFluxSum)/thicknessSum)
 
+!$acc loop vector
                do k = 1, nVertLevels
 
                   ! normalTransportVelocity = normalBarotropicVelocity
@@ -1739,10 +1646,9 @@ module ocn_time_integration_split
                enddo
 
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             deallocate(uTemp)
 
@@ -1775,35 +1681,21 @@ module ocn_time_integration_split
          ! layerThickEdgeFlux because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessCur, sshCur)
-         !$acc update device(layerThickEdgeFlux, normalTransportVelocity)
-#endif
          if (associated(highFreqThicknessNew)) then
-#ifdef MPAS_OPENACC
-            !$acc enter data copyin(highFreqThicknessNew)
-#endif
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, &
                  err, highFreqThicknessNew)
-#ifdef MPAS_OPENACC
-            !$acc exit data delete(highFreqThicknessNew)
-#endif
          else
-            call ocn_vert_transport_velocity_top( &
+            call ocn_vert_transport_velocity_top_gpu( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, err)
          endif
-#ifdef MPAS_OPENACC
-         !$acc exit data delete(layerThicknessCur, sshCur)
-         !$acc update host(vertAleTransportTop, normalTransportVelocity)
-#endif
          call mpas_timer_stop('thick vert trans vel top')
 
-         call ocn_tend_thick(tendPool, forcingPool)
+         call ocn_tend_thick_gpu(tendPool, forcingPool)
 
          call mpas_timer_stop('se thick tend')
 
@@ -1815,67 +1707,20 @@ module ocn_time_integration_split
          call mpas_timer_stop("se halo thickness")
 
          call mpas_timer_start('se tracer tend', .false.)
-         call ocn_tend_tracer(tendPool, statePool, forcingPool, &
+
+         call ocn_tend_tracer_gpu(tendPool, statePool, forcingPool, &
                               meshPool, swForcingPool, &
                               dt, activeTracersOnly, 2)
 
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupCur, 1)
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupNew, 2)
-         call mpas_pool_get_array(statePool,   'normalVelocity', &
+         call mpas_pool_get_array_gpu(statePool,   'normalVelocity', &
                                                 normalVelocityCur, 1)
-         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
+         call mpas_pool_get_array_gpu(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
 
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-         !$acc enter data copyin(normalBarotropicVelocityNew, &
-         !$acc                   normalBaroclinicVelocityNew)
-         !$acc enter data copyin(activeTracersNew)
-         !$acc update device(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness) then
-            !$acc enter data copyin(lowFreqDivergenceNew)
-            !$acc enter data copyin(lowFreqDivergenceCur)
-            !$acc enter data copyin(lowFreqDivergenceTend)
-         endif
-         if (splitExplicitStep < numTSIterations) then
-            !$acc update device (normalTransportVelocity)
-            !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-            !$acc enter data copyin(sshNew)
-            !$acc update device(tracersSurfaceValue)
-            if ( associated(normalGMBolusVelocity) ) then
-               !$acc update device (normalGMBolusVelocity)
-            end if
-            if ( associated(normalMLEVelocity) ) then
-               !$acc update device (normalMLEvelocity)
-            end if
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc enter data copyin(frazilSurfacePressure)
-            endif
-            if (landIcePressureOn) then
-               !$acc enter data copyin(landIcePressure)
-               !$acc enter data copyin(landIceDraft)
-            endif
-            if (config_use_freq_filtered_thickness) then
-               !$acc enter data copyin(highFreqThicknessNew)
-               !$acc enter data copyin(highFreqThicknessCur)
-            endif
-         elseif (splitExplicitStep == numTSIterations) then
-            !$acc enter data copyin(layerThicknessCur)
-            !$acc enter data copyin(layerThicknessTend)
-            !$acc enter data copyin(normalBaroclinicVelocityCur)
-            if (config_compute_active_tracer_budgets) then
-               !$acc update device(activeTracerHorizontalAdvectionEdgeFlux)
-               !$acc update device(activeTracerHorizontalAdvectionTendency)
-               !$acc update device(activeTracerVerticalAdvectionTendency)
-               !$acc update device(activeTracerHorMixTendency)
-               !$acc update device(activeTracerSurfaceFluxTendency)
-               !$acc update device(temperatureShortWaveTendency)
-               !$acc update device(activeTracerNonLocalTendency)
-            endif
-         endif
-#endif
 
          call mpas_timer_stop('se tracer tend')
 
@@ -1900,11 +1745,13 @@ module ocn_time_integration_split
                           forcingPool, meshPool, 2, dt)
 
          call mpas_timer_start('se loop fini')
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupCur, 1)
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+         call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
                                                 tracersGroupNew, 2)
          if(config_enable_nonhydrostatic_mode) then
+            write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', &
                                                 vertVelocityNonhydroCur, 1)
             call mpas_pool_get_array(statePool, 'vertVelocityNonhydro', &
@@ -1928,16 +1775,12 @@ module ocn_time_integration_split
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.
 
-!! Keeping this calc on the CPU for now
-#ifdef MPAS_OPENACC
-            !$acc update host(layerThicknessNew)
-            !$acc update host(activeTracersNew)
-            !$acc update host(tracersSurfaceValue)
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
-#endif
+!$acc parallel
+!$acc loop gang worker 
             do iCell = 1, nCellsAll
+!$acc loop vector private(temp_h,temp)
             do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                ! this is h_{n+1}
@@ -1947,7 +1790,6 @@ module ocn_time_integration_split
                ! this is h_{n+1/2}
                layerThicknessNew(k,iCell) = 0.5* &
                (layerThicknessCur(k,iCell) + temp_h)
-
                do i = startIndex, endIndex
                   ! This is Phi at n+1
                   temp = (tracersGroupCur(i,k,iCell)* &
@@ -1960,46 +1802,30 @@ module ocn_time_integration_split
                end do ! tracer index
             end do ! vertical
             end do ! iCell
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc update device(layerThicknessNew)
-            !$acc update device(activeTracersNew)
-#endif
 
             if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
+!NV!          !!! NOT EXECUTING !!!
+              write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
               !$omp parallel
               !$omp do schedule(runtime) private(k, temp_h)
-#endif
               do iCell = 1, nCells
                  do k = 2, maxLevelCell(iCell)
                     temp_h = vertVelocityNonhydroCur(k,iCell) + dt * vertVelocityNonhydroTend(k,iCell)
                     vertVelocityNonhydroNew(k,iCell) = 0.5_RKIND*(vertVelocityNonhydroCur(k,iCell) + temp_h)
                  end do
               end do
-#ifndef MPAS_OPENACC
               !$omp end do
               !$omp end parallel
-#endif
             end if
 
             if (config_use_freq_filtered_thickness) then
-
-#ifdef MPAS_OPENACC
-               !$acc parallel loop present(minLevelCell, maxLevelCell) &
-               !$acc   present(highFreqThicknessNew) &
-               !$acc   present(highFreqThicknessCur) &
-               !$acc   present(lowFreqDivergenceNew) &
-               !$acc   present(lowFreqDivergenceCur) &
-               !$acc   present(lowFreqDivergenceTend)
-#else
+!NV!          !!! NOT EXECUTING !!!
+              write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp)
-#endif
                do iCell = 1, nCellsAll
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
@@ -2019,20 +1845,14 @@ module ocn_time_integration_split
                            (lowFreqDivergenceCur(k,iCell) + temp)
                end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
             end if
 
-#ifdef MPAS_OPENACC
-            !$acc parallel loop collapse(2) present(normalVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityNew, edgeMask) &
-            !$acc   present(normalBarotropicVelocityNew)
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang vector collapse(2)
             do iEdge = 1, nEdgesAll
             do k = 1, nVertLevels
 
@@ -2045,15 +1865,14 @@ module ocn_time_integration_split
 
             enddo
             end do ! iEdge
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             ! Efficiency note: We really only need this to compute
             ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
-            call ocn_diagnostic_solve(dt, statePool, forcingPool, &
+            call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
 
@@ -2064,33 +1883,12 @@ module ocn_time_integration_split
 
          elseif (splitExplicitStep == numTSIterations) then
 
-#ifdef MPAS_OPENACC
-            !$acc parallel present(minLevelCell, maxLevelCell) &
-            !$acc   present(layerThicknessTend) &
-            !$acc   present(layerThicknessCur) &
-            !$acc   present(minLevelEdgeBot, maxLevelEdgeTop) &
-            !$acc   present(layerThickEdgeFlux) &
-            !$acc   present(activeTracerHorizontalAdvectionEdgeFlux) &
-            !$acc   present(layerThicknessNew) &
-            !$acc   present(activeTracerHorizontalAdvectionTendency) &
-            !$acc   present(activeTracerVerticalAdvectionTendency) &
-            !$acc   present(activeTracerHorMixTendency) &
-            !$acc   present(activeTracerSurfaceFluxTendency) &
-            !$acc   present(temperatureShortWaveTendency) &
-            !$acc   present(activeTracerNonLocalTendency)
-#endif
-
-
-#ifdef MPAS_OPENACC
-            !$acc loop gang
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
             do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
+!$acc loop vector
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h_{n+1}
                layerThicknessNew(k,iCell) = &
@@ -2098,43 +1896,33 @@ module ocn_time_integration_split
                                   dt*layerThicknessTend(k,iCell)
             end do
             end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
 
             if(config_enable_nonhydrostatic_mode) then
-#ifndef MPAS_OPENACC
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
                do iCell = 1, nCells
                   do k = 1, maxLevelCell(iCell)
                      vertVelocityNonhydroNew(k,iCell) = vertVelocityNonhydroCur(k,iCell) + dt * vertVelocityNonhydroTend(k,iCell)
                   end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
             end if
 
             if (config_compute_active_tracer_budgets) then
 
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iEdge = 1, nEdgesAll
-#ifdef MPAS_OPENACC
-               !$acc loop seq
-#endif
+!$acc loop vector
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                   do iTracer = 1, size(activeTracerHorizontalAdvectionEdgeFlux,1)
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
                      activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) / &
@@ -2142,84 +1930,47 @@ module ocn_time_integration_split
                   enddo
                enddo
                enddo
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
                !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                do iCell = 1, nCellsAll
+!$acc loop vector
                do k= minLevelCell(iCell), maxLevelCell(iCell)
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-                  do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
-                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
-                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
-                               layerThicknessNew(k,iCell)
-
-                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
-                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
-                               layerThicknessNew(k,iCell)
-
-                     activeTracerHorMixTendency(iTracer,k,iCell) = &
-                     activeTracerHorMixTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-
-                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
-                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-
-                     activeTracerNonLocalTendency(iTracer,k,iCell) = &
-                     activeTracerNonLocalTendency(iTracer,k,iCell) / &
-                                layerThicknessNew(k,iCell)
-                  end do
-#else
-                  activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
-                  activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
+               do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
+                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerVerticalAdvectionTendency(:,k,iCell) = &
-                  activeTracerVerticalAdvectionTendency(:,k,iCell) / &
+                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
                             layerThicknessNew(k,iCell)
 
-                  activeTracerHorMixTendency(:,k,iCell) = &
-                  activeTracerHorMixTendency(:,k,iCell) / &
+                  activeTracerHorMixTendency(iTracer,k,iCell) = &
+                  activeTracerHorMixTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerSurfaceFluxTendency(:,k,iCell) = &
-                  activeTracerSurfaceFluxTendency(:,k,iCell) / &
+                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
+                  activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  activeTracerNonLocalTendency(:,k,iCell) = &
-                  activeTracerNonLocalTendency(:,k,iCell) / &
+                  activeTracerNonLocalTendency(iTracer,k,iCell) = &
+                  activeTracerNonLocalTendency(iTracer,k,iCell) / &
                              layerThicknessNew(k,iCell)
-#endif
+               end do
 
                   temperatureShortWaveTendency(k,iCell) = &
                   temperatureShortWaveTendency(k,iCell) / &
                              layerThicknessNew(k,iCell)
                end do
                end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                !$omp end do
                !$omp end parallel
-#endif
             endif
 
-#ifdef MPAS_OPENACC
-            !$acc end parallel
-#endif
-
-! This tracer block is still computed on the CPU
-#ifdef MPAS_OPENACC
-            !$acc update host(layerThicknessNew)
-            !$acc update host(layerThicknessCur, layerThicknessTend)
-            !$acc update host(activeTracersNew)
-            !$acc update host(tracersSurfaceValue)
-#endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &
@@ -2230,66 +1981,68 @@ module ocn_time_integration_split
                                 configName, config_use_tracerGroup)
 
                   if ( config_use_tracerGroup ) then
-                     call mpas_pool_get_array(tracersPool, &
+                     call mpas_pool_get_array_gpu(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupCur, 1)
-                     call mpas_pool_get_array(tracersPool, &
+                     call mpas_pool_get_array_gpu(tracersPool, &
                                               groupItr%memberName, &
                                               tracersGroupNew, 2)
 
                      modifiedGroupName = &
                              trim(groupItr % memberName) // 'Tend'
-                     call mpas_pool_get_array(tracersTendPool, &
+                     call mpas_pool_get_array_gpu(tracersTendPool, &
                                               modifiedGroupName, &
                                               tracersGroupTend)
 
-#ifndef MPAS_OPENACC
                      !$omp parallel
                      !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                      do iCell = 1, nCellsAll
+!$acc loop vector
                      do k = minLevelCell(iCell), maxLevelCell(iCell)
-                        tracersGroupNew(:,k,iCell) = &
-                       (tracersGroupCur(:,k,iCell) * &
+                     do iTracer = 1, size(tracersGroupNew,1)
+                        tracersGroupNew(iTracer,k,iCell) = &
+                       (tracersGroupCur(iTracer,k,iCell) * &
                         layerThicknessCur(k,iCell) + dt* &
-                       tracersGroupTend(:,k,iCell))/ &
+                       tracersGroupTend(iTracer,k,iCell))/ &
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-#ifndef MPAS_OPENACC
+                     end do
+!$acc end parallel
                      !$omp end do
                      !$omp end parallel
-#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
                          'activeTracers' ) then
-#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
                         do iCell = 1, nCellsAll
+!$acc loop vector
                         do k = minLevelCell(iCell), maxLevelCell(iCell)
                            tracersGroupNew(indexSalinity,k,iCell) = &
                            max(0.001_RKIND,  &
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
                      if (trim(groupItr % memberName) == &
                          'debugTracers' .and. &
                          config_reset_debugTracers_near_surface) then
+!NV!                    !!! NOT EXECUTING !!!
+                        write(*,*) "config_reset_debugTracers_near_surface NOT EXECUTING"
 
-#ifndef MPAS_OPENACC
                         !$omp parallel
                         !$omp do schedule(runtime) private(k, lat)
-#endif
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
@@ -2332,38 +2085,19 @@ module ocn_time_integration_split
                               end do
                            end if
                         end do ! cells
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer
             end do ! tracer group
 
-#ifdef MPAS_OPENACC
-            !$acc update device(layerThicknessNew)
-            !$acc update device(activeTracersNew)
-#endif
-
             if (config_use_freq_filtered_thickness) then
-#ifdef MPAS_OPENACC
-               !$acc parallel present(minLevelCell, maxLevelCell) &
-               !$acc   present(lowFreqDivergenceNew) &
-               !$acc   present(lowFreqDivergenceCur) &
-               !$acc   present(lowFreqDivergenceTend)
-#endif
-
-#ifdef MPAS_OPENACC
-               !$acc loop gang
-#else
+!NV!           !!! NOT EXECUTING !!!
+               write(*,*) "config_use_freq_filtered_thickness NOT EXECUTING"
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-#endif
                do iCell = 1, nCellsAll
-#ifdef MPAS_OPENACC
-               !$acc loop vector
-#endif
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
@@ -2374,15 +2108,8 @@ module ocn_time_integration_split
                   lowFreqDivergenceTend(k,iCell)
                end do
                end do
-#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-               !$acc end parallel
-#endif
-
             end if
 
             ! Recompute final u to go on to next step.
@@ -2401,24 +2128,12 @@ module ocn_time_integration_split
             ! so normalBaroclinicVelocity does not have to be
             ! recomputed here.
 
-#ifdef MPAS_OPENACC
-            !$acc parallel present(minLevelEdgeBot, maxLevelEdgeTop) &
-            !$acc   present(normalVelocityNew) &
-            !$acc   present(normalBarotropicVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityNew) &
-            !$acc   present(normalBaroclinicVelocityCur)
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc loop gang
-#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-#endif
+!$acc parallel
+!$acc loop gang worker
             do iEdge = 1, nEdgesAll
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
+!$acc loop vector
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
                                normalBarotropicVelocityNew(iEdge) + &
@@ -2426,81 +2141,12 @@ module ocn_time_integration_split
                                normalBaroclinicVelocityCur(k,iEdge)
             end do
             end do ! iEdges
-#ifndef MPAS_OPENACC
+!$acc end parallel
             !$omp end do
             !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-            !$acc end parallel
-#endif
 
          endif ! splitExplicitStep
 
-#ifdef MPAS_OPENACC
-         !$acc exit data copyout(layerThicknessNew)
-         !$acc exit data copyout(normalVelocityNew)
-         !$acc exit data delete(normalBarotropicVelocityNew, &
-         !$acc                  normalBaroclinicVelocityNew)
-         !$acc exit data copyout(activeTracersNew)
-         !$acc update host(layerThickEdgeFlux)
-         if (config_use_freq_filtered_thickness) then
-            !$acc exit data copyout(lowFreqDivergenceNew)
-            !$acc exit data delete(lowFreqDivergenceCur)
-            !$acc exit data delete(lowFreqDivergenceTend)
-         endif
-         if (splitExplicitStep < numTSIterations) then
-            if (config_use_gm) then
-               !$acc update host(vertGMBolusVelocityTop)
-            end if
-            if (config_submesoscale_enable) then
-               !$acc update host(vertMLEBolusVelocityTop)
-            end if
-            !$acc exit data delete (atmosphericPressure, seaIcePressure)
-            !$acc exit data copyout(sshNew)
-            !$acc update host(layerThickEdgeMean)
-            !$acc update host(relativeVorticity, circulation)
-            !$acc update host(vertTransportVelocityTop, &
-            !$acc             relativeVorticityCell, &
-            !$acc             divergence, &
-            !$acc             kineticEnergyCell, &
-            !$acc             tangentialVelocity, &
-            !$acc             vertVelocityTop)
-            !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-            !$acc             normalizedRelativeVorticityCell)
-            !$acc update host (surfacePressure)
-            !$acc update host(zMid, zTop)
-            !$acc update host(tracersSurfaceValue)
-            !$acc update host(normalVelocitySurfaceLayer)
-            !$acc update host(density, potentialDensity, displacedDensity)
-            !$acc update host(thermExpCoeff,  &
-            !$acc&            salineContractCoeff)
-            !$acc update host(montgomeryPotential, pressure)
-            if (landIcePressureOn) then
-               !$acc exit data delete(landIcePressure)
-               !$acc exit data delete(landIceDraft)
-            endif
-            if (config_use_freq_filtered_thickness) then
-               !$acc exit data copyout(highFreqThicknessNew)
-               !$acc exit data delete(highFreqThicknessCur)
-            endif
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc exit data delete(frazilSurfacePressure)
-            endif
-         elseif (splitExplicitStep == numTSIterations) then
-            !$acc exit data delete(layerThicknessCur, layerThicknessTend)
-            !$acc exit data delete(normalBaroclinicVelocityCur)
-            if (config_compute_active_tracer_budgets) then
-               !$acc update host(activeTracerHorizontalAdvectionEdgeFlux)
-               !$acc update host(activeTracerHorizontalAdvectionTendency)
-               !$acc update host(activeTracerVerticalAdvectionTendency)
-               !$acc update host(activeTracerHorMixTendency)
-               !$acc update host(activeTracerSurfaceFluxTendency)
-               !$acc update host(temperatureShortWaveTendency)
-               !$acc update host(activeTracerNonLocalTendency)
-            endif
-         endif
-#endif
 
          call mpas_timer_stop('se loop fini')
          call mpas_timer_stop('se loop')
@@ -2520,80 +2166,14 @@ module ocn_time_integration_split
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      !$acc update device (normalTransportVelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEVelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(activeTracersNew)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host (vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host (vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshNew)
-      !$acc exit data delete(activeTracersNew)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
-#endif
-
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
+      call ocn_vmix_implicit_gpu(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
 
       ! Update halo on u and tracers, which were just updated for
@@ -2604,6 +2184,8 @@ module ocn_time_integration_split
       ! the change due to implicit vertical mixing across the boundary.
 
       if(config_enable_nonhydrostatic_mode) then
+!NV!    !!! NOT EXECUTING !!!
+        write(*,*) "config_enable_nonhydrostatic_mode NOT EXECUTING"
         dminfo = domain % dminfo
          call ocn_nonhydrostatic_pressure_tend(normalVelocityNew, &
               vertVelocityNonhydroNew, layerThicknessNew, layerThickEdgeFlux, &
@@ -2636,6 +2218,8 @@ module ocn_time_integration_split
                          groupItr%memberName, timeLevel=2)
             ! Reset iAge to zero where mask == 0
             if (config_use_idealAgeTracers.and.trim(groupItr%memberName) == 'idealAgeTracers') then
+!NV!            !!! NOT EXECUTING !!!
+                write(*,*) "config_use_idealAgeTracers NOT EXECUTING"
                 call mpas_pool_get_array(tracersPool, &
                                          groupItr%memberName, &
                                          tracersGroupNew, 2)
@@ -2646,17 +2230,13 @@ module ocn_time_integration_split
                                          'idealAgeTracersIdealAgeMask', &
                                           tracerGroupIdealAgeMask)
 
-#ifndef MPAS_OPENACC
                 !$omp parallel
                 !$omp do schedule(runtime)
-#endif
                 do iCell = 1, nCellsOwned
                    tracersGroupNew(1,1,iCell) = tracerGroupIdealAgeMask(1,iCell)*tracersGroupNew(1,1,iCell)
                 end do ! cells
-#ifndef MPAS_OPENACC
                 !$omp end do
                 !$omp end parallel
-#endif
              endif
 
             ! Halo update on all tracer groups
@@ -2670,7 +2250,9 @@ module ocn_time_integration_split
       call mpas_timer_stop("se implicit vert mix")
 
       if ( configVertAdvMethod == vertAdvRemap ) then
-
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "configVertAdvMethod == vertAdvRemap NOT EXECUTING"
+         
          call mpas_timer_start("vertical remap")
 
          call mpas_pool_get_array(statePool, 'layerThicknessLag', layerThicknessLagNew, 2)
@@ -2688,86 +2270,45 @@ module ocn_time_integration_split
 
       call mpas_timer_start('se fini')
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
+
       if (config_prescribe_velocity) then
-         !$acc enter data copyin(normalVelocityCur)
-      endif
-      if (config_prescribe_thickness) then
-         !$acc enter data copyin(layerThicknessCur)
-      endif
-      !$acc update device (normalTransportVelocity)
-      if (config_use_gm) then
-         !$acc update device (normalGMBolusVelocity)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update device (normalMLEvelocity)
-      end if
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(activeTracersNew)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
-      if (config_prescribe_velocity) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) present(normalVelocityNew, normalVelocityCur)
-#else
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_prescribe_velocity NOT EXECUTING"
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       if (config_prescribe_thickness) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) present(layerThicknessNew, layerThicknessCur)
-#else
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_prescribe_thickness NOT EXECUTING"
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCellsAll
          do k=1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice
-      call ocn_effective_density_in_land_ice_update(forcingPool, &
+!NV!  !!! NOT EXECUTING !!!
+      call ocn_effective_density_in_land_ice_update_gpu(forcingPool, &
                                                     statePool, err)
 
-      call mpas_timer_start('se final mpas reconstruct', .false.)
-
-#ifdef MPAS_OPENACC
-      !$acc enter data create(velocityX, velocityY, velocityZ)
-      !$acc enter data create(velocityZonal, velocityMeridional)
-      !$acc enter data create(gradSSHX, gradSSHY, gradSSHZ)
-      !$acc enter data create(gradSSHZonal, gradSSHMeridional)
-      !$acc enter data create(surfaceVelocity, SSHGradient)
-#endif
+      call mpas_timer_start('se final mpas reconstruct gpu', .false.)
 
       call mpas_reconstruct_gpu(meshPool, normalVelocityNew,       &
                                 velocityX, velocityY, velocityZ,   &
@@ -2779,15 +2320,12 @@ module ocn_time_integration_split
                                 gradSSHZonal, gradSSHMeridional, &
                                 includeHalos = .true.)
 
-      call mpas_timer_stop('se final mpas reconstruct')
+      call mpas_timer_stop('se final mpas reconstruct gpu')
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(surfaceVelocity, velocityZonal, velocityMeridional, &
-      !$acc   SSHGradient, gradSSHZonal, gradSSHMeridional)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
+!$acc parallel
+!$acc loop gang vector
       do iCell = 1, nCellsAll
          surfaceVelocity(indexSurfaceVelocityZonal,iCell) = &
                                    velocityZonal(minLevelCell(iCell),iCell)
@@ -2798,74 +2336,19 @@ module ocn_time_integration_split
          SSHGradient(indexSSHGradientMeridional,iCell) = &
                                                gradSSHMeridional(iCell)
       end do
-#ifndef MPAS_OPENACC
+!$acc end parallel
       !$omp end do
       !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      if (config_use_gm) then
-         !$acc update host(vertGMBolusVelocityTop)
-      end if
-      if (config_submesoscale_enable) then
-         !$acc update host(vertMLEBolusVelocityTop)
-      end if
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(sshNew)
-      !$acc exit data delete(activeTracersNew)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data copyout(layerThicknessNew, normalVelocityNew)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-      if (config_prescribe_velocity) then
-         !$acc exit data delete(normalVelocityCur)
-      endif
-      if (config_prescribe_thickness) then
-         !$acc exit data delete(layerThicknessCur)
-      endif
-      !$acc exit data copyout(velocityX, velocityY, velocityZ)
-      !$acc exit data copyout(gradSSHX, gradSSHY, gradSSHZ)
-      !$acc exit data copyout(velocityZonal, velocityMeridional)
-      !$acc exit data copyout(gradSSHZonal, gradSSHMeridional)
-      !$acc exit data copyout(surfaceVelocity, SSHGradient)
-#endif
-
-      call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
+      call ocn_time_average_coupled_accumulate_gpu(statePool,forcingPool,2)
 
       if (config_use_GM .or. config_submesoscale_enable) then
-         call ocn_reconstruct_eddy_vectors(meshPool)
+         call ocn_reconstruct_eddy_vectors_gpu(meshPool)
       end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
          call mpas_timer_start("se effective density halo")
          call mpas_pool_get_field(statePool, &
                                  'effectiveDensityInLandIce', &
@@ -2877,6 +2360,8 @@ module ocn_time_integration_split
 
       call mpas_timer_stop('se fini')
       call mpas_timer_stop("se timestep")
+
+!!!$acc update host(pressure,thermExpCoeff,salineContractCoeff,zMid,density,potentialDensity)
 
    end subroutine ocn_time_integrator_split!}}}
 
@@ -3034,20 +2519,22 @@ module ocn_time_integration_split
          call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
          call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
 
-         call mpas_pool_get_array(statePool, 'layerThickness', &
+         call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                               layerThickness, 1)
-         call mpas_pool_get_array(statePool, 'normalVelocity', &
+         call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
                                               normalVelocity, 1)
-         call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+         call mpas_pool_get_array_gpu(statePool, 'normalBarotropicVelocity', &
                                               normalBarotropicVelocity, 1)
-         call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+         call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', &
                                               normalBaroclinicVelocity, 1)
 
-         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-         call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+         call mpas_pool_get_array_gpu(meshPool, 'refBottomDepth', refBottomDepth)
+         call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+         call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+!$acc update host(layerThickness,normalVelocity,normalBarotropicVelocity,normalBaroclinicVelocity,&
+!$acc             refBottomDepth,cellsOnEdge,minLevelCell,minLevelEdgeBot,maxLevelEdgeTop)
 
          !*** Compute barotropic velocity at first timestep
          !*** This is only done upon start-up.
@@ -3149,6 +2636,7 @@ module ocn_time_integration_split
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta
 
+!$acc update device(normalBarotropicVelocity,normalBaroclinicVelocity,normalVelocity)
    end subroutine ocn_time_integration_split_init!}}}
 
 !***********************************************************************

--- a/src/shared/mpas_ocn_config.F
+++ b/src/shared/mpas_ocn_config.F
@@ -25,7 +25,14 @@ module ocn_config
    public
    save
 
-#include "../inc/config_declare.inc"
+   #include "../inc/config_declare.inc"
+   real (kind=RKIND) :: mod_lic_coeff_0, mod_lic_coeff_S, mod_lic_coeff_p, mod_lic_coeff_pS
+   real (kind=RKIND) :: mod_oo_coeff_0, mod_oo_coeff_S, mod_oo_coeff_p, mod_oo_coeff_pS,mod_oo_az1_liq
+   integer :: mod_jerlov_water_type
+
+!$acc declare create(mod_lic_coeff_0,mod_lic_coeff_S,mod_lic_coeff_p,mod_lic_coeff_pS,&
+!$acc                mod_oo_coeff_0,mod_oo_coeff_S,mod_oo_coeff_p,mod_oo_coeff_pS,mod_oo_az1_liq,&
+!$acc                mod_jerlov_water_type)
 
 !***********************************************************************
 
@@ -43,7 +50,21 @@ contains
    subroutine ocn_config_init(configPool)!{{{
        type (mpas_pool_type), pointer :: configPool
 
-#include "../inc/config_get.inc"
+       #include "../inc/config_get.inc"
+       mod_lic_coeff_0 = config_land_ice_cavity_freezing_temperature_coeff_0
+       mod_lic_coeff_S = config_land_ice_cavity_freezing_temperature_coeff_S
+       mod_lic_coeff_p = config_land_ice_cavity_freezing_temperature_coeff_p
+       mod_lic_coeff_pS = config_land_ice_cavity_freezing_temperature_coeff_pS
+       mod_oo_coeff_0 = config_open_ocean_freezing_temperature_coeff_0
+       mod_oo_coeff_S = config_open_ocean_freezing_temperature_coeff_S
+       mod_oo_coeff_p = config_open_ocean_freezing_temperature_coeff_p
+       mod_oo_coeff_pS = config_open_ocean_freezing_temperature_coeff_pS
+       mod_oo_az1_liq = config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+       mod_jerlov_water_type = config_jerlov_water_type
+
+!$acc update device(mod_lic_coeff_0,mod_lic_coeff_S,mod_lic_coeff_p,mod_lic_coeff_pS,&
+!$acc               mod_oo_coeff_0,mod_oo_coeff_S,mod_oo_coeff_p,mod_oo_coeff_pS,mod_oo_az1_liq,&
+!$acc               mod_jerlov_water_type)
 
    end subroutine ocn_config_init!}}}
 

--- a/src/shared/mpas_ocn_diagnostics.F
+++ b/src/shared/mpas_ocn_diagnostics.F
@@ -56,13 +56,20 @@ module ocn_diagnostics
    !--------------------------------------------------------------------
 
    public :: ocn_diagnostic_solve, &
+             ocn_diagnostic_solve_gpu, &
              ocn_diagnostic_solve_layerThicknessEdge, &
+             ocn_diagnostic_solve_layerThicknessEdge_gpu, &
              ocn_relativeVorticity_circulation, &
+             ocn_relativeVorticity_circulation_gpu, &
              ocn_vert_transport_velocity_top, &
+             ocn_vert_transport_velocity_top_gpu, &
              ocn_fuperp, &
+             ocn_fuperp_gpu, &
              ocn_filter_btr_mode_tend_vel, &
              ocn_reconstruct_eddy_vectors, &
+             ocn_reconstruct_eddy_vectors_gpu, &
              ocn_compute_kpp_input_fields, &
+             ocn_compute_kpp_input_fields_gpu, &
              ocn_validate_state, &
              ocn_build_log_filename, &
              ocn_diagnostics_init
@@ -156,21 +163,21 @@ contains
                                                  indexSalinityPtr)
       indexTemperature = indexTemperaturePtr
       indexSalinity    = indexSalinityPtr
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracers, timeLevel)
 
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
       if (landIcePressureOn) then
-         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-         call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceFraction', landIceFraction)
       end if
 
       nEdges = nEdgesAll
@@ -179,51 +186,14 @@ contains
 
       coef_3rd_order = config_coef_3rd_order
 
-#ifdef MPAS_OPENACC
-      !! Listing new inputs required by the first routine where they are used
-      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickness, (not on device)
-      !!                                            normalVelocity (not on device)
-      !! ocn_relativeVorticity_circulation       :: 
-      !! ocn_diagnostic_solve_vortVel            :: normalTransportVelocity, (diagnostics array)
-      !!                                            normalGMBolusVelocity (diagnostics array)
-      !! ocn_diagnostic_solve_kineticEnergy      ::
-      !! ocn_diagnostic_solve_vorticity          ::
-      !! ocn_diagnostic_solve_surface_pressure   :: atmosphericPressure, (not on device)
-      !!                                            seaIcePressure, (not on device)
-      !!                                            frazilSurfacePressure, (not on device)
-      !!                                            landIcePressure (not on device)
-      !! ocn_diagnostic_solve_z_coordinates      :: 
-      !! ocn_equation_of_state_density           :: activeTracers, (not on device)
-      !!                                            tracersSurfaceValue, (diagnostics array)
-      !!                                            maxLevelCell, (mesh array)
-      !!                                            refBottomDepth  (mesh array)
-      !! ocn_diagnostic_solve_pressure           ::
-      !! ocn_diagnostic_solve_richardson         :: edgeAreaFractionOfCell (mesh array)
-
-      !! tracersSurfaceValue calc                :: minLevelCell (mesh array)
-      !! normalVelocitySurfaceLayer calc         :: minLevelEdgeBot (mesh array)
-      !! surfaceFluxAttenuationCoefficientRunoff :: layerThickEdgeFlux (diagnostics array)
-      !! ocn_diagnostic_solve_ssh                :: ssh, (not on device)
-      !!                                            landIceDraft (not on device)
-
-!     !$acc enter data copyin(layerThickness, normalVelocity)
-!     !$acc update device (normalTransportVelocity, &
-!     !$acc                normalGMBolusVelocity)
-
-!     !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-
-!     !$acc enter data copyin(activeTracers, ssh)
-!     !$acc enter data copyin(activeTracers)
-!     !$acc update device(tracersSurfaceValue)
-
-!     if ( associated(frazilSurfacePressure) ) then
-!        !$acc enter data copyin(frazilSurfacePressure)
-!     endif
-     if (landIcePressureOn) then
-        !$acc enter data copyin(landIcePressure)
-        !$acc enter data copyin(landIceDraft)
-     endif
-#endif
+!$acc update host(normalVelocity,layerThickness,layerThickEdgeMean,layerThickEdgeFlux,relativeVorticity,circulation,&
+!$acc               normalTransportVelocity,vertVelocityTop,vertTransportVelocityTop,relativeVorticityCell,divergence,&
+!$acc               kineticEnergyCell,tangentialVelocity,normalGMBolusVelocity,vertGMBolusVelocityTop,normRelVortEdge,&
+!$acc               normPlanetVortEdge,normalizedRelativeVorticityCell,atmosphericPressure,seaIcePressure,surfacePressure,&
+!$acc               zMid,zTop,ssh,activeTracers,tracersSurfaceValue,density,thermExpCoeff,salineContractCoeff,&
+!$acc               potentialDensity,displacedDensity,montgomeryPotential,pressure,edgeAreaFractionOfCell,BruntVaisalaFreqTop,&
+!$acc               RiTopOfCell,minLevelCell,normalVelocitySurfaceLayer,minLevelEdgeBot,tracersSurfaceLayerValue,indexSurfaceLayerDepth,&
+!$acc               sfcFlxAttCoeff,surfaceFluxAttenuationCoefficientRunoff,pressureAdjustedSSH,gradSSH,landIceDraft)
 
       ! inputs: layerThickness, normalVelocity
       ! output: layerThickEdgeMean, layerThickEdgeFlux
@@ -257,8 +227,9 @@ contains
       if ( configVertAdvMethod == vertAdvRemap ) then
 
          ! Overwrite vertVelocityTop with exact Eulerian solution from remapping
-         call mpas_pool_get_array(statePool, 'layerThicknessLag', &
+         call mpas_pool_get_array_gpu(statePool, 'layerThicknessLag', &
              layerThicknessLag, timeLevel)
+!$acc update host(layerThicknessLag)
          call ocn_diagnostic_solve_vertVel_remap(layerThickness, &
              layerThicknessLag, dt, vertVelocityTop)
 
@@ -386,45 +357,21 @@ contains
       ! field will be updated below is better approximations are available
 
 !TDR need to consider how to handle tracersSurfaceValues
-#ifdef MPAS_OPENACC
-      ! tracersSurfaceValue calc
-      ! inputs: activeTracers, minLevelCell
-      ! outputs: tracersSurfaceValue
-      !$acc kernels present(tracersSurfaceValue, activeTracers, minLevelCell)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
-#ifdef MPAS_OPENACC
-      !$acc loop independent
-#endif
       do iCell = 1, nCells
          do iTracer = 1,size(tracersSurfaceValue,1)
             tracersSurfaceValue(iTracer, iCell) = activeTracers(iTracer, minLevelCell(iCell), iCell)
          enddo
       end do
-#ifdef MPAS_OPENACC
-      !$acc end kernels
-#else
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      ! normalVelocitySurfaceLayer calc
-      ! inputs: normalVelocity, minLevelEdgeBot
-      ! outputs: normalVelocitySurfaceLayer
-      !$acc parallel loop gang vector &
-      !$acc          present(normalVelocity, normalVelocitySurfaceLayer, minLevelEdgeBot)
-#else
       !$omp do schedule(runtime)
-#endif
       do iEdge = 1, nEdges
          normalVelocitySurfaceLayer(iEdge) = normalVelocity(minLevelEdgeBot(iEdge), iEdge)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       if ( full_compute ) then
 
@@ -467,95 +414,335 @@ contains
 
       end if ! full_compute
 
-#ifdef MPAS_OPENACC
-      !! Listing outputs by first routine that modifies variable
-      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdgeFlux, (diagnostics array)
-      !!                                            layerThickEdgeMean (diagnostics array)
-      !! ocn_relativeVorticity_circulation       :: relativeVorticity, (diagnostics array)
-      !!                                            circulation (diagnostics array)
-      !! ocn_diagnostic_solve_vortVel            :: vertTransportVelocityTop, (diagnostics array)
-      !!                                            vertGMBolusVelocityTop, (diagnostics array)
-      !!                                            relativeVorticityCell, (diagnostics array)
-      !!                                            divergence, (diagnostics array)
-      !!                                            kineticEnergyCell, (diagnostics array)
-      !!                                            tangentialVelocity (diagnostics array)
-      !!                                            vertVelocityTop (diagnostics array)
-      !! ocn_diagnostic_solve_kineticEnergy      :: 
-      !! ocn_diagnostic_solve_vorticity          :: normRelVortEdge, (diagnostics array)
-      !!                                            normPlanetVortEdge, (diagnostics array)
-      !!                                            normalizedRelativeVorticityCell (diagnostics array)
-      !! ocn_diagnostic_solve_surface_pressure   :: surfacePressure (diagnostics array)
-      !! ocn_diagnostic_solve_z_coordinates      :: zMid, (diagnostics array)
-      !!                                            zTop,(diagnostics array)
-      !!                                            ssh (not on device)
-      !! ocn_equation_of_state_density           :: density, (diagnostics array)
-      !!                                            potentialDensity, (diagnostics array)
-      !!                                            displacedDensity, (diagnostics array)
-      !!                                            thermalExpansionCoeff, (diagnostics array)
-      !!                                            salineContractionCoeff (diagnostics array)
-      !! ocn_diagnostic_solve_pressure           :: montgomeryPotential, (diagnostics array)
-      !!                                            pressure (diagnostics array)
-      !! ocn_diagnostic_solve_richardson         :: BruntVaisalaFreqTop, (diagnostics array)
-      !!                                            RiTopOfCell (diagnostics array)
-      !! tracersSurfaceValue calc                :: tracersSurfaceValue (diagnostics array)
-      !! normalVelocitySurfaceLayer calc         :: normalVelocitySurfaceLayer (diagnostics array)
-      !! surfaceFluxAttenuationCoefficientRunoff :: tracersSurfaceLayerValue, (diagnostics array)
-      !!                                            indexSurfaceLayerDepth, (diagnostics array)
-      !!                                            normalVelocitySurfaceLayer, (diagnostics array)
-      !!                                            surfaceFluxAttenuationCoefficient, ????
-      !!                                            surfaceFluxAttenuationCoefficientRunoff (diagnostics array)
-      !! ocn_diagnostic_solve_ssh                :: pressureAdjustedSSH, (diagnostics array)
-      !!                                            gradSSH (diagnostics array)
-
-!     !$acc update host(layerThickEdgeFlux, layerThickEdgeCenter)
-!     !$acc update host(relativeVorticity, circulation)
-!     !$acc update host(vertTransportVelocityTop, &
-!     !$acc             vertGMBolusVelocityTop, &
-!     !$acc             relativeVorticityCell, &
-!     !$acc             divergence, &
-!     !$acc             kineticEnergyCell, &
-!     !$acc             tangentialVelocity, &
-!     !$acc             vertVelocityTop)
-!     !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-!     !$acc             normalizedRelativeVorticityCell)
-!     !$acc update host (surfacePressure)
-!     !$acc update host(zMid, zTop)
-!     !$acc exit data copyout(ssh)
-!     !$acc update host(density, potentialDensity, displacedDensity)
-!     !$acc update host(thermExpCoeff,  &
-!     !$acc&            salineContractCoeff)
-!     !$acc update host(tracersSurfaceValue)
-
-!     !$acc update host(normalVelocitySurfaceLayer)
-!     !$acc update host(montgomeryPotential, pressure)
-
-!     if ( full_compute ) then
-!        !$acc update host(RiTopOfCell, &
-!        !$acc             BruntVaisalaFreqTop)
-
-!        !$acc update host(tracersSurfaceLayerValue, &
-!        !$acc             indexSurfaceLayerDepth, &
-!        !$acc             normalVelocitySurfaceLayer, &
-!        !$acc             sfcFlxAttCoeff, &
-!        !$acc             surfaceFluxAttenuationCoefficientRunoff)
-!     end if ! full_compute
-
-!     !$acc exit data delete (atmosphericPressure, seaIcePressure)
-!     if ( associated(frazilSurfacePressure) ) then
-!        !$acc exit data delete(frazilSurfacePressure)
-!     endif
-     if (landIcePressureOn) then
-        !$acc exit data delete(landIcePressure)
-        !$acc exit data delete(landIceDraft)
-     endif
-
-!     !$acc exit data delete (layerThickness, normalVelocity, &
-!     !$acc                   activeTracers)
-#endif
+!$acc update device(layerThickEdgeMean,layerThickEdgeFlux,relativeVorticity,circulation,vertVelocityTop,&
+!$acc             vertTransportVelocityTop,relativeVorticityCell,divergence,kineticEnergyCell,tangentialVelocity,&
+!$acc             vertGMBolusVelocityTop,normRelVortEdge,normPlanetVortEdge,normalizedRelativeVorticityCell,&
+!$acc             surfacePressure,zMid,zTop,ssh,activeTracers,tracersSurfaceValue,density,thermExpCoeff,salineContractCoeff,&
+!$acc             potentialDensity,displacedDensity,montgomeryPotential,pressure,BruntVaisalaFreqTop,RiTopOfCell,&
+!$acc             normalVelocitySurfaceLayer,tracersSurfaceLayerValue,indexSurfaceLayerDepth,sfcFlxAttCoeff,&
+!$acc             surfaceFluxAttenuationCoefficientRunoff,pressureAdjustedSSH,gradSSH)
 
       call mpas_timer_stop('diagnostic solve')
 
    end subroutine ocn_diagnostic_solve!}}}
+
+   subroutine ocn_diagnostic_solve_gpu(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, &
+                                   timeLevelIn, full)!{{{
+
+      real (kind=RKIND), intent(in) :: dt !< Input: Time step
+      type (mpas_pool_type), intent(in) :: statePool !< Input: State information
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
+      type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
+      integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
+      logical, intent(in), optional :: full   !< Input: Run all computations?
+
+      integer :: iEdge, iCell, iTracer, k, kmin, kmax
+      integer :: err, nCells, nEdges, nVertices, numTracers
+      integer :: timeLevel
+
+      real (kind=RKIND) :: coef_3rd_order
+
+      real (kind=RKIND), dimension(:), pointer :: &
+        ssh,  seaIcePressure, atmosphericPressure
+      real (kind=RKIND), dimension(:,:), pointer :: &
+        layerThickness, layerThicknessLag, normalVelocity
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+
+      integer, pointer :: indexTemperaturePtr, indexSalinityPtr
+      integer :: indexTemperature, indexSalinity
+
+      logical :: full_compute = .true.
+
+      real (kind=RKIND), dimension(:), pointer :: &
+        frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
+
+      integer, dimension(:), pointer :: &
+        landIceMask
+
+      call mpas_timer_start('diagnostic solve gpu')
+
+      if ( present(full) ) then
+         full_compute = full
+      else
+         full_compute = .true.
+      end if
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracers, timeLevel)
+
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, timeLevel)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+
+      if (landIcePressureOn) then
+         call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array_gpu(forcingPool, 'landIceFraction', landIceFraction)
+      end if
+
+      nEdges = nEdgesAll
+      nCells = nCellsAll
+      nVertices = nVerticesAll
+
+      coef_3rd_order = config_coef_3rd_order
+
+!$acc data present(normalVelocity,layerThickness,layerThickEdgeMean,layerThickEdgeFlux,relativeVorticity,circulation,&
+!$acc               normalTransportVelocity,vertVelocityTop,vertTransportVelocityTop,relativeVorticityCell,divergence,&
+!$acc               kineticEnergyCell,tangentialVelocity,normalGMBolusVelocity,vertGMBolusVelocityTop,normRelVortEdge,&
+!$acc               normPlanetVortEdge,normalizedRelativeVorticityCell,atmosphericPressure,seaIcePressure,surfacePressure,&
+!$acc               zMid,zTop,ssh,activeTracers,tracersSurfaceValue,density,thermExpCoeff,salineContractCoeff,&
+!$acc               potentialDensity,displacedDensity,montgomeryPotential,pressure,edgeAreaFractionOfCell,BruntVaisalaFreqTop,&
+!$acc               RiTopOfCell,minLevelCell,normalVelocitySurfaceLayer,minLevelEdgeBot,tracersSurfaceLayerValue,indexSurfaceLayerDepth,&
+!$acc               sfcFlxAttCoeff,surfaceFluxAttenuationCoefficientRunoff,pressureAdjustedSSH,gradSSH,landIceDraft)
+
+      ! inputs: layerThickness, normalVelocity
+      ! output: layerThickEdgeMean, layerThickEdgeFlux
+      call ocn_diagnostic_solve_layerThicknessEdge_gpu(normalVelocity, &
+                                                   layerThickness)
+
+      ! inputs: normalVelocity
+      ! outputs: relativeVorticity, circulation
+      call ocn_relativeVorticity_circulation_gpu(relativeVorticity, circulation, normalVelocity, err)
+
+      ! inputs: relativeVorticity, layerThickEdgeFlux, normalVelocity, normalTransportVelocity, 
+      !         normalGMBolusVelocity
+      ! outputs: vertTransportVelocityTop, vertGMBolusVelocityTop, relativeVorticityCell, 
+      !          divergence, kineticEnergyCell, tangentialVelocity, vertMLEBolusVelocityTop
+      ! in and out: vertVelocityTop
+      call ocn_diagnostic_solve_vortVel_gpu(relativeVorticity, &
+             layerThickEdgeFlux, normalVelocity, normalTransportVelocity, &
+             vertVelocityTop, vertTransportVelocityTop, relativeVorticityCell, &
+             divergence, kineticEnergyCell, tangentialVelocity)
+
+      !compute vertical velocity due to gm bolus velocity if requested
+      if (config_use_gm) then
+         call ocn_diagnostic_solve_GMvel_gpu(layerThickEdgeFlux, normalGMBolusVelocity, vertGMBolusVelocityTop)
+      end if
+
+      !compute vertical velocity due to submesoscale eddies (MLE) velocity if requested
+      if (config_submesoscale_enable) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_diagnostic_solve_MLEvel NOT EXECUTING"
+         call ocn_diagnostic_solve_MLEvel(layerThickEdgeFlux, normalMLEVelocity, vertMLEBolusVelocityTop)
+      end if
+
+      if ( configVertAdvMethod == vertAdvRemap ) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "configVertAdvMethod == vertAdvRemap NOT EXECUTING"
+
+         ! Overwrite vertVelocityTop with exact Eulerian solution from remapping
+         call mpas_pool_get_array(statePool, 'layerThicknessLag', &
+             layerThicknessLag, timeLevel)
+         call ocn_diagnostic_solve_vertVel_remap(layerThickness, &
+             layerThicknessLag, dt, vertVelocityTop)
+
+         ! Overwrite vertical tracer budget terms with new vertVelocityTop
+         if ( config_compute_active_tracer_budgets ) then
+            numTracers = size(activeTracers, dim=1)
+            do iTracer = 1, numTracers
+               !$omp parallel
+               !$omp do schedule(runtime) private(k,kmin,kmax)
+               do iCell = 1, nCells
+                  kmin = minLevelCell(iCell)
+                  kmax = maxLevelCell(iCell)
+
+                  activeTracerVerticalAdvectionTopFlux(iTracer, :, iCell) = 0.0_RKIND
+                  do k = kmin+1, kmax
+                     activeTracerVerticalAdvectionTopFlux(iTracer, k, iCell) = &
+                           min(0.0_RKIND,vertVelocityTop(k, iCell))* &
+                                         activeTracers(iTracer, k-1, iCell) &
+                         + max(0.0_RKIND,vertVelocityTop(k,iCell))* &
+                                         activeTracers(iTracer, k, iCell)
+                  enddo
+
+                  do k = kmin, kmax-1
+                     activeTracerVerticalAdvectionTendency(iTracer, k, iCell) = ( &
+                          activeTracerVerticalAdvectionTopFlux(iTracer, k+1, iCell) &
+                        - activeTracerVerticalAdvectionTopFlux(iTracer, k, iCell) &
+                        ) / layerThickness(k, iCell)
+                  enddo
+                  activeTracerVerticalAdvectionTendency(iTracer, kmax, iCell) = &
+                     - activeTracerVerticalAdvectionTopFlux(iTracer, kmax, iCell) &
+                     / layerThickness(kmax, iCell)
+               enddo
+               !$omp end do
+               !$omp end parallel
+            enddo
+         endif
+      endif
+
+      !
+      ! Compute kinetic energy
+      !
+      ! inputs :: normalVelocity
+      ! outputs :: kineticEnergyCell
+      if ( ke_vertex_flag == 1 ) then
+         call ocn_diagnostic_solve_kineticEnergy_gpu(normalVelocity, kineticEnergyCell)
+      end if
+
+      ! inputs :: normalVelocity, tangentialVelocity, layerThickness, relativeVorticity
+      ! outputs :: normRelVortEdge, normPlanetVortEdge, 
+      !            normalizedRelativeVorticityCell
+      call ocn_diagnostic_solve_vorticity_gpu(dt, normalVelocity, tangentialVelocity, &
+                layerThickness, relativeVorticity, &
+                normRelVortEdge, normPlanetVortEdge, &
+                normalizedRelativeVorticityCell)
+
+      !
+      ! Surface pressure
+      ! This section must be placed in the code before computing the density.
+      !
+      ! inputs: atmosphericPressure, seaIcePressure, frazilSurfacePressure, landIcePressure
+      ! outputs: surfacePressure
+      call ocn_diagnostic_solve_surface_pressure_gpu(forcingPool, atmosphericPressure, &
+                seaIcePressure, surfacePressure)
+
+      !
+      ! Z-coordinates
+      ! This section must be placed in the code before computing the density.
+      !
+      ! inputs : layerThickness
+      ! outputs : zMid, zTop, ssh)
+      call ocn_diagnostic_solve_z_coordinates_gpu(layerThickness, zMid, zTop, ssh)
+
+      !
+      ! equation of state
+      !
+
+      ! Only need densities on 0, 1, and 2 halo cells
+      nCells = nCellsAll
+
+      ! inputs: activeTracers, tracersSurfaceValue,maxLevelCell,refBottomDepth 
+      ! outputs: density, potentialDensity, displacedDensity, thermalExpansionCoeff, salineContractionCoeff
+      ! compute in-place density
+      call ocn_equation_of_state_density_gpu(statePool, meshPool, activeTracers, tracersSurfaceValue, &
+                                         nCells, 0, 'relative', density, err, &
+                                         thermExpCoeff, salineContractCoeff, &
+                                         timeLevelIn=timeLevel)
+      ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
+      call ocn_equation_of_state_density_gpu(statePool, meshPool, activeTracers, tracersSurfaceValue, &
+                                         nCells, 1, 'absolute', potentialDensity, &
+                                         err, timeLevelIn=timeLevel)
+
+      ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
+      ! That is, layer k has been displaced to the depth of layer k+1.
+      call ocn_equation_of_state_density_gpu(statePool, meshPool, activeTracers, tracersSurfaceValue, &
+                                         nCells, 1, 'relative', displacedDensity, &
+                                         err, timeLevelIn=timeLevel)
+
+      !
+      ! Pressure
+      ! This section must be placed in the code after computing the density.
+      !
+      ! inputs: layerThickness, density, surfacePressure
+      ! outputs: montgomeryPotential, pressure
+      call ocn_diagnostic_solve_pressure_gpu(layerThickness, density, &
+                surfacePressure, montgomeryPotential, pressure)
+
+      nCells = nCellsAll
+
+      if ( full_compute ) then
+         !
+         ! Brunt-Vaisala frequency and gradient Richardson number
+         !
+         ! inputs: displacedDensity, density, zMid, normalVelocity, edgeAreaFractionOfCell
+         ! outputs: BruntVaisalaFreqTop, RiTopOfCell
+         call ocn_diagnostic_solve_richardson_gpu(displacedDensity, density, zMid, &
+                normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)
+      end if    ! full_compute
+
+      !
+      ! extrapolate tracer values to ocean surface
+      ! this eventually be a modelled process
+      ! at present, just copy k=1 tracer values onto surface values
+      ! field will be updated below is better approximations are available
+
+!TDR need to consider how to handle tracersSurfaceValues
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang worker
+      do iCell = 1, nCells
+!$acc loop vector
+         do iTracer = 1,size(tracersSurfaceValue,1)
+            tracersSurfaceValue(iTracer, iCell) = activeTracers(iTracer, minLevelCell(iCell), iCell)
+         enddo
+      end do
+!$acc end parallel
+      !$omp end do
+
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang worker vector
+      do iEdge = 1, nEdges
+         normalVelocitySurfaceLayer(iEdge) = normalVelocity(minLevelEdgeBot(iEdge), iEdge)
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      if ( full_compute ) then
+         !
+         ! average tracer values over the ocean surface layer
+         ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
+         !
+         ! inputs: layerThickness, activeTracers, layerThicknessEdgeFlux, normalVelocity
+         ! outputs: tracersSurfaceLayerValue, indexSurfaceLayerDepth, normalVelocitySurfaceLayer,
+         !          surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff
+         call ocn_diagnostic_solve_surfaceLayer_gpu(layerThickness, activeTracers, &
+                layerThickEdgeFlux, normalVelocity, tracersSurfaceLayerValue, &
+                indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
+                sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
+
+      end if ! full_compute
+
+      !
+      !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
+      !
+      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceMask
+      ! outputs: 
+      if (landIcePressureOn) then
+         call ocn_compute_land_ice_flux_input_fields_gpu(layerThickness, normalVelocity, activeTracers, &
+                landIceFraction, landIceMask, timeLevel, indexTemperature, indexSalinity)
+      end if
+
+      if ( full_compute ) then
+         !
+         ! inputs: ssh, seaIcePressure, landIceDraft
+         ! outputs: pressureAdjustedSSH, gradSSH
+         if (landIcePressureOn) then
+            call ocn_diagnostic_solve_ssh_gpu(forcingPool, ssh, seaIcePressure, &
+                   pressureAdjustedSSH, gradSSH, landIceDraft=landIceDraft )
+        else 
+            call ocn_diagnostic_solve_ssh_gpu(forcingPool, ssh, seaIcePressure, &
+                   pressureAdjustedSSH, gradSSH)
+         end if
+      end if ! full_compute
+
+!$acc end data
+
+      call mpas_timer_stop('diagnostic solve gpu')
+
+   end subroutine ocn_diagnostic_solve_gpu!}}}
 
 !***********************************************************************
 !
@@ -606,31 +793,17 @@ contains
 
       err = 0
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) present(circulation, relativeVorticity)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iVertex = 1, nVerticesAll
          do k = 1, nVertLevels
             circulation(k, iVertex) = 0.0_RKIND
             relativeVorticity(k, iVertex) = 0.0_RKIND
          enddo
       enddo
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
-      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
-      !$acc                  minLevelVertexTop) &
-      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp)
-#else
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
-#endif
       do iVertex = 1, nVerticesAll
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do i = 1, vertexDegree
@@ -642,14 +815,93 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_relativeVorticity_circulation!}}}
+
+   subroutine ocn_relativeVorticity_circulation_gpu(relativeVorticity, circulation, normalVelocity, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         relativeVorticity
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         circulation
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iVertex, iEdge, i, k
+
+      real (kind=RKIND) :: invAreaTri1, r_tmp
+
+      err = 0
+
+!$acc data present(areaTriangle,edgesOnVertex,minLevelVertexTop,maxLevelVertexBot,dcEdge,edgeSignOnVertex,&
+!$acc              normalVelocity,circulation,relativeVorticity)
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iVertex = 1, nVerticesAll
+         do k = 1, nVertLevels
+            circulation(k, iVertex) = 0.0_RKIND
+            relativeVorticity(k, iVertex) = 0.0_RKIND
+         enddo
+      enddo
+!$acc end parallel
+      !$omp end do
+
+      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
+!$acc parallel
+!$acc loop gang worker private(invAreaTri1)
+      do iVertex = 1, nVerticesAll
+         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+!$acc loop vector private(r_tmp,iEdge)
+            do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
+
+!$acc loop seq
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+
+              r_tmp = dcEdge(iEdge) * normalVelocity(k, iEdge)
+              circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp
+              relativeVorticity(k, iVertex) = relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp * invAreaTri1
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_relativeVorticity_circulation_gpu!}}}
 
 !***********************************************************************
 !
@@ -700,15 +952,8 @@ contains
       ! Begin code
 
       ! Compute mean layer thickness at edge
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(layerThickness, layerThickEdgeMean, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop, cellsOnEdge) &
-      !$acc    private(k, kmin, kmax, cell1, cell2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
-#endif
       do iEdge = 1, nEdgesAll
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
@@ -726,10 +971,8 @@ contains
                                           layerThickness(k,cell2))
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       ! Compute edge flux based on option set on init
       select case (thickEdgeFluxChoice)
@@ -737,37 +980,22 @@ contains
       case (thickEdgeFluxCenter)
          ! Use centered (mean) thickness as flux value
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) &
-         !$acc    present(layerThickEdgeFlux, layerThickEdgeMean)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iEdge = 1, nEdgesAll
          do k = 1,nVertLevels
             layerThickEdgeFlux(k,iEdge) = &
             layerThickEdgeMean(k,iEdge)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case (thickEdgeFluxUpwind)
          ! Use upwind thickness as the edge flux value
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(normalVelocity, layerThickness, &
-         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc            layerThickEdgeFlux, cellsOnEdge) &
-         !$acc    private(k, kmin, kmax, cell1, cell2)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
-#endif
          do iEdge = 1, nEdgesAll
             kmin = minLevelEdgeBot(iEdge)
             kmax = maxLevelEdgeTop(iEdge)
@@ -790,10 +1018,8 @@ contains
                end if
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case default
          ! Should have been caught on init
@@ -805,6 +1031,138 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_layerThicknessEdge!}}}
+
+   subroutine ocn_diagnostic_solve_layerThicknessEdge_gpu(normalVelocity, &
+                                                      layerThickness)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity,  &!< [in] transport
+         layerThickness    !< [in] layer thickness at cell center
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      ! Outputs are the shared variables from diagnostic_variables:
+      !real (kind=RKIND), dimension(:,:), intent(out) :: &
+      !   layerThickEdgeMean, & !< [out] centered layer thickness on edge
+      !   layerThickEdgeFlux    !< [out] flux-related thickness on edge
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge, k,     &! edge and vertical loop indices
+         cell1, cell2, &! neighbor cell indices across an edge
+         kmin, kmax     ! min,max active vertical levels
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+!$acc data present(minLevelEdgeBot,maxLevelEdgeTop,cellsOnEdge,&
+!$acc              normalVelocity,layerThickness,layerThickEdgeMean,layerThickEdgeFlux)
+
+      ! Compute mean layer thickness at edge
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,cell1,cell2)
+      do iEdge = 1, nEdgesAll
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+!$acc loop vector
+         do k = 1,nVertLevels
+            ! initialize layerThicknessEdgeMean to avoid divide by
+            ! zero and NaN problems.
+            layerThickEdgeMean(k,iEdge) = -1.0e34_RKIND
+         end do
+!$acc loop vector
+         do k = kmin,kmax
+            ! central differenced
+            layerThickEdgeMean(k,iEdge) = 0.5_RKIND * &
+                                         (layerThickness(k,cell1) + &
+                                          layerThickness(k,cell2))
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      ! Compute edge flux based on option set on init
+      select case (thickEdgeFluxChoice)
+
+      case (thickEdgeFluxCenter)
+         ! Use centered (mean) thickness as flux value
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+         do iEdge = 1, nEdgesAll
+         do k = 1,nVertLevels
+            layerThickEdgeFlux(k,iEdge) = &
+            layerThickEdgeMean(k,iEdge)
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+      case (thickEdgeFluxUpwind)
+         ! Use upwind thickness as the edge flux value
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,cell1,cell2)
+         do iEdge = 1, nEdgesAll
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+!$acc loop vector
+            do k=1,nVertLevels
+               ! initialize layerThicknessEdgeFlux to avoid divide by
+               ! zero and NaN problems.
+               layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
+            end do
+!$acc loop vector
+            do k = kmin,kmax
+               if (normalVelocity(k,iEdge) > 0.0_RKIND) then
+                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell1)
+               elseif (normalVelocity(k,iEdge) < 0.0_RKIND) then
+                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell2)
+               else
+                  layerThickEdgeFlux(k,iEdge) = &
+                                      max(layerThickness(k,cell1), &
+                                          layerThickness(k,cell2))
+               end if
+            end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+      case default
+         ! Should have been caught on init
+         call mpas_log_write('Thickness flux option unknown', &
+                             MPAS_LOG_CRIT)
+
+      end select
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_layerThicknessEdge_gpu!}}}
 
 !***********************************************************************
 !
@@ -861,24 +1219,15 @@ contains
 
       allocate(kineticEnergyVertex(nVertLevels, nVerticesAll), &
                kineticEnergyVertexOnCells(nVertLevels, nCells))
-      !$acc enter data create(kineticEnergyVertex, &
-      !$acc                   kineticEnergyVertexOnCells)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(kineticEnergyVertex, normalVelocity, &
-      !$acc            areaTriangle, dcEdge, dvEdge, edgesOnVertex)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(i, k, iEdge, rTmp)
-#endif
       do iVertex = 1, nVerticesAll
          kineticEnergyVertex(:, iVertex) = 0.0_RKIND
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
             rTmp  = dcEdge(iEdge)*dvEdge(iEdge)*0.25_RKIND/ &
                     areaTriangle(iVertex)
-            !$acc loop seq
             do k = 1, nVertLevels
                kineticEnergyVertex(k,iVertex) = &
                kineticEnergyVertex(k,iVertex) + rTmp* &
@@ -886,26 +1235,16 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(kineticEnergyVertexOnCells, kineticEnergyVertex,& 
-      !$acc            kiteIndexOnCell, kiteAreasOnVertex, invAreaCell,&
-      !$acc            verticesOnCell, nEdgesOnCell)
-#else
       !$omp do schedule(runtime) &
       !$omp    private(i, j, k, iVertex, invAreaCell1)
-#endif
       do iCell = 1, nCells
          kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             j = kiteIndexOnCell(i, iCell)
             iVertex = verticesOnCell(i, iCell)
-            !$acc loop seq
             do k = 1, nVertLevels
                kineticEnergyVertexOnCells(k,iCell) = &
                kineticEnergyVertexOnCells(k,iCell) + &
@@ -914,20 +1253,13 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       !
       ! Compute kinetic energy in each cell by blending
       ! kineticEnergyCell and kineticEnergyVertexOnCells
       !
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) &
-      !$acc    present(kineticEnergyCell, kineticEnergyVertexOnCells)
-#else
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCells
       do k = 1, nVertLevels
          kineticEnergyCell(k,iCell) = 5.0_RKIND/8.0_RKIND* &
@@ -936,19 +1268,145 @@ contains
                                       kineticEnergyVertexOnCells(k,iCell)
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(kineticEnergyVertex, &
-      !$acc                  kineticEnergyVertexOnCells)
       deallocate(kineticEnergyVertex, &
                  kineticEnergyVertexOnCells)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_kineticEnergy!}}}
+
+   subroutine ocn_diagnostic_solve_kineticEnergy_gpu(normalVelocity, &
+                                                 kineticEnergyCell)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity     !< [in] velocity normal to edge
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         kineticEnergyCell  !< [out] kinetic energy at cell center
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, j, k,               &! generic loop indices
+         iCell, iEdge, iVertex, &! indices for cell, edge, vertex
+         nCells                  ! number of cells and vertices
+
+      real (kind=RKIND) :: &
+         rTmp,        &! local tmp for common factors
+         invAreaCell1  ! 1/cell area
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         kineticEnergyVertex, &! horiz kinetic energy at vertices
+         kineticEnergyVertexOnCells
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      nCells = nCellsHalo( 2 )
+
+      allocate(kineticEnergyVertex(nVertLevels, nVerticesAll), &
+               kineticEnergyVertexOnCells(nVertLevels, nCells))
+
+!$acc data create(kineticEnergyVertex,kineticEnergyVertexOnCells)&
+!$acc      present(edgesOnVertex,dcEdge,dvEdge,areaTriangle,invAreaCell,nEdgesOnCell,kiteIndexOnCell,&
+!$acc              verticesOnCell,kiteAreasOnVertex,&
+!$acc              normalVelocity,kineticEnergyCell)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, k, iEdge, rTmp)
+!$acc parallel
+!$acc loop gang worker
+      do iVertex = 1, nVerticesAll
+!$acc loop vector
+         do k = 1, nVertLevels
+            kineticEnergyVertex(k, iVertex) = 0.0_RKIND
+         enddo
+!$acc loop vector private(iEdge,rTmp)
+            do k = 1, nVertLevels
+!$acc loop seq
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+            rTmp  = dcEdge(iEdge)*dvEdge(iEdge)*0.25_RKIND/ &
+                    areaTriangle(iVertex)
+
+               kineticEnergyVertex(k,iVertex) = &
+               kineticEnergyVertex(k,iVertex) + rTmp* &
+                            normalVelocity(k,iEdge)**2
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+
+      !$omp do schedule(runtime) &
+      !$omp    private(i, j, k, iVertex, invAreaCell1)
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1)
+      do iCell = 1, nCells
+!$acc loop vector
+         do k = 1, nVertLevels
+            kineticEnergyVertexOnCells(k, iCell) = 0.0_RKIND
+         enddo
+         invAreaCell1 = invAreaCell(iCell)
+!$acc loop vector private(j,iVertex)
+            do k = 1, nVertLevels
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+
+               kineticEnergyVertexOnCells(k,iCell) = &
+               kineticEnergyVertexOnCells(k,iCell) + &
+                        kiteAreasOnVertex(j,iVertex)* &
+                        kineticEnergyVertex(k,iVertex)*invAreaCell1
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+
+      !
+      ! Compute kinetic energy in each cell by blending
+      ! kineticEnergyCell and kineticEnergyVertexOnCells
+      !
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iCell = 1, nCells
+      do k = 1, nVertLevels
+         kineticEnergyCell(k,iCell) = 5.0_RKIND/8.0_RKIND* &
+                                      kineticEnergyCell(k,iCell) & 
+                                    + 3.0_RKIND/8.0_RKIND* &
+                                      kineticEnergyVertexOnCells(k,iCell)
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(kineticEnergyVertex, &
+                 kineticEnergyVertexOnCells)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_kineticEnergy_gpu!}}}
 
 !***********************************************************************
 !
@@ -1037,24 +1495,12 @@ contains
       !
       allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVerticesAll), &
                normalizedRelativeVorticityVertex(nVertLevels, nVerticesAll))
-      !$acc enter data create(normalizedPlanetaryVorticityVertex, &
-      !$acc                   normalizedRelativeVorticityVertex)
 
       nVertices = nVerticesHalo(2)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(normalizedRelativeVorticityVertex, &
-      !$acc            normalizedPlanetaryVorticityVertex, &
-      !$acc            relativeVorticity, fVertex, layerThickness, &
-      !$acc            areaTriangle, kiteAreasOnVertex, cellsOnVertex, &
-      !$acc            maxLevelVertexBot) &
-      !$acc    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
-#endif
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = 1, maxLevelVertexBot(iVertex)
@@ -1075,32 +1521,18 @@ contains
                             fVertex(iVertex)/layerThicknessVertex
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nEdges = nEdgesHalo(2)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(normalizedRelativeVorticityEdge, &
-      !$acc            normalizedPlanetaryVorticityEdge, &
-      !$acc            normalizedRelativeVorticityVertex, &
-      !$acc            normalizedPlanetaryVorticityVertex, &
-      !&acc            minLevelEdgeTop, maxLevelEdgeBot, &
-      !$acc            verticesOnEdge) &
-      !$acc    private(k, vertex1, vertex2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, vertex1, vertex2)
-#endif
       do iEdge = 1, nEdges
          normalizedRelativeVorticityEdge (:,iEdge) = 0.0_RKIND
          normalizedPlanetaryVorticityEdge(:,iEdge) = 0.0_RKIND
          vertex1 = verticesOnEdge(1, iEdge)
          vertex2 = verticesOnEdge(2, iEdge)
-         !$acc loop seq
          do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
             normalizedRelativeVorticityEdge(k,iEdge) = 0.5_RKIND* &
                    (normalizedRelativeVorticityVertex(k,vertex1) &
@@ -1110,26 +1542,14 @@ contains
                   + normalizedPlanetaryVorticityVertex(k,vertex2))
         end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsHalo(1)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(normalizedRelativeVorticityCell, &
-      !$acc            normalizedRelativeVorticityVertex, &
-      !$acc            invAreaCell, kiteAreasOnVertex, &
-      !$acc            nEdgesOnCell, kiteIndexOnCell, &
-      !$acc            minLevelCell, maxLevelCell, verticesOnCell) &
-      !$acc    private(i, j, k, iVertex, invAreaCell1)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, j, k, iVertex, invAreaCell1)
-#endif
       do iCell = 1, nCells
          normalizedRelativeVorticityCell(:,iCell) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
@@ -1137,7 +1557,6 @@ contains
          do i = 1, nEdgesOnCell(iCell)
             j = kiteIndexOnCell(i, iCell)
             iVertex = verticesOnCell(i, iCell)
-            !$acc loop seq
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                normalizedRelativeVorticityCell(k,iCell) = &
                normalizedRelativeVorticityCell(k,iCell) + &
@@ -1147,10 +1566,8 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsAll
       nVertices = nVerticesAll
@@ -1163,26 +1580,12 @@ contains
          allocate( &
             vorticityGradientNormalComponent    (nVertLevels,nEdges), &
             vorticityGradientTangentialComponent(nVertLevels,nEdges))
-         !$acc enter data create(vorticityGradientNormalComponent, &
-         !$acc                   vorticityGradientTangentialComponent)
 
          nEdges = nEdgesHalo( 1 )
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(vorticityGradientNormalComponent, &
-         !$acc            vorticityGradientTangentialComponent, &
-         !$acc            normalizedRelativeVorticityCell, &
-         !$acc            normalizedRelativeVorticityVertex, &
-         !$acc            dcEdge, dvEdge, cellsOnEdge, verticesOnedge, &
-         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc            minLevelEdgeTop, maxLevelEdgeBot) &
-         !$acc    private(k, cell1, cell2, vertex1, vertex2, invLength)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, cell1, cell2, vertex1, vertex2, invLength)
-#endif
          do iEdge = 1,nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -1192,7 +1595,6 @@ contains
             ! Compute gradient of PV in normal direction
 
             invLength = 1.0_RKIND/dcEdge(iEdge)
-            !$acc loop seq
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                vorticityGradientNormalComponent(k,iEdge) = &
                   (normalizedRelativeVorticityCell(k,cell2) - &
@@ -1202,7 +1604,6 @@ contains
             ! Compute gradient of PV in the tangent direction
 
             invLength = 1.0_RKIND / dvEdge(iEdge)
-            !$acc loop seq
             do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
               vorticityGradientTangentialComponent(k,iEdge) = &
                  (normalizedRelativeVorticityVertex(k,vertex2) - &
@@ -1210,25 +1611,13 @@ contains
             enddo
 
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
 
          !
          ! Modify PV edge with upstream bias.
          !
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(normalizedRelativeVorticityEdge,      &
-         !$acc            vorticityGradientNormalComponent,     &
-         !$acc            vorticityGradientTangentialComponent, &
-         !$acc            normalVelocity, tangentialVelocity,   &
-         !$acc            minLevelEdgeTop, maxLevelEdgeBot)
-#else
          !$omp do schedule(runtime) private(k)
-#endif
          do iEdge = 1,nEdges
-            !$acc loop seq
             do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
                normalizedRelativeVorticityEdge(k,iEdge) = &
                normalizedRelativeVorticityEdge(k,iEdge) - &
@@ -1239,26 +1628,275 @@ contains
                      vorticityGradientTangentialComponent(k,iEdge) )
             end do
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
-         !$acc exit data delete(vorticityGradientNormalComponent, &
-         !$acc                  vorticityGradientTangentialComponent)
          deallocate(vorticityGradientNormalComponent, &
                     vorticityGradientTangentialComponent)
 
       endif
 
-      !$acc exit data delete(normalizedPlanetaryVorticityVertex, &
-      !$acc                  normalizedRelativeVorticityVertex)
       deallocate(normalizedPlanetaryVorticityVertex, &
                  normalizedRelativeVorticityVertex)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_vorticity!}}}
+
+   subroutine ocn_diagnostic_solve_vorticity_gpu(dt, &
+                         normalVelocity, tangentialVelocity, &
+                         layerThickness, relativeVorticity, &
+                         normalizedRelativeVorticityEdge, &
+                         normalizedPlanetaryVorticityEdge, &
+                         normalizedRelativeVorticityCell)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), intent(in) :: dt !< [in] Time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity,     &!< [in] velocity normal to edge
+         tangentialVelocity, &!< [in] velocity tangent to edge
+         layerThickness,     &!< [in] layer thickness
+         relativeVorticity    !< [in] relative vorticity at cell center
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         normalizedRelativeVorticityEdge,  &!< [out] rel vort at edge
+         normalizedPlanetaryVorticityEdge, &!< [out] planet vort edge
+         normalizedRelativeVorticityCell    !< [out] rel vort in cell
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, j, k,                   &! loop indices
+         iCell, iEdge, iVertex,     &! indices for cell, edge, vertex
+         nCells, nEdges, nVertices, &! number of cells, edges, vertices
+         vertex1, vertex2,          &! neighbor vertex addresses
+         cell1, cell2                ! neighbor cell   addresses
+
+      real(kind=RKIND) :: &
+         invAreaTri1,          &! 1/triangle area
+         invAreaCell1,         &! 1/cell area
+         invLength,            &! 1/length
+         layerThicknessVertex, &! layer thickness at vertex
+         apvm_scale_factor      ! scale factor for APVM form
+
+      ! Local arrays
+      ! normalizedPlanetaryVorticityVertex: earth's rotational rate
+      !   (Coriolis parameter, f) divided by layer thickness,
+      !   defined at vertices units: s^{-1}
+      ! normalizedRelativeVorticityVertex: curl of horizontal velocity
+      !   divided by layer thickness, defined at vertices units: s^{-1}
+      ! vorticityGradientNormalComponent: gradient of vorticity in the
+      !   normal direction (positive points from cell1 to cell2)
+      !   units: s^{-1} m^{-1}
+      ! vorticityGradientTangentialComponent: gradient of vorticity in
+      !   the tangent direction (positive points from vertex1 to vertex2)
+      !   units: s^{-1} m^{-1}
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         normalizedPlanetaryVorticityVertex,  &
+         normalizedRelativeVorticityVertex,   &
+         vorticityGradientNormalComponent,    &
+         vorticityGradientTangentialComponent
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !
+      ! Compute normalized relative and planetary vorticity
+      !
+      allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVerticesAll), &
+               normalizedRelativeVorticityVertex(nVertLevels, nVerticesAll))
+
+      nVertices = nVerticesHalo(2)
+
+!$acc data create(normalizedPlanetaryVorticityVertex,normalizedRelativeVorticityVertex)&
+!$acc      present(areaTriangle,maxLevelVertexBot,cellsOnVertex,kiteAreasOnVertex,fVertex,verticesOnEdge,&
+!$acc              minLevelEdgeTop,maxLevelEdgeBot,invAreaCell,nEdgesOnCell,kiteIndexOnCell,verticesOnCell,&
+!$acc              minLevelCell,maxLevelCell,&
+!$acc              normalVelocity,tangentialVelocity,layerThickness,relativeVorticity,&
+!$acc              normalizedRelativeVorticityEdge,normalizedPlanetaryVorticityEdge,normalizedRelativeVorticityCell)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
+!$acc parallel
+!$acc loop gang worker private(invAreaTri1)
+      do iVertex = 1, nVertices
+         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+!$acc loop vector private(layerThicknessVertex,iCell)
+         do k = 1, maxLevelVertexBot(iVertex)
+            layerThicknessVertex = 0.0_RKIND
+!$acc loop seq
+            do i = 1, vertexDegree
+               iCell = cellsOnVertex(i,iVertex)
+               layerThicknessVertex = layerThicknessVertex &
+                                    + layerThickness(k,iCell) &
+                                    * kiteAreasOnVertex(i,iVertex)
+            end do
+            layerThicknessVertex = layerThicknessVertex*invAreaTri1
+!NV!            if (layerThicknessVertex == 0) cycle
+            if (layerThicknessVertex /= 0) then
+
+            normalizedRelativeVorticityVertex(k,iVertex) = &
+                            relativeVorticity(k,iVertex) / &
+                            layerThicknessVertex
+            normalizedPlanetaryVorticityVertex(k,iVertex) = &
+                            fVertex(iVertex)/layerThicknessVertex
+            endif
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nEdges = nEdgesHalo(2)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, vertex1, vertex2)
+!$acc parallel
+!$acc loop gang worker private(vertex1,vertex2)
+      do iEdge = 1, nEdges
+!$acc loop vector
+         do k = 1, nVertLevels
+            normalizedRelativeVorticityEdge (k,iEdge) = 0.0_RKIND
+            normalizedPlanetaryVorticityEdge(k,iEdge) = 0.0_RKIND
+         enddo
+         vertex1 = verticesOnEdge(1, iEdge)
+         vertex2 = verticesOnEdge(2, iEdge)
+!$acc loop vector
+         do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
+            normalizedRelativeVorticityEdge(k,iEdge) = 0.5_RKIND* &
+                   (normalizedRelativeVorticityVertex(k,vertex1) &
+                  + normalizedRelativeVorticityVertex(k,vertex2))
+            normalizedPlanetaryVorticityEdge(k,iEdge) = 0.5_RKIND* &
+                   (normalizedPlanetaryVorticityVertex(k,vertex1) &
+                  + normalizedPlanetaryVorticityVertex(k,vertex2))
+        end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsHalo(1)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(i, j, k, iVertex, invAreaCell1)
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,j,iVertex) 
+      do iCell = 1, nCells
+!$acc loop vector
+         do k = 1, nVertLevels
+            normalizedRelativeVorticityCell(k,iCell) = 0.0_RKIND
+         enddo
+         invAreaCell1 = invAreaCell(iCell)
+!$acc loop vector
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+
+               normalizedRelativeVorticityCell(k,iCell) = &
+               normalizedRelativeVorticityCell(k,iCell) + &
+                                  kiteAreasOnVertex(j,iVertex)* &
+                  normalizedRelativeVorticityVertex(k,iVertex)* &
+                  invAreaCell1
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsAll
+      nVertices = nVerticesAll
+      nEdges = nEdgesAll
+      apvm_scale_factor = config_apvm_scale_factor
+
+      ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
+      if (config_apvm_scale_factor>1e-10) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_apvm_scale_factor NOT EXECUTING"
+
+         allocate( &
+            vorticityGradientNormalComponent    (nVertLevels,nEdges), &
+            vorticityGradientTangentialComponent(nVertLevels,nEdges))
+
+         nEdges = nEdgesHalo( 1 )
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, cell1, cell2, vertex1, vertex2, invLength)
+         do iEdge = 1,nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            vertex1 = verticesOnEdge(1, iEdge)
+            vertex2 = verticesOnEdge(2, iEdge)
+
+            ! Compute gradient of PV in normal direction
+
+            invLength = 1.0_RKIND/dcEdge(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+               vorticityGradientNormalComponent(k,iEdge) = &
+                  (normalizedRelativeVorticityCell(k,cell2) - &
+                   normalizedRelativeVorticityCell(k,cell1))*invLength
+            enddo
+
+            ! Compute gradient of PV in the tangent direction
+
+            invLength = 1.0_RKIND / dvEdge(iEdge)
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
+              vorticityGradientTangentialComponent(k,iEdge) = &
+                 (normalizedRelativeVorticityVertex(k,vertex2) - &
+                  normalizedRelativeVorticityVertex(k,vertex1))*invLength
+            enddo
+
+         enddo
+         !$omp end do
+
+         !
+         ! Modify PV edge with upstream bias.
+         !
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1,nEdges
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
+               normalizedRelativeVorticityEdge(k,iEdge) = &
+               normalizedRelativeVorticityEdge(k,iEdge) - &
+                    apvm_scale_factor*dt* &
+                    (normalVelocity(k,iEdge)* &
+                     vorticityGradientNormalComponent(k,iEdge)      &
+                   + tangentialVelocity(k,iEdge)* &
+                     vorticityGradientTangentialComponent(k,iEdge) )
+            end do
+         enddo
+         !$omp end do
+         !$omp end parallel
+
+         deallocate(vorticityGradientNormalComponent, &
+                    vorticityGradientTangentialComponent)
+
+      endif
+
+!$acc end data
+
+      deallocate(normalizedPlanetaryVorticityVertex, &
+                 normalizedRelativeVorticityVertex)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_vorticity_gpu!}}}
 
 !***********************************************************************
 !
@@ -1319,44 +1957,25 @@ contains
       ! Brunt-Vaisala frequency (this has units of s^{-2})
       !
       coef = -gravity / rho_sw
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(BruntVaisalaFreqTop, displacedDensity, density, zMid, maxLevelCell, &
-      !$acc                  minLevelCell) &
-      !$acc          private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCellsAll
          BruntVaisalaFreqTop(minLevelCell(iCell),iCell) = 0.0_RKIND
-#ifdef MPAS_OPENACC
-         !$acc loop seq
-#endif
          do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
             BruntVaisalaFreqTop(k,iCell) = coef * (displacedDensity(k-1,iCell) - density(k,iCell)) &
               / (zMid(k-1,iCell) - zMid(k,iCell))
           end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !
       ! Gradient Richardson number
       !
 
       nCells = nCellsHalo( 2 )
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(RiTopOfCell, maxLevelCell, nEdgesOnCell, edgesOnCell, normalVelocity, &
-      !$acc                  edgeAreaFractionOfCell, zMid, BruntVaisalaFreqTop, minLevelCell) &
-      !$acc          private(k, i, iEdge, delU2, shearSquared, shearMean)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, shearSquared, i, iEdge, delU2, shearMean)
-#endif
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
          do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
@@ -1373,12 +1992,112 @@ contains
           end do
           RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    end subroutine ocn_diagnostic_solve_richardson!}}}
+
+   subroutine ocn_diagnostic_solve_richardson_gpu(displacedDensity, density, zMid, &
+                normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        displacedDensity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        density
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        zMid
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        normalVelocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        edgeAreaFractionOfCell
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        BruntVaisalaFreqTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        RiTopOfCell
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real(kind=RKIND) :: coef, shearSquared, delU2, shearMean
+      integer :: iCell, k, i, iEdge
+      integer :: nCells
+
+      !
+      ! Brunt-Vaisala frequency (this has units of s^{-2})
+      !
+      coef = -gravity / rho_sw
+
+!$acc data present(minLevelCell,maxLevelCell,nEdgesOnCell,edgesOnCell,&
+!$acc              displacedDensity,density,zMid,normalVelocity,edgeAreaFractionOfCell,BruntVaisalaFreqTop,RiTopOfCell)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang worker 
+      do iCell = 1, nCellsAll
+         BruntVaisalaFreqTop(minLevelCell(iCell),iCell) = 0.0_RKIND
+!$acc loop vector
+         do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+            BruntVaisalaFreqTop(k,iCell) = coef * (displacedDensity(k-1,iCell) - density(k,iCell)) &
+              / (zMid(k-1,iCell) - zMid(k,iCell))
+          end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !
+      ! Gradient Richardson number
+      !
+
+      nCells = nCellsHalo( 2 )
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, shearSquared, i, iEdge, delU2, shearMean)
+!$acc parallel
+!$acc loop gang worker
+      do iCell=1,nCells
+         RiTopOfCell(:,iCell) = 100.0_RKIND
+!$acc loop vector private(shearSquared,iEdge,delU2,shearMean)
+         do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+           shearSquared = 0.0_RKIND
+!$acc loop seq
+           do i = 1, nEdgesOnCell(iCell)
+             iEdge = edgesOnCell(i, iCell)
+             delU2 = (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2
+             shearSquared = shearSquared + edgeAreaFractionOfCell(i,iCell) * delU2
+           enddo
+           ! Note that the factor of two is from averaging dot product to cell center on a C-grid
+           shearMean = sqrt(2.0_RKIND*shearSquared )
+           shearMean = shearMean / (zMid(k-1,iCell) - zMid(k,iCell))
+           RiTopOfCell(k,iCell) = BruntVaisalaFreqTop(k,iCell) / (shearMean**2 + 1.0e-10_RKIND)
+          end do
+          RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   end subroutine ocn_diagnostic_solve_richardson_gpu!}}}
 
 !***********************************************************************
 !
@@ -1455,27 +2174,15 @@ contains
 
          sfcLayerDepth = config_cvmix_kpp_surface_layer_averaging
          nTracers = size(activeTracers, dim=1)
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(tracersSurfaceLayerValue, activeTracers, &
-         !$acc            layerThickness, minLevelCell, maxLevelCell, &
-         !$acc            indexSurfaceLayerDepth) &
-         !$acc    private(k, kmin, kmax, ksfc, &
-         !$acc            rSfcLayer, sumSfcLayer, fracSfcLayer)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax, ksfc, &
          !$omp            rSfcLayer, sumSfcLayer, fracSfcLayer)
-#endif
          do iCell=1,nCellsOwned
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
             sumSfcLayer = 0.0_RKIND
             rSfcLayer = kmax
-#ifdef MPAS_OPENACC
-            !$acc loop seq
-#endif
             do k = kmin,kmax
                sumSfcLayer = sumSfcLayer + layerThickness(k,iCell)
                if (sumSfcLayer > sfcLayerDepth) then
@@ -1490,9 +2197,6 @@ contains
             fracSfcLayer = rSfcLayer - real(ksfc,RKIND)
 
             tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
-#ifdef MPAS_OPENACC
-            !$acc loop seq
-#endif
             do k=kmin,ksfc
             do n=1,nTracers
                tracersSurfaceLayerValue(n,iCell) = &
@@ -1509,28 +2213,15 @@ contains
                          layerThickness(k,iCell)) / sfcLayerDepth
             enddo
          enddo ! cell loop
-#ifndef MPAS_OPENACC
-         !$omp end do
-         !$omp end parallel
-#endif
 
          ! average normal velocity values over the ocean surface layer
          ! the ocean surface layer is generally assumed to be about 0.1
          !    of the boundary layer depth
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(normalVelocitySurfaceLayer, normalVelocity, &
-         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc            cellsOnEdge, layerThicknessEdgeFlux) &
-         !$acc    private(k, kmin, kmax, ksfc, cell1, cell2, &
-         !$acc            rSfcLayer, sumSfcLayer, fracSfcLayer)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax, ksfc, cell1, cell2, &
          !$omp            rSfcLayer, sumSfcLayer, fracSfcLayer)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -1539,9 +2230,6 @@ contains
             sumSfcLayer = 0.0_RKIND
             rSfcLayer   = min(kmin,kmax)
 
-#ifdef MPAS_OPENACC
-            !$acc loop seq
-#endif
             do k = kmin,kmax
                sumSfcLayer = sumSfcLayer + layerThicknessEdgeFlux(k,iEdge)
                if (sumSfcLayer > sfcLayerDepth) then
@@ -1556,9 +2244,6 @@ contains
             fracSfcLayer = rSfcLayer - real(ksfc,RKIND)
 
             normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
-#ifdef MPAS_OPENACC
-            !$acc loop seq
-#endif
             do k = kmin,ksfc
                normalVelocitySurfaceLayer(iEdge) = &
                normalVelocitySurfaceLayer(iEdge) + &
@@ -1573,10 +2258,8 @@ contains
                         layerThicknessEdgeFlux(k,iEdge)) / sfcLayerDepth
             end if
          enddo ! edge loop
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif ! KPP on
 
@@ -1584,28 +2267,224 @@ contains
 
       nCells = nCellsHalo( 1 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(surfaceFluxAttenuationCoefficient, &
-      !$acc            surfaceFluxAttenuationCoefficientRunoff)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCells
          surfaceFluxAttenuationCoefficient(iCell) = &
                       config_flux_attenuation_coefficient
          surfaceFluxAttenuationCoefficientRunoff(iCell) = &
                       config_flux_attenuation_coefficient_runoff
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_surfaceLayer !}}}
+
+   subroutine ocn_diagnostic_solve_surfaceLayer_gpu(layerThickness, &
+                activeTracers, layerThicknessEdgeFlux, normalVelocity, &
+                tracersSurfaceLayerValue, indexSurfaceLayerDepth, &
+                normalVelocitySurfaceLayer, &
+                surfaceFluxAttenuationCoefficient, &
+                surfaceFluxAttenuationCoefficientRunoff)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness,         &!< [in] layer thickness
+         layerThicknessEdgeFlux, &!< [in] layer thick at edge (flx form)
+         normalVelocity           !< [in] velocity
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         activeTracers            !< [in] tracers to be averaged
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         tracersSurfaceLayerValue     !< [out] tracer avg over sfc lyr
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         indexSurfaceLayerDepth,     &!< [out] layer index at sfc lyr depth
+         normalVelocitySurfaceLayer, &!< [out] avg velocity over sfc layer
+         surfaceFluxAttenuationCoefficient, &!< [out] sfc flx attenuation
+         surfaceFluxAttenuationCoefficientRunoff !< [out] sfc flx attenuation
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         nCells, nEdges,  &! num of cells, edges
+         n, nTracers,     &! num of tracers, tracer index
+         iCell, iEdge, k, &! loop indices for cell, edge vertical
+         kmin, kmax, ksfc,&! vertical indices for active, sfc layers
+         cell1, cell2      ! neighbor cell indices across edge
+
+      real(kind=RKIND) :: &
+         sfcLayerDepth,   &! surface layer depth
+         sumSfcLayer,     &! running sum of depth for sfc lyr calc
+         fracSfcLayer,    &! fraction of layer in which sfc layer exists
+         rSfcLayer         ! real vertical layer index for sfc lyr
+
+      logical :: tmp
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! average tracer values over the ocean surface layer
+      ! the ocean surface layer is generally assumed to be about 0.1 of
+      !    the boundary layer depth
+
+!$acc data present(minLevelCell,maxLevelCell,cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,&
+!$acc              layerThickness,activeTracers,layerThicknessEdgeFlux,normalVelocity,&
+!$acc              tracersSurfaceLayerValue,indexSurfaceLayerDepth,normalVelocitySurfaceLayer,&
+!$acc              surfaceFluxAttenuationCoefficient,surfaceFluxAttenuationCoefficientRunoff)
+
+      ! sfc layer averages currently only used when KPP on
+      if (config_use_cvmix_kpp) then
+
+         sfcLayerDepth = config_cvmix_kpp_surface_layer_averaging
+         nTracers = size(activeTracers, dim=1)
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax, ksfc, &
+         !$omp            rSfcLayer, sumSfcLayer, fracSfcLayer)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,sumSfcLayer,rSfcLayer,ksfc,fracSfcLayer,k,tmp)
+         do iCell=1,nCellsOwned
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            sumSfcLayer = 0.0_RKIND
+            rSfcLayer = kmax
+            tmp = .true.
+!$acc loop seq
+            do k = kmin,kmax
+!NV!               sumSfcLayer = sumSfcLayer + layerThickness(k,iCell)
+!NV!               if (sumSfcLayer > sfcLayerDepth) then
+               if (sumSfcLayer+layerThickness(k,iCell) > sfcLayerDepth) then
+!NV!                  sumSfcLayer = sumSfcLayer - layerThickness(k,iCell)
+                  if(tmp) then 
+                     rSfcLayer = (k-1) + (sfcLayerDepth - sumSfcLayer)/ &
+                                       layerThickness(k,iCell)
+                     tmp = .false.
+                  endif
+!NV!                  exit
+               else
+                  sumSfcLayer = sumSfcLayer + layerThickness(k,iCell)
+               endif
+            end do ! k
+            indexSurfaceLayerDepth(iCell) = rSfcLayer
+            ksfc = int(rSfcLayer)
+            fracSfcLayer = rSfcLayer - real(ksfc,RKIND)
+
+            tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
+!$acc loop seq
+            do k=kmin,ksfc
+!$acc loop vector
+            do n=1,nTracers
+               tracersSurfaceLayerValue(n,iCell) = &
+               tracersSurfaceLayerValue(n,iCell) + &
+                        activeTracers(n,k,iCell)*layerThickness(k,iCell)
+            enddo
+            enddo
+
+            k = min(ksfc+1, kmax)
+!$acc loop vector
+            do n=1,nTracers
+               tracersSurfaceLayerValue(n,iCell) = &
+              (tracersSurfaceLayerValue(n,iCell) + &
+                         fracSfcLayer*activeTracers(n,k,iCell)* &
+                         layerThickness(k,iCell)) / sfcLayerDepth
+            enddo
+         enddo ! cell loop
+!$acc end parallel
+
+         ! average normal velocity values over the ocean surface layer
+         ! the ocean surface layer is generally assumed to be about 0.1
+         !    of the boundary layer depth
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax, ksfc, cell1, cell2, &
+         !$omp            rSfcLayer, sumSfcLayer, fracSfcLayer)
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,kmin,kmax,sumSfcLayer,rSfcLayer,ksfc,fracSfcLayer,k,tmp)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            kmin  = minLevelEdgeBot(iEdge)
+            kmax  = maxLevelEdgeTop(iEdge)
+            sumSfcLayer = 0.0_RKIND
+            rSfcLayer   = min(kmin,kmax)
+            tmp = .true.
+!$acc loop seq
+            do k = kmin,kmax
+!NV!               sumSfcLayer = sumSfcLayer + layerThicknessEdgeFlux(k,iEdge)
+!NV!               if (sumSfcLayer > sfcLayerDepth) then
+               if (sumSfcLayer+layerThicknessEdgeFlux(k,iEdge) > sfcLayerDepth) then
+!NV!                  sumSfcLayer = sumSfcLayer - layerThicknessEdgeFlux(k,iEdge)
+                  if(tmp) then
+                     rSfcLayer = (k-1) + (sfcLayerDepth - sumSfcLayer)/ &
+                                       layerThicknessEdgeFlux(k,iEdge)
+                     tmp = .false.
+                  endif
+!NV!                  exit
+               else
+                  sumSfcLayer = sumSfcLayer + layerThicknessEdgeFlux(k,iEdge)
+               endif
+            end do ! k
+            ksfc = int(rSfcLayer)
+            fracSfcLayer = rSfcLayer - real(ksfc,RKIND)
+
+            normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
+!$acc loop seq
+            do k = kmin,ksfc
+               normalVelocitySurfaceLayer(iEdge) = &
+               normalVelocitySurfaceLayer(iEdge) + &
+                                       normalVelocity(k,iEdge)* &
+                                       layerThicknessEdgeFlux(k,iEdge)
+            end do
+            k = ksfc+1
+            if (k <= kmax) then
+               normalVelocitySurfaceLayer(iEdge) = &
+              (normalVelocitySurfaceLayer(iEdge) + &
+                        fracSfcLayer*normalVelocity(k,iEdge)* &
+                        layerThicknessEdgeFlux(k,iEdge)) / sfcLayerDepth
+            end if
+         enddo ! edge loop
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+      endif ! KPP on
+
+      ! compute the attenuation coefficient for surface fluxes
+
+      nCells = nCellsHalo( 1 )
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector 
+      do iCell = 1, nCells
+         surfaceFluxAttenuationCoefficient(iCell) = &
+                      config_flux_attenuation_coefficient
+         surfaceFluxAttenuationCoefficientRunoff(iCell) = &
+                      config_flux_attenuation_coefficient_runoff
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_surfaceLayer_gpu !}}}
 
 !***********************************************************************
 !
@@ -1665,26 +2544,14 @@ contains
       if (.not. config_use_gm) return
 
       allocate(div_huGMBolus(nVertLevels))
-      !$acc enter data create(div_huGMBolus)
 
       ! Compute vertical velocity from the divergence of horizontal GM
       ! Bolus velocity
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(vertGMBolusVelocityTop, &
-      !$acc            normalGMBolusVelocity, layerThickEdgeFlux, &
-      !$acc            dvEdge, invAreaCell, edgeSignOnCell, &
-      !$acc            nEdgesOnCell, edgesOnCell, &
-      !$acc            minLevelCell, maxLevelCell) &
-      !$acc    private(div_huGMBolus, i, k, kmin, kmax, iEdge, &
-      !$acc            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(div_huGMBolus, i, k, kmin, kmax, iEdge, &
       !$omp            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
-#endif
       do iCell = 1, nCellsOwned
          div_huGMBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
@@ -1711,17 +2578,119 @@ contains
             vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(div_huGMBolus)
       deallocate(div_huGMBolus)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_GMvel!}}}
+
+   subroutine ocn_diagnostic_solve_GMvel_gpu(layerThickEdgeFlux, &
+                                         normalGMBolusVelocity, &
+                                         vertGMBolusVelocityTop)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeFlux,     &!< [in] thickness flux at edge
+         normalGMBolusVelocity    !< [in] Bolus velocity normal to edge
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertGMBolusVelocityTop !< [out] Bolus vertical velocity at top
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, k,         &! loop indices for neighbors, vertical levels
+         iCell, iEdge, &! addresses for cells, edges
+         eoe,          &! address for edges on edge
+         kmin, kmax,   &! min, max indices of active vert layers
+         edgeSignOnCell_temp ! directional sign across edge
+
+      real(kind=RKIND) :: &
+         invAreaCell1, &! 1/cell area
+         dvEdge_temp    ! local value of dvEdge
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         div_huGMBolus ! divergence of thick-weighted Bolus velocity
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Return immediately if not needed
+      if (.not. config_use_gm) return
+
+      allocate(div_huGMBolus(nVertLevels))
+
+!$acc data create(div_huGMBolus) &
+!$acc      present(invAreaCell,minLevelCell,maxLevelCell,nEdgesOnCell,edgesOnCell,edgeSignOnCell,dvEdge,&
+!$acc              layerThickEdgeFlux,normalGMBolusVelocity,vertGMBolusVelocityTop)
+
+      ! Compute vertical velocity from the divergence of horizontal GM
+      ! Bolus velocity
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(div_huGMBolus, i, k, kmin, kmax, iEdge, &
+      !$omp            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,kmin,kmax,iEdge,edgeSignOnCell_temp,dvEdge_temp)
+      do iCell = 1, nCellsOwned
+!$acc loop vector
+         do k = 1, nVertLevels
+            div_huGMBolus(k) = 0.0_RKIND
+         enddo
+         invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dvEdge_temp = dvEdge(iEdge)
+!$acc loop vector
+            do k = kmin, kmax
+               ! Compute vertical velocity from the horizontal GM Bolus velocity
+               div_huGMBolus(k) = div_huGMBolus(k) &
+                                - layerThickEdgeFlux(k,iEdge)* &
+                                  edgeSignOnCell_temp*dvEdge_temp* &
+                                  normalGMBolusVelocity(k,iEdge)* &
+                                  invAreaCell1
+            end do
+         end do
+         ! Vertical velocity at bottom is zero, initialized above.
+!$acc loop vector
+         do k = 1, kmin-1
+            vertGMBolusVelocityTop(k,iCell) = 0.0_RKIND
+         enddo
+         vertGMBolusVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+!$acc loop seq
+         do k = kmax, 1, -1
+            vertGMBolusVelocityTop(k,iCell) = &
+            vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(div_huGMBolus)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_GMvel_gpu!}}}
 
 !***********************************************************************
 !
@@ -1779,26 +2748,14 @@ contains
       if (.not. config_submesoscale_enable) return
 
       allocate(div_huMLEBolus(nVertLevels))
-      !$acc enter data create(div_huMLEBolus)
 
       ! Compute vertical velocity from the divergence of horizontal MLE
       ! (submesoscale eddy)  Bolus velocity
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(vertMLEBolusVelocityTop, &
-      !$acc            normalMLEVelocity, layerThickEdgeFlux, &
-      !$acc            dvEdge, invAreaCell, edgeSignOnCell, &
-      !$acc            nEdgesOnCell, edgesOnCell, &
-      !$acc            minLevelCell, maxLevelCell) &
-      !$acc    private(div_huMLEBolus, i, k, kmin, kmax, iEdge, &
-      !$acc            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(div_huMLEBolus, i, k, kmin, kmax, iEdge, &
       !$omp            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
-#endif
       do iCell = 1, nCellsOwned
          div_huMLEBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
@@ -1824,12 +2781,9 @@ contains
             vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(div_huMLEBolus)
       deallocate(div_huMLEBolus)
 
    !--------------------------------------------------------------------
@@ -1908,18 +2862,9 @@ contains
 
       ! Compute relative vorticity in cells
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(relativeVorticityCell, relativeVorticity, &
-      !$acc            invAreaCell, kiteAreasOnVertex, &
-      !$acc            nEdgesOnCell, kiteIndexOnCell, verticesOnCell, &
-      !$acc            minLevelCell, maxLevelCell) &
-      !$acc    private(i, iVertex, j, k, kmin, kmax, invAreaCell1) 
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, iVertex, j, k, kmin, kmax, invAreaCell1) 
-#endif
       do iCell = 1, nCellsOwned
          relativeVorticityCell(:,iCell) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
@@ -1937,10 +2882,8 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       ! Need 0,1,2 halo cells
       nCells = nCellsHalo(2)
@@ -1949,26 +2892,12 @@ contains
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels))
-      !$acc enter data create(div_hu, div_huTransport)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(divergence, kineticEnergyCell, &
-      !$acc            vertVelocityTop, vertTransportVelocityTop, &
-      !$acc            normalVelocity, normalTransportVelocity, &
-      !$acc            layerThicknessEdgeFlux, dcEdge, dvEdge, &
-      !$acc            invAreaCell, nEdgesOnCell, edgesOnCell, &
-      !$acc            edgeSignOnCell, minLevelCell, maxLevelCell) &
-      !$acc    private(div_hu, div_huTransport, i, k, kmin, kmax, & 
-      !$acc            iEdge, invAreaCell1, r_tmp, dcEdge_temp, & 
-      !$acc            dvEdge_temp, edgeSignOnCell_temp)  
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(div_hu, div_huTransport, i, k, kmin, kmax, & 
       !$omp            iEdge, invAreaCell1, r_tmp, dcEdge_temp, & 
       !$omp            dvEdge_temp, edgeSignOnCell_temp)  
-#endif
       do iCell = 1, nCells
          divergence(:,iCell) = 0.0_RKIND
          kineticEnergyCell(:,iCell) = 0.0_RKIND
@@ -2012,29 +2941,18 @@ contains
             vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(div_hu, div_huTransport)
       deallocate(div_hu,div_huTransport)
 
       ! Compute tangential velocity
 
       nEdges = nEdgesHalo(2)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc    present(tangentialVelocity, normalVelocity, &
-      !$acc            weightsOnEdge, nEdgesOnEdge, edgesOnEdge, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop) &
-      !$acc    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
-#endif
       do iEdge = 1, nEdges
          tangentialVelocity(:,iEdge) = 0.0_RKIND
          kmin = minLevelEdgeBot(iEdge)
@@ -2049,14 +2967,222 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
+
+   subroutine ocn_diagnostic_solve_vortVel_gpu( &
+                           relativeVorticity, layerThicknessEdgeFlux, &
+                           normalVelocity, normalTransportVelocity, &
+                           vertVelocityTop, vertTransportVelocityTop, &
+                           relativeVorticityCell, divergence, &
+                           kineticEnergyCell, tangentialVelocity)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         relativeVorticity,      &!< [in] relative vorticity in cells
+         layerThicknessEdgeFlux, &!< [in] thickness flux at edge
+         normalVelocity,         &!< [in] velocity normal to edge
+         normalTransportVelocity  !< [in] transport vel normal to edge
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         vertVelocityTop,       &!< [out] vertical velocity top of cell
+         vertTransportVelocityTop, &!< [out] vert transport vel at top
+         relativeVorticityCell, &!< [out] relative vorticity in cell
+         divergence,            &!< [out] divergence
+         kineticEnergyCell,     &!< [out] kinetic energy in cell
+         tangentialVelocity      !< [out] tangential velocity at edge
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, j, k,               &! loop indices
+         iCell, iVertex, iEdge, &! indices for cells, vertices, edges
+         nCells, nEdges,        &! number of cells, edges
+         kmin, kmax,            &! min, max active vert level index
+         eoe,                   &! index for edge on edge
+         edgeSignOnCell_temp     ! local tmp for sign across edge
+
+      real(kind=RKIND) :: &
+         invAreaCell1,      &! 1/cell area
+         dcEdge_temp,       &! local val of dcEdge
+         dvEdge_temp,       &! local val of dvEdge
+         r_tmp,             &! tmp for common factors
+         weightsOnEdge_temp  ! local tmp for weights on edge
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         div_hu,         &! local divergence of thick-weighted velocity
+         div_huTransport  ! local div of thick-weighted transport vel
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      allocate(div_hu(nVertLevels),div_huTransport(nVertLevels))
+
+!$acc data create(div_hu,div_huTransport)&
+!$acc      present(invAreaCell,minLevelCell,maxLevelCell,nEdgesOnCell,kiteIndexOnCell,verticesOnCell,kiteAreasOnVertex,&
+!$acc              edgesOnCell,edgeSignOnCell,dcEdge,dvEdge,minLevelEdgeBot,maxLevelEdgeTop,nEdgesOnEdge,edgesOnEdge,&
+!$acc              weightsOnEdge,&
+!$acc              relativeVorticity,layerThicknessEdgeFlux,normalVelocity,normalTransportVelocity,&
+!$acc              vertVelocityTop,vertTransportVelocityTop,relativeVorticityCell,divergence,kineticEnergyCell,tangentialVelocity)
+
+      ! Compute relative vorticity in cells
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(i, iVertex, j, k, kmin, kmax, invAreaCell1) 
+!$acc parallel
+!$acc loop gang private(invAreaCell1,kmin,kmax,j,iVertex)
+      do iCell = 1, nCellsOwned
+!$acc loop vector
+         do k = 1,nVertLevels
+            relativeVorticityCell(k,iCell) = 0.0_RKIND
+         enddo
+         invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+
+!$acc loop vector
+            do k = kmin,kmax
+
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+
+               relativeVorticityCell(k,iCell) = &
+               relativeVorticityCell(k,iCell) + &
+                        kiteAreasOnVertex(j,iVertex)* &
+                        relativeVorticity(k,iVertex)*invAreaCell1
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      ! Need 0,1,2 halo cells
+      nCells = nCellsHalo(2)
+
+      !
+      ! Compute divergence, kinetic energy, and vertical velocity
+      !
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(div_hu, div_huTransport, i, k, kmin, kmax, & 
+      !$omp            iEdge, invAreaCell1, r_tmp, dcEdge_temp, & 
+      !$omp            dvEdge_temp, edgeSignOnCell_temp)  
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,kmin,kmax,iEdge,edgeSignOnCell_temp,dcEdge_temp,dvEdge_temp)
+      do iCell = 1, nCells
+!$acc loop vector
+         do k = 1, nVertLevels
+            divergence(k,iCell) = 0.0_RKIND
+            kineticEnergyCell(k,iCell) = 0.0_RKIND
+            div_hu(k) = 0.0_RKIND
+            div_huTransport(k) = 0.0_RKIND
+         enddo
+         invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dcEdge_temp = dcEdge(iEdge)
+            dvEdge_temp = dvEdge(iEdge)
+!$acc loop vector private(r_tmp)
+            do k = kmin,kmax
+               r_tmp = dvEdge_temp*normalVelocity(k,iEdge)*invAreaCell1
+
+               divergence(k,iCell) = divergence(k,iCell) &
+                                   - edgeSignOnCell_temp*r_tmp
+               div_hu(k) = div_hu(k) &
+                         - layerThicknessEdgeFlux(k,iEdge)* &
+                           edgeSignOnCell_temp*r_tmp
+               div_huTransport(k) = div_huTransport(k) &
+                                  - layerThicknessEdgeFlux(k,iEdge)* &
+                                    edgeSignOnCell_temp*dvEdge_temp* &
+                                    normalTransportVelocity(k,iEdge)* &
+                                    invAreaCell1
+               kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) &
+                                          + 0.25*r_tmp*dcEdge_temp* &
+                                            normalVelocity(k,iEdge)
+            end do
+         end do
+         ! Vertical velocity at bottom is zero, initialized above.
+!$acc loop vector
+         do k = 1, kmin-1
+            vertVelocityTop(k,iCell) = 0.0_RKIND
+            vertTransportVelocityTop(k,iCell) = 0.0_RKIND
+         enddo
+         vertVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+         vertTransportVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+!$acc loop seq
+         do k = kmax, 1, -1
+            vertVelocityTop(k,iCell) = &
+            vertVelocityTop(k+1,iCell) - div_hu(k)
+            vertTransportVelocityTop(k,iCell) = &
+            vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+
+      ! Compute tangential velocity
+
+      nEdges = nEdgesHalo(2)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,eoe,weightsOnEdge_temp)
+      do iEdge = 1, nEdges
+!$acc loop vector
+         do k = 1, nVertLevels
+            tangentialVelocity(k,iEdge) = 0.0_RKIND
+         enddo
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+!$acc loop seq
+         do i = 1, nEdgesOnEdge(iEdge)
+            eoe = edgesOnEdge(i,iEdge)
+            weightsOnEdge_temp = weightsOnEdge(i, iEdge)
+!$acc loop vector
+            do k = kmin,kmax
+               tangentialVelocity(k,iEdge) = &
+               tangentialVelocity(k,iEdge) + weightsOnEdge_temp* &
+                                             normalVelocity(k, eoe)
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(div_hu,div_huTransport)
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_vortVel_gpu!}}}
 
 !***********************************************************************
 !
@@ -2199,68 +3325,137 @@ contains
       ! sea ice, frazil ice or the weight of an ice shelf
       ! The latter two are only available when those options are on.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(surfacePressure, atmosphericPressure, &
-      !$acc            seaIcePressure)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
 
          surfacePressure(iCell) = atmosphericPressure(iCell) &
                                 + seaIcePressure(iCell)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! Add frazil component if needed
       if ( associated(frazilSurfacePressure) ) then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(surfacePressure, frazilSurfacePressure)
-#else
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nCellsAll
             surfacePressure(iCell) = surfacePressure(iCell) &
                                    + frazilSurfacePressure(iCell)
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
       endif ! frazil pressure
 
       ! Add land ice pressure if needed
 
       if (landIcePressureOn) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(surfacePressure, landIcePressure)
-         !!acc    present(surfacePressure)
-         !! need this eventually, but there is currently
-         !! an issue, probably with the re-retrieval of pointer
-#else
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nCellsAll
             surfacePressure(iCell) = surfacePressure(iCell) &
                                    + landIcePressure(iCell)
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
       endif ! land ice pressure
-#ifndef MPAS_OPENACC
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_surface_pressure!}}}
+
+   subroutine ocn_diagnostic_solve_surface_pressure_gpu(forcingPool, &
+               atmosphericPressure, seaIcePressure, surfacePressure)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         forcingPool         !< [in] Forcing information
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         atmosphericPressure, &!< [in] atmospheric pressure on surface
+         seaIcePressure        !< [in] sea-ice pressure on surface
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         surfacePressure       !< [out] total surface pressure
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: iCell ! cell loop index
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         frazilSurfacePressure, &! frazil ice pressure from forcing
+         landIcePressure         ! land ice pressure
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Pressure
+      !
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', &
+                                             frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', &
+                                             landIcePressure)
+
+!$acc data present(surfacePressure,atmosphericPressure,seaIcePressure,frazilSurfacePressure,&
+!$acc              landIcePressure)
+
+      ! Compute pressure for generalized coordinates.
+      ! Pressure at top surface may be due to atmospheric pressure,
+      ! sea ice, frazil ice or the weight of an ice shelf
+      ! The latter two are only available when those options are on.
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+      do iCell = 1, nCellsAll
+
+         surfacePressure(iCell) = atmosphericPressure(iCell) &
+                                + seaIcePressure(iCell)
+      end do
+!$acc end parallel
+      !$omp end do
+
+      ! Add frazil component if needed
+      if ( associated(frazilSurfacePressure) ) then
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+         do iCell = 1, nCellsAll
+            surfacePressure(iCell) = surfacePressure(iCell) &
+                                   + frazilSurfacePressure(iCell)
+         end do
+!$acc end parallel
+         !$omp end do
+      endif ! frazil pressure
+
+      ! Add land ice pressure if needed
+
+      if (landIcePressureOn) then
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+         do iCell = 1, nCellsAll
+            surfacePressure(iCell) = surfacePressure(iCell) &
+                                   + landIcePressure(iCell)
+         end do
+!$acc end parallel
+         !$omp end do
+      endif ! land ice pressure
+      !$omp end parallel
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_surface_pressure_gpu!}}}
 
 !***********************************************************************
 !
@@ -2312,15 +3507,8 @@ contains
 
       nCells = nCellsAll
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(maxLevelCell, zMid, layerThickness, zTop, bottomDepth, ssh, &
-      !$acc                  minLevelCell) &
-      !$acc          private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCells
 
          ! Compute zMid, the z-coordinate of the middle of the layer.
@@ -2343,12 +3531,88 @@ contains
          ssh(iCell) = zTop(minLevelCell(iCell),iCell)
 
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    end subroutine ocn_diagnostic_solve_z_coordinates!}}}
+
+   subroutine ocn_diagnostic_solve_z_coordinates_gpu(layerThickness, zMid, zTop, ssh)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zMid
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zTop
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         ssh
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells
+      integer :: iCell
+      integer :: k
+
+      nCells = nCellsAll
+
+!$acc data present(maxLevelCell,bottomDepth,minLevelCell,&
+!$acc              layerThickness,zMid,zTop,ssh)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang worker
+      do iCell = 1, nCells
+
+         ! Compute zMid, the z-coordinate of the middle of the layer.
+         ! Compute zTop, the z-coordinate of the top of the layer.
+         ! Note the negative sign, since bottomDepth is positive
+         ! and z-coordinates are negative below the surface.
+!NV!         k = maxLevelCell(iCell)
+!$acc loop vector
+         do k = maxLevelCell(iCell), nVertLevels
+            zMid(k,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
+            zTop(k,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
+         enddo
+!$acc loop seq
+         do k = maxLevelCell(iCell)-1, minLevelCell(iCell), -1
+            zMid(k,iCell) = zMid(k+1,iCell)  &
+              + 0.5_RKIND*(  layerThickness(k+1,iCell) &
+                           + layerThickness(k  ,iCell))
+            zTop(k,iCell) = zTop(k+1,iCell)  &
+              + layerThickness(k  ,iCell)
+         end do
+
+         ! copy zTop(1,iCell) into sea-surface height array
+         ssh(iCell) = zTop(minLevelCell(iCell),iCell)
+
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   end subroutine ocn_diagnostic_solve_z_coordinates_gpu!}}}
 
 !***********************************************************************
 !
@@ -2410,17 +3674,9 @@ contains
       if (config_pressure_gradient_type == 'MontgomeryPotential') then
 
          allocate(pTop(nVertLevels))
-         !$acc enter data create(pTop)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(montgomeryPotential, density, bottomDepth, & 
-         !$acc            layerThickness, minLevelCell) &
-         !$acc    private(pTop, k, kmin)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(pTop, k, kmin)
-#endif
          do iCell = 1, nCells
 
             ! assume atmospheric pressure at surface is zero for now
@@ -2444,12 +3700,9 @@ contains
             end do
 
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
-         !$acc exit data delete(pTop)
          deallocate(pTop)
 
       !
@@ -2458,15 +3711,8 @@ contains
 
       else
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(pressure, surfacePressure, density, &
-         !$acc            layerThickness, minLevelCell, maxLevelCell) &
-         !$acc    private(k, kmin, kmax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
          do iCell = 1, nCells
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -2481,16 +3727,134 @@ contains
                      + density(k  ,iCell)*layerThickness(k  ,iCell))
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_pressure!}}}
+
+   subroutine ocn_diagnostic_solve_pressure_gpu(layerThickness, density, &
+                surfacePressure, montgomeryPotential, pressure)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness, &!< [in] layer thickness
+         density          !< [in] density
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         surfacePressure  !< [in] pressure at surface
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         montgomeryPotential, &!< [out] Montgomery potential at all lvls
+         pressure              !< [out] pressure at all levels
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         nCells,    &! number of cells
+         iCell, k,  &! cell, vertical loop indices
+         kmin, kmax  ! min, max active vertical levels
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         pTop      ! local pressure at top of layer
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !
+      ! If needed, compute Montgomery potential
+      !   This is the preferred option when layers are isopycnal though
+      !     pressure_and_zmid option can be used for isopycnal as well
+      !
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              pressure,surfacePressure,density,layerThickness)
+
+      nCells = nCellsAll
+      if (config_pressure_gradient_type == 'MontgomeryPotential') then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_diagnostic_solve_pressure_gpu config_pressure_gradient_type NOT EXECUTING"
+
+         allocate(pTop(nVertLevels))
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(pTop, k, kmin)
+         do iCell = 1, nCells
+
+            ! assume atmospheric pressure at surface is zero for now
+            pTop(1) = 0.0_RKIND
+            ! At top layer it is g*SSH, where SSH may be off by a
+            ! constant (ie, bottomDepth can be relative to top or bottom)
+            kmin = minLevelCell(iCell)
+            montgomeryPotential(kmin,iCell) = gravity &
+                   * (bottomDepth(iCell) + &
+                      sum(layerThickness(1:nVertLevels,iCell)))
+
+            do k = 2, nVertLevels
+               pTop(k) = pTop(k-1) + density(k-1,iCell)*gravity* &
+                              layerThickness(k-1,iCell)
+
+               ! from delta M = p delta / density
+               montgomeryPotential(k  ,iCell) = &
+               montgomeryPotential(k-1,iCell) + pTop(k)* &
+                             (1.0_RKIND/density(k  ,iCell) -  &
+                              1.0_RKIND/density(k-1,iCell))
+            end do
+
+         end do
+         !$omp end do
+         !$omp end parallel
+
+         deallocate(pTop)
+
+      !
+      ! Otherwise, compute pressure for generalized coordinates.
+      !
+
+      else
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax)
+!$acc parallel
+!$acc loop gang vector private(kmin,kmax)
+         do iCell = 1, nCells
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            pressure(kmin,iCell) = surfacePressure(iCell) &
+                                 + density(kmin,iCell)*gravity* &
+                                   0.5_RKIND*layerThickness(kmin,iCell)
+!$acc loop seq
+            do k = kmin+1, kmax
+               pressure(k,iCell) = pressure(k-1,iCell) &
+                                 + 0.5_RKIND*gravity* &
+                    (  density(k-1,iCell)*layerThickness(k-1,iCell) &
+                     + density(k  ,iCell)*layerThickness(k  ,iCell))
+            end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+      endif
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_pressure_gpu!}}}
 
 !***********************************************************************
 !
@@ -2544,62 +3908,132 @@ contains
       integer :: cell1, cell2
 
       nCells = nCellsHalo( 1 )
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(seaIcePressure, pressureAdjustedSSH, ssh)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCells
          pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       if (landIcePressureOn) then
-#ifdef MPAS_OPENACC
-         !! This first directive should be correct, but there may
-         !! be a problem with the optional argument. Removing optional
-         !! landIceDraft from the present list for now.
-         !$acc parallel loop present(pressureAdjustedSSH, landIceDraft)
-         !!acc parallel loop present(pressureAdjustedSSH)
-#else
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nCells
             ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
             ! toward land ice
             pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
       nEdges = nEdgesHalo( 1 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(pressureAdjustedSSH, dcEdge, cellsOnEdge, edgeMask, gradSSH)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2)
-#endif
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
 
          gradSSH(iEdge) = edgeMask(minLevelEdgeBot(iEdge), iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    end subroutine ocn_diagnostic_solve_ssh!}}}
+
+   subroutine ocn_diagnostic_solve_ssh_gpu(forcingPool, ssh, seaIcePressure, &
+                pressureAdjustedSSH, gradSSH, landIceDraft)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         ssh
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         seaIcePressure
+      real (kind=RKIND), dimension(:), optional, intent(in) :: &
+         landIceDraft
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         pressureAdjustedSSH
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         gradSSH
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iEdge
+      integer :: cell1, cell2
+
+      nCells = nCellsHalo( 1 )
+
+!$acc data present(cellsOnEdge,edgeMask,minLevelEdgeBot,dcEdge,&
+!$acc              ssh,seaIcePressure,landIceDraft,&
+!$acc              pressureAdjustedSSH,gradSSH)
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+      do iCell = 1, nCells
+         pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      if (landIcePressureOn) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+         do iCell = 1, nCells
+            ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
+            ! toward land ice
+            pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      end if
+
+      nEdges = nEdgesHalo( 1 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2)
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2)
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         gradSSH(iEdge) = edgeMask(minLevelEdgeBot(iEdge), iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   end subroutine ocn_diagnostic_solve_ssh_gpu!}}}
 
 !***********************************************************************
 !
@@ -2680,14 +4114,12 @@ contains
       if (config_vert_coord_movement == 'impermeable_interfaces' .or. &
           configVertAdvMethod == vertAdvRemap) then
          vertAleTransportTop = 0.0_RKIND
-         !$acc update device(vertAleTransportTop)
          return
       end if
 
       allocate(div_hu(nVertLevels, nCellsAll), &
                projectedSSH(nCellsAll), &
                ALE_Thickness(nVertLevels, nCellsAll))
-      !$acc enter data create(projectedSSH, ALE_Thickness, div_hu)
 
       ! Only need to compute over 0 and 1 halos
       nCells = nCellsHalo( 1 )
@@ -2696,20 +4128,10 @@ contains
       ! thickness-weighted divergence and barotropic divergence
       !
       ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(projectedSSH, oldSSH, normalVelocity, div_hu, &
-      !$acc            layerThicknessEdgeFlux, dvEdge, invAreaCell, &
-      !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop) &
-      !$acc    private(i, iEdge, k, kmin, kmax, div_hu_btr, &
-      !$acc            invAreaCell1, flux)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, iEdge, k, kmin, kmax, div_hu_btr, &
       !$omp            invAreaCell1, flux)
-#endif
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
          div_hu_btr      = 0.0_RKIND
@@ -2729,10 +4151,8 @@ contains
          end do
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !
       ! Compute desired thickness at new time
@@ -2753,15 +4173,8 @@ contains
       ! equation for vertAleTransportTop ($w^t$), and using
       ! ALE_Thickness for thickness at the new time.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(vertAleTransportTop, ALE_Thickness, &
-      !$acc                  oldLayerThickness, div_hu, &
-      !$acc                  minLevelCell, maxLevelCell)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1,nCells
          vertAleTransportTop(1,iCell) = 0.0_RKIND
          vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
@@ -2772,12 +4185,9 @@ contains
                         oldLayerThickness(k,iCell))/dt
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(projectedSSH, ALE_Thickness, div_hu)
       deallocate(div_hu, &
                  projectedSSH, &
                  ALE_Thickness)
@@ -2785,6 +4195,169 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vert_transport_velocity_top!}}}
+
+   subroutine ocn_vert_transport_velocity_top_gpu(verticalMeshPool, &
+                     oldLayerThickness, layerThicknessEdgeFlux, &
+                     normalVelocity, oldSSH, dt, vertAleTransportTop, &
+                     err, newHighFreqThickness)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         verticalMeshPool         !< [in] vertical mesh information
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         oldSSH                   !< [in] sea surface height at old time
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         oldLayerThickness,      &!< [in] layer thickness at old time
+         layerThicknessEdgeFlux, &!< [in] layerThickness at edge
+         normalVelocity           !< [in] transport
+
+      !  alters ALE thickness when freq-filtering
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         newHighFreqThickness     !< [in] high frequency thickness
+
+      real (kind=RKIND), intent(in) :: &
+         dt     !< Input: time step
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertAleTransportTop     !< [out] vertical transport top of cell
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge, iCell, k, i, &! edge, cell, vert, nbr indices
+         nCells,             &! number of cells
+         kmin, kmax           ! min/max layer indices for active layers
+
+      real (kind=RKIND) :: &
+         flux,         &!
+         invAreaCell1, &! 1/cell area
+         div_hu_btr     ! divergence of h*u for barotropic u
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         projectedSSH ! projectedSSH: projected SSH at a new time
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         div_hu,       &! divergence of (thickness*velocity)
+         ALE_Thickness  ! ALE thickness at new time
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      err = 0
+
+      if (config_vert_coord_movement == 'impermeable_interfaces' .or. &
+          configVertAdvMethod == vertAdvRemap) then
+         vertAleTransportTop = 0.0_RKIND
+         return
+      end if
+
+      allocate(div_hu(nVertLevels, nCellsAll), &
+               projectedSSH(nCellsAll), &
+               ALE_Thickness(nVertLevels, nCellsAll))
+
+      ! Only need to compute over 0 and 1 halos
+      nCells = nCellsHalo( 1 )
+
+!$acc data present(invAreaCell,nEdgesOnCell,edgesOnCell,minLevelEdgeBot,maxLevelEdgeTop,&
+!$acc              dvEdge,edgeSignOnCell,maxLevelCell,minLevelCell,&
+!$acc              layerThicknessEdgeFlux,normalVelocity,oldSSH,vertAleTransportTop,oldLayerThickness) &
+!$acc      create(div_hu,projectedSSH,ALE_Thickness)
+
+      !
+      ! thickness-weighted divergence and barotropic divergence
+      !
+      ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(i, iEdge, k, kmin, kmax, div_hu_btr, &
+      !$omp            invAreaCell1, flux)
+!$acc parallel
+!$acc loop gang vector private(div_hu_btr,invAreaCell1,iEdge,kmin,kmax,flux)
+      do iCell = 1, nCells
+         div_hu(:,iCell) = 0.0_RKIND
+         div_hu_btr      = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+!$acc loop seq
+            do k = kmin, kmax
+               flux = layerThicknessEdgeFlux(k,iEdge)* &
+                      normalVelocity(k,iEdge)*dvEdge(iEdge)* &
+                      edgeSignOnCell(i,iCell) * invAreaCell1
+               div_hu(k,iCell) = div_hu(k,iCell) - flux
+               div_hu_btr = div_hu_btr - flux
+            end do
+         end do
+         projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !
+      ! Compute desired thickness at new time
+      !
+      if (present(newHighFreqThickness)) then
+        call ocn_ALE_thickness_gpu(verticalMeshPool, projectedSSH, &
+                               ALE_thickness, err, newHighFreqThickness)
+      else
+        call ocn_ALE_thickness_gpu(verticalMeshPool, projectedSSH, &
+                               ALE_thickness, err)
+      endif
+
+      !
+      ! Vertical transport through layer interfaces
+      !
+      ! Vertical transport through layer interface at top and
+      ! bottom is zero. Here we are using solving the continuity
+      ! equation for vertAleTransportTop ($w^t$), and using
+      ! ALE_Thickness for thickness at the new time.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang vector private(k)
+      do iCell = 1,nCells
+         vertAleTransportTop(1,iCell) = 0.0_RKIND
+         vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
+!$acc loop seq
+         do k = maxLevelCell(iCell), minLevelCell(iCell)+1, -1
+            vertAleTransportTop(k,iCell) = &
+                vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
+                     - (ALE_Thickness(k,iCell) - &
+                        oldLayerThickness(k,iCell))/dt
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(div_hu, &
+                 projectedSSH, &
+                 ALE_Thickness)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vert_transport_velocity_top_gpu!}}}
 
 !***********************************************************************
 !
@@ -2825,18 +4398,8 @@ contains
       !
       ! Put f*normalBaroclinicVelocity^{perp} in u as a work variable
       !
-#ifdef MPAS_OPENACC
-      !$acc enter data create(normalVelocity) copyin(normalBaroclinicVelocity)
-
-      !$acc parallel loop gang vector &
-      !$acc          present(cellsOnEdge, maxLevelEdgeTop, normalVelocity, nEdgesOnEdge, &
-      !$acc                  edgesOnEdge, weightsOnEdge, fEdge, normalBaroclinicVelocity, &
-      !$acc                  minLevelEdgeBot) &
-      !$acc          private(cell1, cell2, k, j, eoe)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
-#endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -2851,16 +4414,70 @@ contains
             end do
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout(normalVelocity) delete(normalBaroclinicVelocity)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("ocn_fuperp")
 
    end subroutine ocn_fuperp!}}}
+
+   subroutine ocn_fuperp_gpu(statePool, meshPool, timeLevelIn)!{{{
+
+      type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: State information
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      integer, intent(in), optional :: timeLevelIn !< Input: Input time level for state pool
+
+      integer :: iEdge, cell1, cell2, eoe, j, k
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalBaroclinicVelocity
+      real :: normalVelocityTmp
+
+      integer :: timeLevel
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      call mpas_timer_start("ocn_fuperp gpu")
+
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, timeLevel)
+
+      !DWJ: ADD OMP (Only needed for split explicit)
+
+
+!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,nEdgesOnEdge,edgesOnEdge,weightsOnEdge,fEdge,&
+!$acc              normalVelocity,normalBaroclinicVelocity)
+      !
+      ! Put f*normalBaroclinicVelocity^{perp} in u as a work variable
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
+!$acc parallel
+!$acc loop gang worker
+      do iEdge = 1, nEdgesOwned
+!$acc loop vector private(eoe)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            normalVelocity(k,iEdge) = 0.0_RKIND
+!$acc loop seq
+            do j = 1,nEdgesOnEdge(iEdge)
+               eoe = edgesOnEdge(j,iEdge)
+               normalVelocity(k,iEdge) = normalVelocity(k,iEdge) + weightsOnEdge(j,iEdge) * normalBaroclinicVelocity(k,eoe) &
+                                       * fEdge(eoe)
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+
+      call mpas_timer_stop("ocn_fuperp gpu")
+
+   end subroutine ocn_fuperp_gpu!}}}
 
 !***********************************************************************
 !
@@ -3085,9 +4702,6 @@ contains
       allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
                thermalExpansionCoeff(nVertLevels, nCells), &
                salineContractionCoeff(nVertLevels, nCells))
-      !$acc enter data create(thermalExpansionCoeff,  &
-      !$acc                   salineContractionCoeff, &
-      !$acc                   densitySurfaceDisplaced)
 
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsHalo( 2 )
@@ -3102,9 +4716,6 @@ contains
                           thermalExpansionCoeff, &
                           salineContractionCoeff, timeLevel)
 
-      !$acc exit data copyout(thermalExpansionCoeff,  &
-      !$acc                   salineContractionCoeff, &
-      !$acc                   densitySurfaceDisplaced)
 
       ! compute surface buoyancy forcing based on surface fluxes of
       ! mass, temperature, salinity and frazil (frazil to be added later)
@@ -3216,6 +4827,289 @@ contains
 
     end subroutine ocn_compute_KPP_input_fields!}}}
 
+    subroutine ocn_compute_KPP_input_fields_gpu(statePool, forcingPool, &
+                                            meshPool, timeLevelIn)!{{{
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,  &!< [in] State information
+         meshPool,   &!< [in] Mesh information (for pass to eq state)
+         forcingPool  !< [in] Forcing information
+
+      integer, intent(in), optional :: &
+         timeLevelIn  !< [in] optional time level for state variables
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, iEdge, i, &! loop indices for cell, edge, neighbors
+         kmin,            &! topmost active cell index
+         nCells,          &! number of cells
+         err,             &! local error code
+         timeLevel         ! time level for state variables (default 1)
+
+      real (kind=RKIND) :: &
+         fracAbsorbed,       &! fraction of sfc flux absorbed
+         fracAbsorbedRunoff, &! same for runoff
+         sumSurfaceStressSquared ! sum of sfc stress squared
+
+      ! pointers for variable/pool retrievals
+      integer, pointer :: &
+         indexTempFlux,   &! index of temperature in tracer array
+         indexSaltFlux     ! index of salinity    in tracer array
+
+      type (mpas_pool_type), pointer :: &
+         tracersSurfaceFluxPool, &! pool of tracer surface fluxes
+         tracersPool              ! pool of tracers
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         penetrativeTemperatureFlux, &! various sfc flux components
+         surfaceThicknessFlux, &
+         surfaceThicknessFluxRunoff, &
+         rainTemperatureFlux, &
+         evapTemperatureFlux, &
+         icebergTemperatureFlux, &
+         seaIceTemperatureFlux, &
+         surfaceStress, &
+         surfaceStressMagnitude
+
+      real (kind=RKIND), dimension(:,:), pointer ::  &
+         layerThickness,           &! layer thickness
+         normalVelocity,           &! normal velocity
+         activeTracersSurfaceFlux, &! sfc flux of active tracers (T,S)
+         activeTracersSurfaceFluxRunoff, &! flx of tracers in runoff
+         nonLocalSurfaceTracerFlux  ! non-local flux of tracers
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+         activeTracers  ! array of active tracers
+
+      ! Scratch Arrays
+      ! densitySurfaceDisplaced: Density computed by displacing SST
+      !    and SSS to every vertical layer within the column
+      !    units: kg m^{-3}
+      ! thermalExpansionCoeff: Thermal expansion coefficient (alpha),
+      !    defined as $-1/\rho d\rho/dT$ (note negative sign)
+      !    units: C^{-1}
+      ! salineContractionCoeff: Saline contraction coefficient (beta),
+      !    defined as $1/\rho d\rho/dS$.  This is also called the
+      !    haline contraction coefficient.  units: PSU^{-1}
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         densitySurfaceDisplaced, &
+         thermalExpansionCoeff,   &
+         salineContractionCoeff
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      call mpas_timer_start('KPP input fields gpu')
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      ! Retrieve variables from pool
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', &
+                                               tracersSurfaceFluxPool)
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+
+      !TODO: should be hard-wired?
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
+                                             activeTracers, 1)
+
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_temperatureSurfaceFlux', &
+                                   indexTempFlux)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_salinitySurfaceFlux', &
+                                   indexSaltFlux)
+
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', &
+                                           normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
+                                           layerThickness, timeLevel)
+
+      call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                              'nonLocalSurfaceTracerFlux', &
+                               nonLocalSurfaceTracerFlux)
+      call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                              'activeTracersSurfaceFlux', &
+                               activeTracersSurfaceFlux)
+      call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                              'activeTracersSurfaceFluxRunoff', &
+                               activeTracersSurfaceFluxRunoff)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceThicknessFlux', &
+                                             surfaceThicknessFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceThicknessFluxRunoff', &
+                                             surfaceThicknessFluxRunoff)
+      call mpas_pool_get_array_gpu(forcingPool, 'penetrativeTemperatureFlux', &
+                                             penetrativeTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceStress', &
+                                             surfaceStress)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceStressMagnitude', &
+                                             surfaceStressMagnitude)
+      call mpas_pool_get_array_gpu(forcingPool, 'rainTemperatureFlux', &
+                                             rainTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'evapTemperatureFlux', &
+                                             evapTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceTemperatureFlux', &
+                                             seaIceTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'icebergTemperatureFlux', &
+                                             icebergTemperatureFlux)
+
+      ! allocate scratch space displaced density computation
+      ncells = nCellsAll
+
+      allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
+               thermalExpansionCoeff(nVertLevels, nCells), &
+               salineContractionCoeff(nVertLevels, nCells))
+
+      ! Only need to compute over the 0 and 1 halos
+      nCells = nCellsHalo( 2 )
+
+!$acc data present(minLevelCell,nEdgesOnCell,edgesOnCell,edgeAreaFractionOfCell,&
+!$acc               tracersSurfaceValue,layerThickness,nonLocalSurfaceTracerFlux,activeTracersSurfaceFlux,&
+!$acc               penetrativeTemperatureFlux,penetrativeTemperatureFluxOBL,rainTemperatureFlux,&
+!$acc               evapTemperatureFlux,seaIceTemperatureFlux,icebergTemperatureFlux,activeTracersSurfaceFluxRunoff,&
+!$acc               surfaceThicknessFlux,activeTracers,surfaceThicknessFluxRunoff,surfaceBuoyancyForcing,&
+!$acc               surfaceStress,surfaceStressMagnitude,surfaceFrictionVelocity)&
+!$acc      create(densitySurfaceDisplaced,thermalExpansionCoeff,salineContractionCoeff)
+
+      ! compute displaced density defined as density computed
+      ! from T, S that have been displaced (adiabatically) from surface
+
+      call ocn_equation_of_state_density_gpu(statePool, meshPool, &
+                          activeTracers, tracersSurfaceValue, &
+                          nCells, 0, 'surfaceDisplaced', &
+                          densitySurfaceDisplaced, err, &
+                          thermalExpansionCoeff, &
+                          salineContractionCoeff, timeLevel)
+
+      ! compute surface buoyancy forcing based on surface fluxes of
+      ! mass, temperature, salinity and frazil (frazil to be added later)
+      ! since this computation is confusing, variables, units and sign
+      ! convention is repeated here
+      ! everything below should be consistent with that specified in
+      !   Registry and with the CVMix/KPP documentation:
+      !    https://www.dropbox.com/s/6hqgc0rsoa828nf/cvmix_20aug2013.pdf
+      !
+      ! surfaceThicknessFlux: surface mass flux, m/s, positive into ocean
+      ! activeTracersSurfaceFlux(indexTempFlux): non-penetrative
+      !    temperature flux, C m/s, positive into ocean
+      ! penetrativeTemperatureFlux: penetrative surface temperature
+      !    flux at ocean surface, positive into ocean
+      ! activeTracersSurfaceFlux(indexSaltFlux): salinity flux, PSU m/s,
+      !    positive into ocean
+      ! penetrativeTemperatureFluxOBL: penetrative temperature flux
+      !    computed at z=OBL, positive down
+      !
+      ! note: the following fields used the CVMix/KPP computation of
+      !    buoyancy forcing are not included here
+      !    1. Tm: temperature associated with surfaceThicknessFlux,
+      !           C  (here we assume Tm == temperatureSurfaceValue)
+      !    2. Sm: salinity associated with surfaceThicknessFlux, PSU 
+      !           (here we assume Sm == salinitySurfaceValue and
+      !            account for salinity flux in
+      !            activeTracersSurfaceFlux array)
+      !
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(kmin, fracAbsorbed, fracAbsorbedRunoff, &
+      !$omp         sumSurfaceStressSquared, i, iEdge)
+!$acc parallel
+!$acc loop gang vector private(kmin,fracAbsorbed,fracAbsorbedRunoff,sumSurfaceStressSquared)
+      do iCell = 1, nCells
+
+         kmin = minLevelCell(iCell)
+         ! Compute fraction of thickness flux that is in the top model layer
+         fracAbsorbed = 1.0_RKIND &
+                      - exp( max(-100.0_RKIND, &
+                                 -layerThickness(kmin, iCell)/ &
+                           config_flux_attenuation_coefficient))
+         fracAbsorbedRunoff = 1.0_RKIND &
+                      - exp( max(-100.0_RKIND, &
+                                 -layerThickness(kmin, iCell)/ &
+                           config_flux_attenuation_coefficient_runoff))
+
+         ! Store the total tracer flux below in
+         ! nonLocalSurfaceTemperatureFlux for use in the CVMix nonlocal
+         ! transport code. This includes tracer forcing due to thickness
+
+         nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = &
+                   activeTracersSurfaceFlux(indexTempFlux,iCell) &
+                 + penetrativeTemperatureFlux(iCell) &
+                 - penetrativeTemperatureFluxOBL(iCell)  &
+                 - fracAbsorbed* (rainTemperatureFlux(iCell) + &
+                                  evapTemperatureFlux(iCell) + &
+                                  seaIceTemperatureFlux(iCell) + &
+                                  icebergTemperatureFlux(iCell)) &
+                 - fracAbsorbedRunoff* &
+                   activeTracersSurfaceFluxRunoff(indexTempFlux,iCell)
+
+         nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = &
+                   activeTracersSurfaceFlux(indexSaltFlux,iCell) &
+                 - fracAbsorbed*surfaceThicknessFlux(iCell)* &
+                   activeTracers(indexSaltFlux,kmin,iCell) &
+                 - fracAbsorbedRunoff*surfaceThicknessFluxRunoff(iCell)* &
+                   activeTracers(indexSaltFlux,kmin,iCell)
+
+         surfaceBuoyancyForcing(iCell) = &
+                  thermalExpansionCoeff(kmin,iCell)* &
+                  nonLocalSurfaceTracerFlux(indexTempFlux,iCell) &
+                - salineContractionCoeff(kmin,iCell)* &
+                  nonLocalSurfaceTracerFlux(indexSaltFlux,iCell)
+
+         ! at this point, surfaceBuoyancyForcing has units of m/s
+         ! change into units of m^2/s^3 (which can be thought of as
+         ! the flux of buoyancy, units of buoyancy * velocity )
+         surfaceBuoyancyForcing(iCell) = surfaceBuoyancyForcing(iCell)* &
+                                         gravity
+
+         ! compute magnitude of surface stress
+         sumSurfaceStressSquared = 0.0_RKIND
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            sumSurfaceStressSquared = sumSurfaceStressSquared &
+                                    + edgeAreaFractionOfCell(i,iCell)* &
+                                      surfaceStress(iEdge)**2
+         enddo
+
+         ! NOTE that the factor of 2 is from averaging dot products
+         ! to cell centers on a C-grid
+         surfaceStressMagnitude(iCell) = &
+                           sqrt(2.0_RKIND * sumSurfaceStressSquared)
+         surfaceFrictionVelocity(iCell) = &
+                           sqrt(surfaceStressMagnitude(iCell) / rho_sw)
+
+      enddo
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      ! deallocate scratch space
+      deallocate(thermalExpansionCoeff, &
+                 salineContractionCoeff, &
+                 densitySurfaceDisplaced)
+
+      call mpas_timer_stop('KPP input fields gpu')
+
+    !-------------------------------------------------------------------
+
+    end subroutine ocn_compute_KPP_input_fields_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_compute_land_ice_flux_input_fields
@@ -3286,18 +5180,10 @@ contains
 
       allocate(blTempScratch(nCellsAll), &
                blSaltScratch(nCellsAll))
-      !$acc enter data create(blTempScratch, blSaltScratch)
 
       ! Compute top drag
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceFraction)
-
-      !$acc parallel loop present(cellsOnEdge, kineticEnergyCell, minLevelCell, minLevelEdgeBot) &
-      !$acc    present(landIceFraction, topDrag, normalVelocity)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, velocityMagnitude, landIceEdgeFraction)
-#endif
       do iEdge = 1, nEdgesAll
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
@@ -3310,17 +5196,10 @@ contains
                           * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! compute top drag magnitude and friction velocity at cell centers
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(landIceFrictionVelocity, kineticEnergyCell, minLevelCell, topDragMag) &
-      !$acc    present(landIceFraction)
-#else
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
@@ -3332,18 +5211,10 @@ contains
                                    (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
                                    + config_land_ice_flux_rms_tidal_velocity**2))
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(blTempScratch, blSaltScratch, activeTracers, &
-      !$acc            minLevelCell, maxLevelCell, layerThickness)
-#else
       !$omp do schedule(runtime) private(blThickness, iLevel, dz)
-#endif
       do iCell = 1, nCellsAll
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND
@@ -3360,18 +5231,9 @@ contains
            blSaltScratch(iCell) = blSaltScratch(iCell)/blThickness
          end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(landIceBoundaryLayerTracers, &
-      !$acc            blTempScratch, blSaltScratch, cellMask, &
-      !$acc            nEdgesOnCell, cellsOnCell, minLevelCell)
-#else
       !$omp do schedule(runtime) private(weightSum, i, cell2)
-#endif
       do iCell = 1, nCellsAll
          landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
          landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
@@ -3389,18 +5251,12 @@ contains
             landIceBoundaryLayerTracers(:, iCell) = landIceBoundaryLayerTracers(:, iCell)/weightSum
          end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       if(jenkinsOn) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop present(landIceTracerTransferVelocities, landIceFrictionVelocity)
-#else
          !$omp parallel
          !$omp do schedule(runtime)
-#endif
          do iCell = 1, nCellsAll
             ! transfer coefficients from namelist
             landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell) &
@@ -3408,19 +5264,11 @@ contains
             landIceTracerTransferVelocities(indexSaltTrans, iCell) = landIceFrictionVelocity(iCell) &
                                              * config_land_ice_flux_jenkins_salt_transfer_coefficient
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       else if(hollandJenkinsOn) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(fCell, landIceTracerTransferVelocities, &
-         !$acc            landIceFrictionVelocity)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(h_nu, Gamma_turb)
-#endif
          do iCell = 1, nCellsAll
             ! friction-velocity dependent non-dimensional transfer coefficients from
             ! Holland and Jenkins 1999, (14)-(16) with eta_* = 1
@@ -3437,40 +5285,218 @@ contains
             landIceTracerTransferVelocities(indexSaltTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
                                                                    * Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
       end if
 
-      !$acc exit data delete(blTempScratch, blSaltScratch)
       deallocate(blTempScratch, &
                  blSaltScratch)
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceMask)
-
-      !$acc parallel loop present(landIceMask, sfcFlxAttCoeff)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
          if(landIceMask(iCell) == 1) then
             sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("land_ice_diagnostic_fields")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_compute_land_ice_flux_input_fields!}}}
+
+   subroutine ocn_compute_land_ice_flux_input_fields_gpu(layerThickness, normalVelocity, &
+      activeTracers, landIceFraction, landIceMask, &
+      timeLevel, indexTval, indexSval)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: timeLevel, indexTval, indexSval
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness, normalVelocity
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         landIceFraction
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         activeTracers
+
+      integer, dimension(:), intent(in) :: &
+         landIceMask
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2, iLevel, i
+
+      real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:), allocatable ::  &
+         blTempScratch, blSaltScratch
+
+      ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
+      real (kind=RKIND), parameter :: &
+         Pr = 13.8_RKIND, &             ! the Prandtl number
+         Sc = 2432.0_RKIND, &           ! the Schmidt number
+         nuSaltWater = 1.95e-6_RKIND, & ! molecular viscosity of sea water (m^2/s)
+         kVonKarman = 0.4_RKIND, &      ! the von Karman constant
+         xiN = 0.052_RKIND              ! dimensionless planetary boundary layer constant
+
+      integer :: indexBLTval, indexBLSval, indexHeatTransval, indexSaltTransval
+
+      !-----------------------------------------------------------------
+
+      if ( trim(config_land_ice_flux_mode) .ne. 'standalone' .and. trim(config_land_ice_flux_mode) .ne. 'coupled' ) then
+         return
+      end if
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_compute_land_ice_flux_input_fields_gpu NOT EXECUTING"
+
+      call mpas_timer_start("land_ice_diagnostic_fields", .false.)
+
+      allocate(blTempScratch(nCellsAll), &
+               blSaltScratch(nCellsAll))
+
+      ! Compute top drag
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2, velocityMagnitude, landIceEdgeFraction)
+      do iEdge = 1, nEdgesAll
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         ! top drag tau = - CD*|u|*u, where |u| = sqrt(2*KE) = sqrt(KE1 + KE2) from the neighboring cells
+         velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell2),cell2))
+         landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
+
+         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &
+                          * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
+
+      end do
+      !$omp end do
+
+      ! compute top drag magnitude and friction velocity at cell centers
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+         ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
+         topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
+                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
+
+         ! the friction velocity is the square root of the top drag + variance of tidal velocity
+         ! (computed regardless of land-ice coverage)
+         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * &
+                                   (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
+                                   + config_land_ice_flux_rms_tidal_velocity**2))
+      end do
+      !$omp end do
+
+      ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
+      !$omp do schedule(runtime) private(blThickness, iLevel, dz)
+      do iCell = 1, nCellsAll
+         blThickness = 0.0_RKIND
+         blTempScratch(iCell) = 0.0_RKIND
+         blSaltScratch(iCell) = 0.0_RKIND
+         do iLevel = minLevelCell(iCell), maxLevelCell(iCell)
+            dz = min(layerThickness(iLevel,iCell),config_land_ice_flux_boundaryLayerThickness-blThickness)
+            if(dz <= 0.0_RKIND) exit
+            blTempScratch(iCell) = blTempScratch(iCell) + activeTracers(indexTval, iLevel, iCell)*dz
+            blSaltScratch(iCell) = blSaltScratch(iCell) + activeTracers(indexSval, iLevel, iCell)*dz
+            blThickness = blThickness + dz
+         end do
+         if(blThickness > 0.0_RKIND) then
+           blTempScratch(iCell) = blTempScratch(iCell)/blThickness
+           blSaltScratch(iCell) = blSaltScratch(iCell)/blThickness
+         end if
+      end do
+      !$omp end do
+
+      !$omp do schedule(runtime) private(weightSum, i, cell2)
+      do iCell = 1, nCellsAll
+         landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
+         landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
+         if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
+            weightSum = 1.0_RKIND
+            do i = 1, nEdgesOnCell(iCell)
+               cell2 = cellsOnCell(i,iCell)
+
+               landIceBoundaryLayerTracers(indexBLT, iCell) = landIceBoundaryLayerTracers(indexBLT, iCell) &
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
+               landIceBoundaryLayerTracers(indexBLS, iCell) = landIceBoundaryLayerTracers(indexBLS, iCell) &
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
+               weightSum = weightSum + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
+            end do
+            landIceBoundaryLayerTracers(:, iCell) = landIceBoundaryLayerTracers(:, iCell)/weightSum
+         end if
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      if(jenkinsOn) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nCellsAll
+            ! transfer coefficients from namelist
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell) &
+                                             * config_land_ice_flux_jenkins_heat_transfer_coefficient
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = landIceFrictionVelocity(iCell) &
+                                             * config_land_ice_flux_jenkins_salt_transfer_coefficient
+         end do
+         !$omp end do
+         !$omp end parallel
+      else if(hollandJenkinsOn) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(h_nu, Gamma_turb)
+         do iCell = 1, nCellsAll
+            ! friction-velocity dependent non-dimensional transfer coefficients from
+            ! Holland and Jenkins 1999, (14)-(16) with eta_* = 1
+            h_nu = 5.0_RKIND*nuSaltWater/landIceFrictionVelocity(iCell) ! uStar should never be zero because of tidal term
+
+            Gamma_turb = 1.0_RKIND/(2.0_RKIND*xiN) - 1.0_RKIND/kVonKarman
+            if(abs(fCell(iCell)) > 0.0_RKIND) then
+              Gamma_turb = Gamma_turb + 1.0_RKIND/kVonKarman*log(landIceFrictionVelocity(iCell) &
+                *xiN/(abs(fCell(iCell))*h_nu))
+            end if
+
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
+                                                                   * Pr**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
+                                                                   * Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
+
+      deallocate(blTempScratch, &
+                 blSaltScratch)
+
+      ! modify the spatially-varying attenuation coefficient where there is land ice
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+         if(landIceMask(iCell) == 1) then
+            sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
+         end if
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("land_ice_diagnostic_fields")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_compute_land_ice_flux_input_fields_gpu!}}}
 
 !***********************************************************************
 !
@@ -3530,6 +5556,62 @@ contains
       call mpas_timer_stop('reconstruct eddy vecs')
 
    end subroutine ocn_reconstruct_eddy_vectors!}}}
+
+   subroutine ocn_reconstruct_eddy_vectors_gpu(meshPool) !{{{
+
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
+      call mpas_timer_start('reconstruct eddy vecs gpu')
+
+!$acc data present(normalTransportVelocity,transportVelocityX,transportVelocityY,transportVelocityZ,transportVelocityZonal,transportVelocityMeridional,&
+!$acc               normalGMBolusVelocity,eddyVelocityX,eddyVelocityY,eddyVelocityZ,GMBolusVelocityZonal,GMBolusVelocityMeridional,&
+!$acc               gmStreamFuncTopOfEdge,GMStreamFuncX,GMStreamFuncY,GMStreamFuncZ,GMStreamFuncZonal,GMStreamFuncMeridional)
+
+      call mpas_reconstruct_gpu(meshPool, normalTransportVelocity,          &
+                       transportVelocityX,            &
+                       transportVelocityY,            &
+                       transportVelocityZ,            &
+                       transportVelocityZonal,        &
+                       transportVelocityMeridional    &
+                      )
+
+      if(config_use_gm) then 
+         call mpas_reconstruct_gpu(meshPool, normalGMBolusVelocity,          &
+                       eddyVelocityX,            &
+                       eddyVelocityY,            &
+                       eddyVelocityZ,            &
+                       GMBolusVelocityZonal,        &
+                       GMBolusVelocityMeridional    &
+                      )
+
+         call mpas_reconstruct_gpu(meshPool, gmStreamFuncTopOfEdge,          &
+                      GMStreamFuncX,            &
+                      GMStreamFuncY,            &
+                      GMStreamFuncZ,            &
+                      GMStreamFuncZonal,        &
+                      GMStreamFuncMeridional    &
+                     )
+      end if
+
+      if (config_submesoscale_enable) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_submesoscale_enable NOT EXECUTING"
+         call mpas_reconstruct(meshPool, normalMLEvelocity,          &
+                       eddyVelocityX,            &
+                       eddyVelocityY,            &
+                       eddyVelocityZ,            &
+                       mleVelocityZonal,        &
+                       mleVelocityMeridional    &
+                      )
+
+      end if
+
+!$acc end data
+
+      call mpas_timer_stop('reconstruct eddy vecs gpu')
+
+   end subroutine ocn_reconstruct_eddy_vectors_gpu!}}}
+
 
 
 !***********************************************************************

--- a/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/shared/mpas_ocn_diagnostics_variables.F
@@ -253,83 +253,83 @@ contains
       call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
 
       if (config_use_topographic_wave_drag) then
-         call mpas_pool_get_array(diagnosticsPool, 'topographic_wave_drag', topographic_wave_drag)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'topographic_wave_drag', topographic_wave_drag)
       end if
 
       if ( trim(config_ocean_run_mode) == 'forward' ) then
-         call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'wettingVelocity', &
                    wettingVelocity)
          call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', &
                    wettingVelocityField)
       end if
 
       if (config_use_GM.or.config_use_Redi) then
-         call mpas_pool_get_array(diagnosticsPool, 'RediKappa', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediKappa', &
                    RediKappa)
-         call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediKappaScaling', &
                    RediKappaScaling)
-         call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediKappaSfcTaper', &
                    RediKappaSfcTaper)
-         call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rediLimiterCount', &
                    rediLimiterCount)
 
-         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa',  &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gmBolusKappa',  &
                    gmBolusKappa)
-         call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gmKappaScaling', &
                    gmKappaScaling)
-         call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediHorizontalTaper', &
                    RediHorizontalTaper)
-         call mpas_pool_get_array(diagnosticsPool, 'gmHorizontalTaper', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gmHorizontalTaper', &
                    gmHorizontalTaper)
-         call mpas_pool_get_array(diagnosticsPool, 'RossbyRadius', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RossbyRadius', &
                    RossbyRadius)
       end if
 
       if (config_use_GM .or. config_submesoscale_enable) then
-         call mpas_pool_get_array(diagnosticsPool, 'gradDensityEddy', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradDensityEddy', &
                    gradDensityEddy)
       end if
 
       if ( config_compute_active_tracer_budgets ) then
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerSurfaceFluxTendency', &
                    activeTracerSurfaceFluxTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'temperatureShortWaveTendency', &
                    temperatureShortWaveTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerNonLocalTendency', &
                    activeTracerNonLocalTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerHorMixTendency', &
                    activeTracerHorMixTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerVerticalAdvectionTopFlux', &
                    activeTracerVerticalAdvectionTopFlux)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerHorizontalAdvectionEdgeFlux', &
                    activeTracerHorizontalAdvectionEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerHorizontalAdvectionTendency', &
                    activeTracerHorizontalAdvectionTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerVerticalAdvectionTendency',  &
                    activeTracerVerticalAdvectionTendency)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'activeTracerVertMixTendency', &
                    activeTracerVertMixTendency)
       end if
 
       if ( config_use_activeTracers_surface_restoring ) then
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'salinitySurfaceRestoringTendency', &
                    salinitySurfaceRestoringTendency)
       end if
 
       ! Retrieve pointers for configurations where land_ice_flux_mode is enabled
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
-         call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-         call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'topDrag', topDrag)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'topDragMagnitude', topDragMag)
          call mpas_pool_get_dimension(diagnosticsPool, &
                    'index_landIceBoundaryLayerTemperature', indexBLTPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
@@ -343,211 +343,211 @@ contains
          indexHeatTrans = indexHeatTransPtr
          indexSaltTrans = indexSaltTransPtr
 
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                    'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                    'landIceTracerTransferVelocities', &
                     landIceTracerTransferVelocities)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                    'landIceFrictionVelocity', landIceFrictionVelocity)
       end if
 
       if ( trim(config_ocean_run_mode) == 'init' ) then
-         call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rx1InitSmoothingMask', &
                    smoothingMask, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'verticalStretch', &
                    verticalStretch, 1)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'globalVerticalStretchMax', &
                    globalVerticalStretchMax, 1)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'globalVerticalStretchMin', &
                    globalVerticalStretchMin, 1)
       end if
 
       if (config_use_topographic_wave_drag) then
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'topographic_wave_drag', &
                    topographic_wave_drag)
       end if
 
       if (config_use_tidal_potential_forcing) then
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'ssh_sal', &
                    ssh_sal)
       end if
 
       if ( trim(config_ocean_run_mode) == 'init' .or. &
                 config_AM_debugDiagnostics_enable ) then
-         call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'rx1MaxCell', &
                    rx1MaxCell, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'globalRx1Max', &
                    globalRx1Max, 1)
       end if
 
       if ( trim(config_ocean_run_mode) == 'forward' .or. &
            trim(config_ocean_run_mode) == 'analysis' ) then
-         call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'k33', k33)
 
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSH', gradSSH)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSHX', gradSSHX)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSHY', gradSSHY)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSHZ', gradSSHZ)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSHZonal', &
                    gradSSHZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gradSSHMeridional', &
                    gradSSHMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SSHGradient', SSHGradient)
 
-         call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
-         call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-         call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'viscosity', viscosity)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'divergence', divergence)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'circulation', circulation)
 
-         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'velocityX', velocityX)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'velocityY', velocityY)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'velocityZ', velocityZ)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'velocityMeridional', &
                    velocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'velocityZonal', &
                    velocityZonal)
 
-         call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
 
-         call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'slopeTriadUp', &
                    slopeTriadUp)
-         call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'slopeTriadDown', &
                    slopeTriadDown)
 
          ! GM-related fields
-         call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'cGMphaseSpeed', &
                    cGMphaseSpeed)
-         call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'gmStreamFuncTopOfEdge', &
                    gmStreamFuncTopOfEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMStreamFuncX', &
                    GMStreamFuncX)
-         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMStreamFuncY', &
                    GMStreamFuncY)
-         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMStreamFuncZ', &
                    GMStreamFuncZ)
-         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMStreamFuncZonal', &
                    GMStreamFuncZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMStreamFuncMeridional', &
                    GMStreamFuncMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'mleVelocityZonal', &
                    mleVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'mleVelocityMeridional', &
                    mleVelocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityX', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'eddyVelocityX', &
                    eddyVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityY', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'eddyVelocityY', &
                    eddyVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityZ', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'eddyVelocityZ', &
                    eddyVelocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMBolusVelocityZonal', &
                    GMBolusVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'GMBolusVelocityMeridional', &
                    GMBolusVelocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'normalGMBolusVelocity', &
                    normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalMLEvelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'normalMLEvelocity', &
                    normalMLEvelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertGMBolusVelocityTop', &
                    vertGMBolusVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertMLEBolusVelocityTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertMLEBolusVelocityTop', &
                    vertMLEBolusVelocityTop)
 
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeFlux', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'layerThicknessEdgeFlux', &
                    layerThickEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeMean', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'layerThicknessEdgeMean', &
                    layerThickEdgeMean)
 
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'normalizedRelativeVorticityEdge', &
                    normRelVortEdge)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'normalizedPlanetaryVorticityEdge', &
                    normPlanetVortEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'relativeVorticity', &
                    relativeVorticity)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'relativeVorticityCell', &
                    relativeVorticityCell)
 
-         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'surfaceVelocity', &
                    surfaceVelocity)
 
-         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertVelocityTop', &
                    vertVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertNonLocalFlux', &
                    vertNonLocalFlux)
-         call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertViscTopOfEdge', &
                    vertViscTopOfEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertViscTopOfCell', &
                    vertViscTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertDiffTopOfCell', &
                    vertDiffTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertAleTransportTop', &
                    vertAleTransportTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'vertTransportVelocityTop', &
                    vertTransportVelocityTop)
 
-         call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'barotropicForcing', &
                    barotropicForcing)
-         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'kineticEnergyCell', &
                    kineticEnergyCell)
 
-         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'transportVelocityX', &
                    transportVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'transportVelocityY', &
                    transportVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'transportVelocityZ', &
                    transportVelocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'transportVelocityZonal', &
                    transportVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'transportVelocityMeridional', &
                    transportVelocityMeridional)
 
-         call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'tangentialVelocity', &
                    tangentialVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'montgomeryPotential', &
                    montgomeryPotential)
-         call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'BruntVaisalaFreqTop', &
                    BruntVaisalaFreqTop)
 
-         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'bulkRichardsonNumber', &
                    bulkRichardsonNumber)
-         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',&
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'bulkRichardsonNumberBuoy',&
                    bulkRichardsonNumberBuoy)
-         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',&
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'bulkRichardsonNumberShear',&
                    bulkRichardsonNumberShear)
 
          ! set pointers for fields related forcing at ocean surface
-         call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'surfaceBuoyancyForcing', &
                    surfaceBuoyancyForcing)
-         call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'surfaceFrictionVelocity', &
                    surfaceFrictionVelocity)
 
-         call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'barotropicThicknessFlux', &
                    barotropicThicknessFlux)
 
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'normalTransportVelocity', &
                    normalTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'normalVelocitySurfaceLayer', &
                    normalVelocitySurfaceLayer)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'penetrativeTemperatureFluxOBL', &
                    penetrativeTemperatureFluxOBL)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'normalizedRelativeVorticityCell', &
                    normalizedRelativeVorticityCell)
 
-         call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', &
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'tracersSurfaceLayerValue', &
                    tracersSurfaceLayerValue)
 
          ! Set pointer for index variables
@@ -563,10 +563,10 @@ contains
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_SSHGradientMeridional', &
                    indexSSHGradientMeridionalPtr)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'indexSurfaceLayerDepth', &
                    indexSurfaceLayerDepth)
-         call mpas_pool_get_array(diagnosticsPool, &
+         call mpas_pool_get_array_gpu(diagnosticsPool, &
                   'indexBoundaryLayerDepth', &
                    indexBoundaryLayerDepth)
          call mpas_pool_get_dimension(diagnosticsPool, &
@@ -577,310 +577,99 @@ contains
          index_vertNonLocalFluxTemp = index_vertNonLocalFluxTempPtr
          indexSSHGradientMeridional = indexSSHGradientMeridionalPtr
          indexSSHGradientZonal = indexSSHGradientZonalPtr
+
       end if
 
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                "daysSinceStartOfSim", &
                 daysSinceStartOfSim)
-      call mpas_pool_get_array(diagnosticsPool, 'Time', Time)
-      call mpas_pool_get_array(diagnosticsPool, 'Time_bnds', Time_bnds)
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-      call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'Time', Time)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'Time_bnds', Time_bnds)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'xtime', xtime)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'simulationStartTime', &
                 simulationStartTime)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'zMid', zMid)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'zTop', zTop)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'density', density)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'pressure', pressure)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'displacedDensity', &
                 displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'potentialDensity', &
                 potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'inSituThermalExpansionCoeff', &
                 thermExpCoeff)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'inSituSalineContractionCoeff', &
                 salineContractCoeff)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'pressureAdjustedSSH', &
                 pressureAdjustedSSH)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'tracersSurfaceValue', &
                 tracersSurfaceValue)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'surfaceFluxAttenuationCoefficient', &
                 sfcFlxAttCoeff)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'surfaceFluxAttenuationCoefficientRunoff', &
                 surfaceFluxAttenuationCoefficientRunoff)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'boundaryLayerDepth', &
                 boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'boundaryLayerDepthSmooth', &
                 boundaryLayerDepthSmooth)
-      call mpas_pool_get_array(diagnosticsPool, 'barotropicCoriolisTerm', &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'barotropicCoriolisTerm', &
                 barotropicCoriolisTerm)
-      call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'betaEdge', betaEdge)
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'bottomLayerShortwaveTemperatureFlux', &
                 bottomLayerShortwaveTemperatureFlux)
       call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', &
                 smoothingMaskField, 1)
       call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', &
                 verticalStretchField, 1)
-      call mpas_pool_get_array(diagnosticsPool, &
+      call mpas_pool_get_array_gpu(diagnosticsPool, &
                'modifyLandIcePressureMask', &
                 modifyLandIcePressureMask)
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-      call mpas_pool_get_array(diagnosticsPool, 'dThreshMLD', dThreshMLD)
-      call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', &
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'indMLD', indMLD)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'dThreshMLD', dThreshMLD)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'surfacePressure', &
                 surfacePressure)
 
-      call mpas_pool_get_array(diagnosticsPool, 'nhPressureCorrection', nhPressureCorrection)
+      call mpas_pool_get_array_gpu(diagnosticsPool, 'nhPressureCorrection', nhPressureCorrection)
 
       ! Semi-implicit Array Pointer retrievals
       if (trim(config_time_integrator) == 'split_implicit') then
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r0', SIvec_r0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r1', SIvec_r1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_v0', SIvec_v0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_w0', SIvec_w0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_w1', SIvec_w1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t0', SIvec_t0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_q0', SIvec_q0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_s0', SIvec_s0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_s1', SIvec_s1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t0', SIvec_t0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t1', SIvec_t1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_y0', SIvec_y0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_z0', SIvec_z0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_z1', SIvec_z1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r00', SIvec_r00)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_rh0', SIvec_rh0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_rh1', SIvec_rh1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_wh0', SIvec_wh0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_wh1', SIvec_wh1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_ph0', SIvec_ph0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_ph1', SIvec_ph1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_qh0', SIvec_qh0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_sh0', SIvec_sh0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_sh1', SIvec_sh1)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_zh0', SIvec_zh0)
-         call mpas_pool_get_array(diagnosticsPool, 'SIvec_zh1', SIvec_zh1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_r0', SIvec_r0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_r1', SIvec_r1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_v0', SIvec_v0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_w0', SIvec_w0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_w1', SIvec_w1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_t0', SIvec_t0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_q0', SIvec_q0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_s0', SIvec_s0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_s1', SIvec_s1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_t0', SIvec_t0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_t1', SIvec_t1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_y0', SIvec_y0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_z0', SIvec_z0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_z1', SIvec_z1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_r00', SIvec_r00)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_rh0', SIvec_rh0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_rh1', SIvec_rh1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_wh0', SIvec_wh0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_wh1', SIvec_wh1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_ph0', SIvec_ph0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_ph1', SIvec_ph1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_qh0', SIvec_qh0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_sh0', SIvec_sh0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_sh1', SIvec_sh1)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_zh0', SIvec_zh0)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'SIvec_zh1', SIvec_zh1)
       end if
-
-      ! Copy diagnostic variables to accelerator
-      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
-         !$acc enter data create(                                 &
-         !$acc                   topDrag,                         &
-         !$acc                   topDragMag,                      &
-         !$acc                   landIceBoundaryLayerTracers,     &
-         !$acc                   landIceTracerTransferVelocities, &
-         !$acc                   landIceFrictionVelocity)
-      end if
-      if (config_use_topographic_wave_drag) then
-         !$acc enter data create(topographic_wave_drag)
-      end if
-      if (config_use_self_attraction_loading) then
-         !$acc enter data copyin(ssh_sal)
-      end if
-      if ( trim(config_ocean_run_mode) == 'init' ) then
-         !$acc enter data create(                          &
-         !$acc                   rx1Edge,                  &
-         !$acc                   rx1Cell,                  &
-         !$acc                   rx1MaxEdge,               &
-         !$acc                   smoothingMask,            &
-         !$acc                   verticalStretch,          &
-         !$acc                   globalVerticalStretchMax, &
-         !$acc                   globalVerticalStretchMin  &
-         !$acc                   )
-      end if
-      if ( trim(config_ocean_run_mode) == 'init' .or. &
-                config_AM_debugDiagnostics_enable ) then
-         !$acc enter data create(                          &
-         !$acc                   rx1MaxCell,               &
-         !$acc                   globalRx1Max)
-      end if
-      if ( trim(config_ocean_run_mode) == 'forward' .or. &
-           trim(config_ocean_run_mode) == 'analysis' ) then
-         !$acc enter data create(                                 &
-         !$acc                   k33,                             &
-         !$acc                   gradSSH,                         &
-         !$acc                   gradSSHX,                        &
-         !$acc                   gradSSHY,                        &
-         !$acc                   gradSSHZ,                        &
-         !$acc                   viscosity,                       &
-         !$acc                   velocityX,                       &
-         !$acc                   velocityY,                       &
-         !$acc                   velocityZ,                       &
-         !$acc                   divergence,                      &
-         !$acc                   RiTopOfCell,                     &
-         !$acc                   RiTopOfEdge,                     &
-         !$acc                   SSHGradient,                     &
-         !$acc                   circulation,                     &
-         !$acc                   slopeTriadUp,                    &
-         !$acc                   gradSSHZonal,                    &
-         !$acc                   cGMphaseSpeed,                   &
-         !$acc                   velocityZonal,                   &
-         !$acc                   GMStreamFuncX,                   &
-         !$acc                   GMStreamFuncY,                   &
-         !$acc                   GMStreamFuncZ,                   &
-         !$acc                   layerThickEdgeFlux,              &
-         !$acc                   layerThickEdgeMean,              &
-         !$acc                   slopeTriadDown,                  &
-         !$acc                   normRelVortEdge,                 &
-         !$acc                   surfaceVelocity,                 &
-         !$acc                   vertVelocityTop,                 &
-         !$acc                   eddyVelocityX,                   &
-         !$acc                   eddyVelocityY,                   &
-         !$acc                   eddyVelocityZ,                   &
-         !$acc                   vertNonLocalFlux,                &
-         !$acc                   vertViscTopOfEdge,               &
-         !$acc                   gradSSHMeridional,               &
-         !$acc                   barotropicForcing,               &
-         !$acc                   vertViscTopOfCell,               &
-         !$acc                   vertDiffTopOfCell,               &
-         !$acc                   GMStreamFuncZonal,               &
-         !$acc                   relativeVorticity,               &
-         !$acc                   kineticEnergyCell,               &
-         !$acc                   normPlanetVortEdge,              &
-         !$acc                   velocityMeridional,              &
-         !$acc                   transportVelocityX,              &
-         !$acc                   transportVelocityY,              &
-         !$acc                   transportVelocityZ,              &
-         !$acc                   tangentialVelocity,              &
-         !$acc                   montgomeryPotential,             &
-         !$acc                   BruntVaisalaFreqTop,             &
-         !$acc                   vertAleTransportTop,             &
-         !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   mleVelocityZonal,                &
-         !$acc                   bulkRichardsonNumber,            &
-         !$acc                   gmStreamFuncTopOfEdge,           &
-         !$acc                   relativeVorticityCell,           &
-         !$acc                   normalGMBolusVelocity,           &
-         !$acc                   normalMLEvelocity,               &
-         !$acc                   vertGMBolusVelocityTop,          &
-         !$acc                   vertMLEBolusVelocityTop,         &
-         !$acc                   transportVelocityZonal,          &
-         !$acc                   GMStreamFuncMeridional,          &
-         !$acc                   indexSurfaceLayerDepth,          &
-         !$acc                   surfaceBuoyancyForcing,          &
-         !$acc                   surfaceFrictionVelocity,         &
-         !$acc                   indexBoundaryLayerDepth,         &
-         !$acc                   barotropicThicknessFlux,         &
-         !$acc                   normalTransportVelocity,         &
-         !$acc                   vertTransportVelocityTop,        &
-         !$acc                   bulkRichardsonNumberBuoy,        &
-         !$acc                   tracersSurfaceLayerValue,        &
-         !$acc                   GMBolusVelocityMeridional,       &
-         !$acc                   mleVelocityMeridional,           &
-         !$acc                   bulkRichardsonNumberShear,       &
-         !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   transportVelocityMeridional,     &
-         !$acc                   penetrativeTemperatureFluxOBL,   &
-         !$acc                   indexSurfaceVelocityMeridional,  &
-         !$acc                   normalizedRelativeVorticityCell, &
-         !$acc                   nhPressureCorrection             &
-         !$acc                   ) 
-      end if
-      if ( trim(config_ocean_run_mode) == 'forward' ) then
-         !$acc enter data create( &
-         !$acc                   wettingVelocity              &
-         !$acc                   )
-      end if
-      if (config_use_GM.or.config_use_Redi) then
-         !$acc enter data create(                   &
-         !$acc                   RediKappa,         &
-         !$acc                   gmBolusKappa,      &
-         !$acc                   gmKappaScaling,    &
-         !$acc                   RediKappaScaling,  &
-         !$acc                   rediLimiterCount,  &
-         !$acc                   RediKappaSfcTaper, &
-         !$acc                   RediHorizontalTaper,  &
-         !$acc                   gmHorizontalTaper,  &
-         !$acc                   RossbyRadius  &
-         !$acc                   )
-      end if
-      if (config_use_GM.or.config_submesoscale_enable) then
-         !$acc enter data create(gradDensityEddy)
-      end if
-      if ( config_compute_active_tracer_budgets ) then
-         !$acc enter data create(                                         &
-         !$acc                   activeTracerHorMixTendency,              &
-         !$acc                   activeTracerVertMixTendency,             &
-         !$acc                   temperatureShortWaveTendency,            &
-         !$acc                   activeTracerNonLocalTendency,            &
-         !$acc                   activeTracerSurfaceFluxTendency,         &
-         !$acc                   activeTracerVerticalAdvectionTopFlux,    &
-         !$acc                   activeTracerVerticalAdvectionTendency,   &
-         !$acc                   activeTracerHorizontalAdvectionTendency, &
-         !$acc                   activeTracerHorizontalAdvectionEdgeFlux  &
-         !$acc                   )
-      end if
-      if ( config_use_activeTracers_surface_restoring ) then
-         !$acc enter data create(                                  &
-         !$acc                   salinitySurfaceRestoringTendency  &
-         !$acc                   )
-      end if
-      if ( trim(config_time_integrator) == 'split_implicit' ) then
-         !$acc enter data create(                       &
-         !$acc                   SIvec_r0,              &
-         !$acc                   SIvec_r00,             &
-         !$acc                   SIvec_r1,              &
-         !$acc                   SIvec_rh0,             &
-         !$acc                   SIvec_rh1,             &
-         !$acc                   SIvec_ph0,             &
-         !$acc                   SIvec_ph1,             &
-         !$acc                   SIvec_v0,              &
-         !$acc                   SIvec_v0,              &
-         !$acc                   SIvec_s0,              &
-         !$acc                   SIvec_s1,              &
-         !$acc                   SIvec_sh0,             &
-         !$acc                   SIvec_sh1,             &
-         !$acc                   SIvec_t0,              &
-         !$acc                   SIvec_t1,              &
-         !$acc                   SIvec_q0,              &
-         !$acc                   SIvec_q1,              &
-         !$acc                   SIvec_qh0,             &
-         !$acc                   SIvec_w0,              &
-         !$acc                   SIvec_w1,              &
-         !$acc                   SIvec_wh0,             &
-         !$acc                   SIvec_wh1,             &
-         !$acc                   SIvec_y0,              &
-         !$acc                   SIvec_z0,              &
-         !$acc                   SIvec_z1,              &
-         !$acc                   SIvec_zh0,             &
-         !$acc                   SIvec_zh1,             &
-         !$acc                   barotropicCoriolisTerm &
-         !$acc                   )
-      end if
-
-      !$acc enter data create(                                         &
-      !$acc                   zMid,                                    &
-      !$acc                   zTop,                                    &
-      !$acc                   xtime,                                   &
-      !$acc                   indMLD,                                  &
-      !$acc                   dThreshMLD,                              &
-      !$acc                   density,                                 &
-      !$acc                   betaEdge,                                &
-      !$acc                   pressure,                                &
-      !$acc                   thermExpCoeff,                           &
-      !$acc                   sfcFlxAttCoeff,                          &
-      !$acc                   surfacePressure,                         &
-      !$acc                   potentialDensity,                        &
-      !$acc                   displacedDensity,                        &
-      !$acc                   boundaryLayerDepth,                      &
-      !$acc                   salineContractCoeff,                     &
-      !$acc                   pressureAdjustedSSH,                     &
-      !$acc                   tracersSurfaceValue,                     &
-      !$acc                   daysSinceStartOfSim,                     &
-      !$acc                   Time,                                    &
-      !$acc                   Time_bnds,                               &
-      !$acc                   simulationStartTime,                     &
-      !$acc                   boundaryLayerDepthSmooth,                &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
-      !$acc                   )
 
     end subroutine ocn_diagnostics_variables_init!}}}
 
@@ -912,218 +701,6 @@ contains
       !***
 
       err = 0
-
-      ! Remove data from the device
-      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
-         !$acc exit data delete(                                  &
-         !$acc                   topDrag,                         &
-         !$acc                   topDragMag,                      &
-         !$acc                   landIceBoundaryLayerTracers,     &
-         !$acc                   landIceTracerTransferVelocities, &
-         !$acc                   landIceFrictionVelocity)
-      end if
-      if (config_use_topographic_wave_drag) then
-         !$acc exit data delete(topographic_wave_drag)
-      end if
-      if (config_use_self_attraction_loading) then
-         !$acc exit data delete(ssh_sal)
-      end if
-      if ( trim(config_ocean_run_mode) == 'init' ) then
-         !$acc exit data delete(                           &
-         !$acc                   rx1Edge,                  &
-         !$acc                   rx1Cell,                  &
-         !$acc                   rx1MaxEdge,               &
-         !$acc                   smoothingMask,            &
-         !$acc                   verticalStretch,          &
-         !$acc                   globalVerticalStretchMax, &
-         !$acc                   globalVerticalStretchMin  &
-         !$acc                   )
-      end if
-      if ( trim(config_ocean_run_mode) == 'init' .or. &
-                config_AM_debugDiagnostics_enable ) then
-         !$acc exit data delete(                           &
-         !$acc                   rx1MaxCell,               &
-         !$acc                   globalRx1Max)
-      end if
-      if ( trim(config_ocean_run_mode) == 'forward' .or. &
-           trim(config_ocean_run_mode) == 'analysis' ) then
-         !$acc exit data delete(                                  &
-         !$acc                   k33,                             &
-         !$acc                   gradSSH,                         &
-         !$acc                   gradSSHX,                        &
-         !$acc                   gradSSHY,                        &
-         !$acc                   gradSSHZ,                        &
-         !$acc                   viscosity,                       &
-         !$acc                   velocityX,                       &
-         !$acc                   velocityY,                       &
-         !$acc                   velocityZ,                       &
-         !$acc                   divergence,                      &
-         !$acc                   RiTopOfCell,                     &
-         !$acc                   RiTopOfEdge,                     &
-         !$acc                   SSHGradient,                     &
-         !$acc                   circulation,                     &
-         !$acc                   slopeTriadUp,                    &
-         !$acc                   gradSSHZonal,                    &
-         !$acc                   cGMphaseSpeed,                   &
-         !$acc                   velocityZonal,                   &
-         !$acc                   GMStreamFuncX,                   &
-         !$acc                   GMStreamFuncY,                   &
-         !$acc                   GMStreamFuncZ,                   &
-         !$acc                   layerThickEdgeFlux,              &
-         !$acc                   layerThickEdgeMean,              &
-         !$acc                   slopeTriadDown,                  &
-         !$acc                   normRelVortEdge,                 &
-         !$acc                   surfaceVelocity,                 &
-         !$acc                   vertVelocityTop,                 &
-         !$acc                   eddyVelocityX,                   &
-         !$acc                   eddyVelocityY,                   &
-         !$acc                   eddyVelocityZ,                   &
-         !$acc                   vertNonLocalFlux,                &
-         !$acc                   vertViscTopOfEdge,               &
-         !$acc                   gradSSHMeridional,               &
-         !$acc                   barotropicForcing,               &
-         !$acc                   vertViscTopOfCell,               &
-         !$acc                   vertDiffTopOfCell,               &
-         !$acc                   GMStreamFuncZonal,               &
-         !$acc                   relativeVorticity,               &
-         !$acc                   kineticEnergyCell,               &
-         !$acc                   normPlanetVortEdge,              &
-         !$acc                   velocityMeridional,              &
-         !$acc                   transportVelocityX,              &
-         !$acc                   transportVelocityY,              &
-         !$acc                   transportVelocityZ,              &
-         !$acc                   tangentialVelocity,              &
-         !$acc                   montgomeryPotential,             &
-         !$acc                   BruntVaisalaFreqTop,             &
-         !$acc                   vertAleTransportTop,             &
-         !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   mleVelocityZonal,                &
-         !$acc                   bulkRichardsonNumber,            &
-         !$acc                   gmStreamFuncTopOfEdge,           &
-         !$acc                   relativeVorticityCell,           &
-         !$acc                   normalGMBolusVelocity,           &
-         !$acc                   normalMLEvelocity,               &
-         !$acc                   vertGMBolusVelocityTop,          &
-         !$acc                   vertMLEBolusVelocityTop,         &
-         !$acc                   transportVelocityZonal,          &
-         !$acc                   GMStreamFuncMeridional,          &
-         !$acc                   indexSurfaceLayerDepth,          &
-         !$acc                   surfaceBuoyancyForcing,          &
-         !$acc                   surfaceFrictionVelocity,         &
-         !$acc                   indexBoundaryLayerDepth,         &
-         !$acc                   barotropicThicknessFlux,         &
-         !$acc                   normalTransportVelocity,         &
-         !$acc                   vertTransportVelocityTop,        &
-         !$acc                   bulkRichardsonNumberBuoy,        &
-         !$acc                   tracersSurfaceLayerValue,        &
-         !$acc                   mleVelocityMeridional,           &
-         !$acc                   GMBolusVelocityMeridional,       &
-         !$acc                   bulkRichardsonNumberShear,       &
-         !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   transportVelocityMeridional,     &
-         !$acc                   penetrativeTemperatureFluxOBL,   &
-         !$acc                   indexSurfaceVelocityMeridional,  &
-         !$acc                   normalizedRelativeVorticityCell, &
-         !$acc                   nhPressureCorrection             &
-         !$acc                   )
-      end if
-      if ( trim(config_ocean_run_mode) == 'forward' ) then
-         !$acc exit data delete(                              &
-         !$acc                   wettingVelocity              &
-         !$acc                   )
-      end if
-      if (config_use_GM.or.config_use_Redi) then
-         !$acc exit data delete(                    &
-         !$acc                   RediKappa,         &
-         !$acc                   gmBolusKappa,      &
-         !$acc                   gmKappaScaling,    &
-         !$acc                   RediKappaScaling,  &
-         !$acc                   rediLimiterCount,  &
-         !$acc                   RediKappaSfcTaper, &
-         !$acc                   RediHorizontalTaper,  &
-         !$acc                   gmHorizontalTaper,  &
-         !$acc                   RossbyRadius  &
-         !$acc                   )
-      end if
-      if (config_use_GM.or.config_submesoscale_enable) then
-         !$acc exit data delete(gradDensityEddy)
-      end if
-      if ( config_compute_active_tracer_budgets ) then
-         !$acc exit data delete(                                          &
-         !$acc                   activeTracerHorMixTendency,              &
-         !$acc                   activeTracerVertMixTendency,             &
-         !$acc                   temperatureShortWaveTendency,            &
-         !$acc                   activeTracerNonLocalTendency,            &
-         !$acc                   activeTracerSurfaceFluxTendency,         &
-         !$acc                   activeTracerVerticalAdvectionTopFlux,    &
-         !$acc                   activeTracerVerticalAdvectionTendency,   &
-         !$acc                   activeTracerHorizontalAdvectionTendency, &
-         !$acc                   activeTracerHorizontalAdvectionEdgeFlux  &
-         !$acc                   )
-      end if
-      if ( config_use_activeTracers_surface_restoring ) then
-         !$acc exit data delete(                                   &
-         !$acc                   salinitySurfaceRestoringTendency  &
-         !$acc                   )
-      end if
-      if ( trim(config_time_integrator) == 'split_implicit' ) then
-         !$acc exit data delete(                        &
-         !$acc                   SIvec_r0,              &
-         !$acc                   SIvec_r00,             &
-         !$acc                   SIvec_r1,              &
-         !$acc                   SIvec_rh0,             &
-         !$acc                   SIvec_rh1,             &
-         !$acc                   SIvec_ph0,             &
-         !$acc                   SIvec_ph1,             &
-         !$acc                   SIvec_v0,              &
-         !$acc                   SIvec_v0,              &
-         !$acc                   SIvec_s0,              &
-         !$acc                   SIvec_s1,              &
-         !$acc                   SIvec_sh0,             &
-         !$acc                   SIvec_sh1,             &
-         !$acc                   SIvec_t0,              &
-         !$acc                   SIvec_t1,              &
-         !$acc                   SIvec_q0,              &
-         !$acc                   SIvec_q1,              &
-         !$acc                   SIvec_qh0,             &
-         !$acc                   SIvec_w0,              &
-         !$acc                   SIvec_w1,              &
-         !$acc                   SIvec_wh0,             &
-         !$acc                   SIvec_wh1,             &
-         !$acc                   SIvec_y0,              &
-         !$acc                   SIvec_z0,              &
-         !$acc                   SIvec_z1,              &
-         !$acc                   SIvec_zh0,             &
-         !$acc                   SIvec_zh1,             &
-         !$acc                   barotropicCoriolisTerm &
-         !$acc                   )
-      end if
-
-      !$acc exit data delete(                                          &
-      !$acc                   zMid,                                    &
-      !$acc                   zTop,                                    &
-      !$acc                   xtime,                                   &
-      !$acc                   indMLD,                                  &
-      !$acc                   dThreshMLD,                              &
-      !$acc                   density,                                 &
-      !$acc                   betaEdge,                                &
-      !$acc                   pressure,                                &
-      !$acc                   thermExpCoeff,                           &
-      !$acc                   sfcFlxAttCoeff,                          &
-      !$acc                   surfacePressure,                         &
-      !$acc                   potentialDensity,                        &
-      !$acc                   displacedDensity,                        &
-      !$acc                   boundaryLayerDepth,                      &
-      !$acc                   salineContractCoeff,                     &
-      !$acc                   pressureAdjustedSSH,                     &
-      !$acc                   tracersSurfaceValue,                     &
-      !$acc                   daysSinceStartOfSim,                     &
-      !$acc                   Time,                                    &
-      !$acc                   Time_bnds,                               &
-      !$acc                   simulationStartTime,                     &
-      !$acc                   boundaryLayerDepthSmooth,                &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
-      !$acc                   )
 
       ! Nullify pointers
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then

--- a/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -80,6 +80,9 @@ module ocn_eddy_parameterization_helpers
               gradZMidEdge(nVertLevels, nEdges), &
               gradZMidTopOfEdge(nVertLevels+1, nEdges))
 
+!$acc update host(minLevelCell,maxLevelCell,minLevelEdgeBot,maxLevelEdgeTop,cellsOnEdge,dcEdge,&
+!$acc             displacedDensity,density,zMid,layerThickEdgeMean,gradDensityEddy)
+
      !$omp parallel
      !$omp do schedule(runtime) private(k)
      do iEdge=1,nEdgesAll
@@ -173,6 +176,7 @@ module ocn_eddy_parameterization_helpers
      end do
      !$omp end do
      !$omp end parallel
+!$acc update device(gradDensityEddy)
      deallocate(gradDensityEdge, &
                 dDensityDzTopOfCell, &
                 gradDensityTopOfEdge, &
@@ -210,9 +214,12 @@ module ocn_eddy_parameterization_helpers
      nCells = nCellsAll
 
      if ( config_eddyMLD_use_old ) then
-       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+       call mpas_pool_get_array_gpu(forcingPool, 'landIcePressure', landIcePressure)
+       call mpas_pool_get_array_gpu(forcingPool, 'landIceDraft', landIceDraft)
+       call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+!$acc update host(landIcePressure,landIceDraft,landIceMask,&
+!$acc             maxLevelCell,&
+!$acc             pressure,potentialDensity,zMid,dThreshMLD,indMLD)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -294,10 +301,14 @@ module ocn_eddy_parameterization_helpers
           !$omp end parallel
         end if
 
+!$acc update device(dThreshMLD,indMLD)
         deallocate(pressureAdjustedForLandIce)
 
     else ! fixed mixed layer depth code
-       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+       call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, 1)
+!$acc update host(layerThickness,&
+!$acc             maxLevelCell,&
+!$acc             potentialDensity,dThreshMLD,indMLD)
        allocate(depth(nVertLevels))
        refDepth = config_eddyMLD_reference_depth
 
@@ -355,6 +366,7 @@ module ocn_eddy_parameterization_helpers
        !$omp end do
        !$omp end parallel
 
+!$acc update device(dThreshMLD,indMLD)
        deallocate(depth)
 
     end if !end mld calculation choice

--- a/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -45,7 +45,8 @@ module ocn_effective_density_in_land_ice
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_effective_density_in_land_ice_update
+   public :: ocn_effective_density_in_land_ice_update, &
+             ocn_effective_density_in_land_ice_update_gpu
 
    !--------------------------------------------------------------------
    !
@@ -139,23 +140,14 @@ contains
                                            effectiveDensityCur, 1)
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
                                            effectiveDensityNew, 2)
-      !$acc enter data copyin(landIceMask, landIcePressure, ssh, &
-      !$acc                   effectiveDensityCur, effectiveDensityNew)
 
       allocate(effectiveDensityScratch(nCellsAll))
-      !$acc enter data create(effectiveDensityScratch)
 
       ! Compute effective density in each cell
       ! TODO: should only apply to floating land ice,
       !       once wetting/drying is supported
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(effectiveDensityScratch, effectiveDensityCur, &
-      !$acc            landIcePressure, landIceMask, ssh)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
          if (landIceMask(iCell) == 1) then
             ! land ice is present to update the effective density
@@ -166,19 +158,10 @@ contains
             effectiveDensityScratch(iCell) = effectiveDensityCur(iCell)
          end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! smooth/extrapolate density by averaging with nearest neighbors
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(effectiveDensityNew, effectiveDensityScratch, &
-      !$acc            nEdgesOnCell, cellsOnCell, cellMask) &
-      !$acc    private(weightSum)
-#else
       !$omp do schedule(runtime) private(weightSum, i, cell2)
-#endif
       do iCell = 1, nCellsAll
          weightSum = 1.0_RKIND
          effectiveDensityNew(iCell) = effectiveDensityScratch(iCell)
@@ -192,19 +175,128 @@ contains
          effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/ &
                                       weightSum
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(effectiveDensityScratch)
-      !$acc exit data delete(landIceMask, landIcePressure, ssh, &
-      !$acc                  effectiveDensityCur, effectiveDensityNew)
       deallocate(effectiveDensityScratch)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_effective_density_in_land_ice_update !}}}
+
+   subroutine ocn_effective_density_in_land_ice_update_gpu(forcingPool, &
+                                                    statePool, ierr)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         forcingPool !< [in] Forcing information
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         statePool !< [inout] state information
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: ierr !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, iCell,  &! loop indices for neighbor loop and cell loop
+         cell2       ! neighbor cell address
+
+      real (kind=RKIND) :: &
+         weightSum   ! local sum of weights for masked points
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         ssh,                 &! sea surface height
+         landIcePressure,     &! land ice pressure
+         effectiveDensityCur, &! effective density at current time
+         effectiveDensityNew   ! effective density at new time level
+                                                  
+      integer, dimension(:), pointer :: &
+         landIceMask           ! mask for land ice presence on cell
+
+      ! Scratch Arrays
+      ! effectiveDensityScratch: effective seawater density in land
+      ! ice before horizontal averaging units: kg m^{-3}
+      real (kind=RKIND), dimension(:), allocatable :: &
+         effectiveDensityScratch
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Set default return code and exit if not needed
+      ierr = 0
+      if ( (trim(config_land_ice_flux_mode) /= 'coupled') ) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
+
+      ! Retrieve forcing and state variables
+      call mpas_pool_get_array(forcingPool, 'landIceMask', &
+                                             landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIcePressure', &
+                                             landIcePressure)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
+                                           effectiveDensityCur, 1)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
+                                           effectiveDensityNew, 2)
+
+      allocate(effectiveDensityScratch(nCellsAll))
+
+      ! Compute effective density in each cell
+      ! TODO: should only apply to floating land ice,
+      !       once wetting/drying is supported
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+         if (landIceMask(iCell) == 1) then
+            ! land ice is present to update the effective density
+            effectiveDensityScratch(iCell) = -landIcePressure(iCell)/ &
+                                              (ssh(iCell)*gravity)
+         else
+            ! we copy the previous effective density
+            effectiveDensityScratch(iCell) = effectiveDensityCur(iCell)
+         end if
+      end do
+      !$omp end do
+
+      ! smooth/extrapolate density by averaging with nearest neighbors
+      !$omp do schedule(runtime) private(weightSum, i, cell2)
+      do iCell = 1, nCellsAll
+         weightSum = 1.0_RKIND
+         effectiveDensityNew(iCell) = effectiveDensityScratch(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            cell2 = cellsOnCell(i,iCell)
+            effectiveDensityNew(iCell) = effectiveDensityNew(iCell) &
+                                       + cellMask(1,cell2)* &
+                                         effectiveDensityScratch(cell2)
+            weightSum = weightSum + cellMask(1,cell2)
+         end do
+         effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/ &
+                                      weightSum
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(effectiveDensityScratch)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_effective_density_in_land_ice_update_gpu !}}}
+
 
 !***********************************************************************
 

--- a/src/shared/mpas_ocn_equation_of_state.F
+++ b/src/shared/mpas_ocn_equation_of_state.F
@@ -49,13 +49,20 @@ module ocn_equation_of_state
    !--------------------------------------------------------------------
 
    public :: ocn_equation_of_state_density, &
+             ocn_equation_of_state_density_gpu, &
              ocn_equation_of_state_init, &
              ocn_freezing_temperature, &
+             ocn_freezing_temperature_gpu, &
              ocn_freezing_temperature_salinity_deriv
 
    interface ocn_equation_of_state_density
       module procedure ocn_equation_of_state_density_openacc
       module procedure ocn_equation_of_state_density_original
+   end interface
+
+   interface ocn_equation_of_state_density_gpu
+      module procedure ocn_equation_of_state_density_openacc_gpu
+      module procedure ocn_equation_of_state_density_original_gpu
    end interface
 
    !--------------------------------------------------------------------
@@ -247,6 +254,160 @@ contains
 
    end subroutine ocn_equation_of_state_density_openacc!}}}
 
+   subroutine ocn_equation_of_state_density_openacc_gpu(statePool, meshPool, activeTracers, tracersSurfaceValue, &
+                           nCells, kDisplaced, displacement_type, density, err,       &
+                           thermalExpansionCoeff, salineContractionCoeff, timeLevelIn)
+      !{{{
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horiz mesh cells
+         kDisplaced           ! target vert level for adiab displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         activeTracers
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceValue
+
+      integer, intent(in), optional :: &
+         timeLevelIn          ! time level for state variables
+
+      character(len=*), intent(in) :: &
+         displacement_type    ! choice for adiabatic displacement
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,           &! pool containing state variables
+         meshPool              ! pool containing mesh quantities
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! returned error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density of sea water
+
+      ! optional expansion coefficients
+      ! Thermal expansion, defined as $-1/\rho d\rho/dT$ (note neg sign)
+      ! Saline contraction, defined as $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out), optional :: &
+         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha)
+         salineContractionCoeff   ! Saline contraction coefficient (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: tracersPool
+
+      integer, dimension(:), pointer :: maxLevelCell
+      integer :: nVertLevels, indexT, indexS
+      integer, pointer :: indexTptr, indexSptr
+      integer :: timeLevel
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag, start timer
+      err = 0
+
+      call mpas_timer_start("equation of state gpu")
+!NV!  !!! EXECUTING !!!
+
+      !*** initialize or extract relevant fields
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      call mpas_pool_get_subpool  (statePool,   'tracers', &
+                                                 tracersPool)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTptr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSptr)
+      call mpas_pool_get_array_gpu(meshPool,    'maxLevelCell', &
+                                                 maxLevelCell)
+
+      indexT      = indexTptr
+      indexS      = indexSptr
+      nVertLevels = size(density,1)
+
+      !*** call specific equation of state based on user choice
+
+      select case (ocnEqStateChoice)
+
+      case (ocnEqStateTypeLinear)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_equation_of_state_density_openacc_gpu ocnEqStateTypeLinear NOT EXECUTING"
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_linear_density_gpu(nVertLevels,  &
+                     nCells, kDisplaced, displacement_type,         &
+                     indexT, indexS, activeTracers, density, err,   &
+                     thermalExpansionCoeff, salineContractionCoeff, &
+                     tracersSurfaceValue)
+         else
+            call ocn_equation_of_state_linear_density_gpu(nVertLevels, &
+                     nCells, kDisplaced, displacement_type,        &
+                     indexT, indexS, activeTracers, density, err,  &
+                     tracersSurfaceValue)
+         endif
+
+      case (ocnEqStateTypeJM)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_jm_density_gpu(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_jm_density_gpu(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     tracersSurfaceValue)
+         endif
+
+      case (ocnEqStateTypeWright)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_equation_of_state_density_openacc_gpu ocnEqStateTypeWright NOT EXECUTING"
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_wright_density_gpu(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err,                      &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_wright_density_gpu(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err, tracersSurfaceValue)
+         endif
+
+      case default
+         !*** error handled during init
+      end select
+
+      !*** stop timer and exit
+
+      call mpas_timer_stop("equation of state gpu")
+
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_density_openacc_gpu!}}}
+
    subroutine ocn_equation_of_state_density_original(statePool, meshPool, tracersSurfaceValue, &
                            nCells, kDisplaced, displacement_type, density, err,       &
                            thermalExpansionCoeff, salineContractionCoeff, timeLevelIn)
@@ -398,6 +559,157 @@ contains
 
    end subroutine ocn_equation_of_state_density_original!}}}
 
+   subroutine ocn_equation_of_state_density_original_gpu(statePool, meshPool, tracersSurfaceValue, &
+                           nCells, kDisplaced, displacement_type, density, err,       &
+                           thermalExpansionCoeff, salineContractionCoeff, timeLevelIn)
+      !{{{
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horiz mesh cells
+         kDisplaced           ! target vert level for adiab displacement
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceValue
+
+      integer, intent(in), optional :: &
+         timeLevelIn          ! time level for state variables
+
+      character(len=*), intent(in) :: &
+         displacement_type    ! choice for adiabatic displacement
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,           &! pool containing state variables
+         meshPool              ! pool containing mesh quantities
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! returned error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density of sea water
+
+      ! optional expansion coefficients
+      ! Thermal expansion, defined as $-1/\rho d\rho/dT$ (note neg sign)
+      ! Saline contraction, defined as $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out), optional :: &
+         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha)
+         salineContractionCoeff   ! Saline contraction coefficient (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: tracersPool
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+      integer, dimension(:), pointer :: maxLevelCell
+      integer :: nVertLevels, indexT, indexS
+      integer, pointer :: indexTptr, indexSptr
+      integer :: timeLevel
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag, start timer
+      err = 0
+
+      call mpas_timer_start("equation of state gpu")
+
+      !*** initialize or extract relevant fields
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      call mpas_pool_get_subpool  (statePool,   'tracers', &
+                                                 tracersPool)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
+                                                 activeTracers, timeLevel)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTptr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSptr)
+      call mpas_pool_get_array_gpu(meshPool,    'maxLevelCell', &
+                                                 maxLevelCell)
+
+      indexT      = indexTptr
+      indexS      = indexSptr
+      nVertLevels = size(density,1)
+
+      !*** call specific equation of state based on user choice
+
+      select case (ocnEqStateChoice)
+
+      case (ocnEqStateTypeLinear)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_linear_density_gpu(nVertLevels,  &
+                     nCells, kDisplaced, displacement_type,         &
+                     indexT, indexS, activeTracers, density, err,   &
+                     thermalExpansionCoeff, salineContractionCoeff, &
+                     tracersSurfaceValue)
+         else
+            call ocn_equation_of_state_linear_density_gpu(nVertLevels, &
+                     nCells, kDisplaced, displacement_type,        &
+                     indexT, indexS, activeTracers, density, err,  &
+                     tracersSurfaceValue)
+         endif
+
+      case (ocnEqStateTypeJM)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_jm_density_gpu(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_jm_density_gpu(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     tracersSurfaceValue)
+         endif
+
+      case (ocnEqStateTypeWright)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_wright_density_gpu(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err,                      &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_wright_density_gpu(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err, tracersSurfaceValue)
+         endif
+
+      case default
+         !*** error handled during init
+      end select
+
+      !*** stop timer and exit
+
+      call mpas_timer_stop("equation of state gpu")
+
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_density_original_gpu!}}}
+
 
 !***********************************************************************
 !
@@ -516,6 +828,49 @@ contains
          + coeff_mushy * salinity / (1.0_RKIND - salinity / 1e3_RKIND)
 
     end function ocn_freezing_temperature!}}}
+
+    real (kind=RKIND) function ocn_freezing_temperature_gpu(salinity, pressure, inLandIceCavity)!{{{
+!$acc routine seq
+      real (kind=RKIND), intent(in) :: salinity !< Input: Salinity value of water for freezing temperature
+      real (kind=RKIND), intent(in) :: pressure !< Input: Pressure value for freezing temperature
+      logical, intent(in) :: inLandIceCavity !< Input: flag indicating if the freezing temperature is computed
+                                             !         in land ice cavities or in open ocean
+
+      real (kind=RKIND) :: coeff_0, coeff_S, coeff_p, coeff_pS, az1_liq
+      real (kind=RKIND) :: coeff_mushy
+
+      if(inLandIceCavity) then
+!NV!         coeff_0 = config_land_ice_cavity_freezing_temperature_coeff_0
+!NV!         coeff_S = config_land_ice_cavity_freezing_temperature_coeff_S
+!NV!         coeff_p = config_land_ice_cavity_freezing_temperature_coeff_p
+!NV!         coeff_pS = config_land_ice_cavity_freezing_temperature_coeff_pS
+!NV!         coeff_mushy = 0.0_RKIND
+         coeff_0 = mod_lic_coeff_0
+         coeff_S = mod_lic_coeff_S
+         coeff_p = mod_lic_coeff_p
+         coeff_pS = mod_lic_coeff_pS
+         coeff_mushy = 0.0_RKIND
+      else
+!NV!         coeff_0 = config_open_ocean_freezing_temperature_coeff_0
+!NV!         coeff_S = config_open_ocean_freezing_temperature_coeff_S
+!NV!         coeff_p = config_open_ocean_freezing_temperature_coeff_p
+!NV!         coeff_pS = config_open_ocean_freezing_temperature_coeff_pS
+!NV!         az1_liq = config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+         coeff_0 = mod_oo_coeff_0
+         coeff_S = mod_oo_coeff_S
+         coeff_p = mod_oo_coeff_p
+         coeff_pS = mod_oo_coeff_pS
+         az1_liq = mod_oo_az1_liq
+         coeff_mushy = 1.0_RKIND / az1_liq
+      end if
+
+      ocn_freezing_temperature_gpu = coeff_0 &
+         + coeff_S * salinity &
+         + coeff_p * pressure &
+         + coeff_pS * pressure * salinity &
+         + coeff_mushy * salinity / (1.0_RKIND - salinity / 1e3_RKIND)
+
+    end function ocn_freezing_temperature_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/shared/mpas_ocn_equation_of_state_jm.F
@@ -43,6 +43,7 @@ module ocn_equation_of_state_jm
    !--------------------------------------------------------------------
 
    public :: ocn_equation_of_state_jm_density, &
+             ocn_equation_of_state_jm_density_gpu, &
              ocn_equation_of_state_jm_init
 
    !*** generic interface for case of density only or density and
@@ -50,6 +51,10 @@ module ocn_equation_of_state_jm
    interface ocn_equation_of_state_jm_density
       module procedure ocn_equation_of_state_jm_density_only
       module procedure ocn_equation_of_state_jm_density_exp
+   end interface
+   interface ocn_equation_of_state_jm_density_gpu
+      module procedure ocn_equation_of_state_jm_density_only_gpu
+      module procedure ocn_equation_of_state_jm_density_exp_gpu
    end interface
 
    !--------------------------------------------------------------------
@@ -62,6 +67,7 @@ module ocn_equation_of_state_jm
 
    real (kind=RKIND), dimension(:), allocatable :: &
       ocnEqStatePRef   ! reference pressure at each layer
+!$acc declare create(ocnEqStatePRef)
 
    !*** valid range of T,S for Jackett and McDougall
 
@@ -239,9 +245,6 @@ contains
       !*** allocate and compute pressure array
 
       allocate(p(nVertLevels),p2(nVertLevels))
-#ifdef MPAS_OPENACC
-      !$acc enter data create(p, p2)
-#endif
 
       ! Determine pressure to use in density calculation
       !  If kDisplaced=0, in-situ density is returned (no displacement)
@@ -273,19 +276,11 @@ contains
 
       if (kDisplacedLocal == 0) then
          ! use pressure at in situ level
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(p, p2, ocnEqStatePRef)
-#endif
          do k=1,nVertLevels
             p (k) = ocnEqStatePRef(k)
             p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
          enddo
       else ! kDisplacedLocal /= 0
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(p, p2, ocnEqStatePRef)
-#endif
          do k=1,nVertLevels
             ! determine level to which parcel is displaced
             !  and thus which pressure (depth) to use in EOS
@@ -306,18 +301,11 @@ contains
       ! For OpenACC, these are device resident only
       allocate(tracerTemp(nVertLevels,nCells), &
                tracerSalt(nVertLevels,nCells))
-      !$acc enter data create(tracerTemp, tracerSalt)
 
       if (displacementType == 'surfaceDisplaced') then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc    present(tracerssurfacelayervalue, &
-         !$acc            tracerTemp, tracerSalt)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
-#endif
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -328,20 +316,13 @@ contains
             tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
          enddo
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       else
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc    present(tracers, tracerTemp, tracerSalt)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
-#endif
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -350,21 +331,14 @@ contains
             tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2) &
-      !$acc&   present(density, tracerTemp, tracerSalt, p, p2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod)
-#endif
       do iCell=1,nCells
       do k=1,nVertLevels
 
@@ -411,18 +385,251 @@ contains
 
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
       deallocate(p,p2)
       deallocate(tracerTemp, tracerSalt)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_jm_density_only!}}}
+
+   subroutine ocn_equation_of_state_jm_density_only_gpu(nVertLevels,      &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, density, err, &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of vertical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         iCell, k,        &! cell and vertical level loop indices
+         kTmp, kRef,      &! indices to determine ref level for pressure
+         kDisplacedLocal   ! locally modified displacement target level
+
+      character(len=60) :: &
+         displacementTypeLocal ! locally modified displacement type
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         p, p2 ! temporary pressure scalars
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,          &! modified temperature
+         tracerSalt            ! modified salinity
+
+      real (kind=RKIND) :: &
+         work1, work2,     &! temporary scalars for calc
+         work3, work4,     &!
+         tq, sq,           &! adjusted T,S
+         t2, sqr,          &! temperature squared and square root salt
+         bulkMod,          &! Bulk modulus
+         rhosfc             ! density at the surface
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** allocate and compute pressure array
+      allocate(p(nVertLevels),p2(nVertLevels))
+      ! For OpenACC, these are device resident only
+      allocate(tracerTemp(nVertLevels,nCells), &
+               tracerSalt(nVertLevels,nCells))
+
+!$acc data present(ocnEqStatePRef,tracersSurfaceLayerValue,tracers,density) &
+!$acc      create(p,p2,tracerTemp,tracerSalt)
+
+      ! Determine pressure to use in density calculation
+      !  If kDisplaced=0, in-situ density is returned (no displacement)
+      !  If kDisplaced/=0, potential density is returned
+
+      !  if displacementType = 'relative', potential density is calculated
+      !     referenced to level k + kDisplaced
+      !  if displacementType = 'absolute', potential density is calculated
+      !     referenced to level kDisplaced for all k
+      !  NOTE: kDisplaced = 0 or > nVertLevels is incompatible with 'absolute'
+      !     so abort if necessary
+
+      if (displacementType == 'surfaceDisplaced') then
+         displacementTypeLocal = 'relative'
+         kDisplacedLocal = 0
+      else
+         displacementTypeLocal = trim(displacementType)
+         kDisplacedLocal = kDisplaced
+      endif
+
+      ! Eliminate this error check for performance reasons
+      !if (displacementTypeLocal == 'absolute' .and.   &
+      !   (kDisplacedLocal <= 0 .or. kDisplacedLocal > nVertLevels) ) then
+      !
+      !   call mpas_log_write('Abort: In equation_of_state_jm' // &
+      !       ' kDisplaced must be between 1 and nVertLevels for ' // &
+      !       'displacementType = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      if (kDisplacedLocal == 0) then
+         ! use pressure at in situ level
+!$acc parallel
+!$acc loop gang vector
+         do k=1,nVertLevels
+            p (k) = ocnEqStatePRef(k)
+            p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
+         enddo
+!$acc end parallel
+      else ! kDisplacedLocal /= 0
+!$acc parallel
+!$acc loop gang vector private(kTmp,kRef)
+         do k=1,nVertLevels
+            ! determine level to which parcel is displaced
+            !  and thus which pressure (depth) to use in EOS
+            if (displacementTypeLocal == 'relative') then
+               kTmp = min(k + kDisplacedLocal, nVertLevels)
+            else
+               kTmp = min(kDisplacedLocal, nVertLevels)
+            endif
+            kRef  = max(kTmp, 1)  ! make sure index bounded to 1
+            p (k) = ocnEqStatePRef(kRef)
+            p2(k) = ocnEqStatePRef(kRef)*ocnEqStatePRef(kRef)
+         enddo
+!$acc end parallel
+      endif
+
+      !*** compute modified T,S to account for displacement and
+      !*** valid range
+
+      if (displacementType == 'surfaceDisplaced') then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, tq, sq)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(tq,sq)
+         do iCell=1,nCells
+         do k=1,nVertLevels
+            tq = min(tracersSurfaceLayerValue(indexT,iCell), &
+                     ocnEqStateTmax)
+            sq = min(tracersSurfaceLayerValue(indexS,iCell), &
+                     ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         enddo
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, tq, sq)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(tq,sq)
+         do iCell=1,nCells
+         do k = 1, nVertLevels
+            tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
+            sq = min(tracers(indexS,k,iCell), ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      endif
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(sq,tq,sqr,t2,work1,work2,rhosfc,work3,work4,bulkMod)
+      do iCell=1,nCells
+      do k=1,nVertLevels
+
+         sq  = tracerSalt(k,iCell)
+         tq  = tracerTemp(k,iCell)
+
+         sqr = sqrt(sq)
+         t2  = tq*tq
+
+         !***
+         !*** first calculate surface (p=0) values from UNESCO eqns.
+         !***
+
+         work1 =      uns1t0 + uns1t1*tq + &
+                     (uns1t2 + uns1t3*tq + uns1t4*t2)*t2
+         work2 = sqr*(unsqt0 + unsqt1*tq + unsqt2*t2)
+
+         rhosfc = unt1*tq + (unt2 + unt3*tq + (unt4 + unt5*tq)*t2)*t2 &
+                          + (uns2t0*sq + work1 + work2)*sq
+
+         !***
+         !*** now calculate bulk modulus at pressure p from
+         !*** Jackett and McDougall formula
+         !***
+
+         work3 = bup0s1t0 + bup0s1t1*tq +     &
+                (bup0s1t2 + bup0s1t3*tq)*t2 + &
+          p(k) *(bup1s1t0 + bup1s1t1*tq + bup1s1t2*t2) + &
+          p2(k)*(bup2s1t0 + bup2s1t1*tq + bup2s1t2*t2)
+
+         work4 = sqr*(bup0sqt0 + bup0sqt1*tq + bup0sqt2*t2 + &
+                      bup1sqt0*p(k))
+
+         bulkMod = bup0s0t0 + bup0s0t1*tq +                    &
+                  (bup0s0t2 + bup0s0t3*tq + bup0s0t4*t2)*t2 + &
+            p(k) *(bup1s0t0 + bup1s0t1*tq +                &
+                  (bup1s0t2 + bup1s0t3*tq)*t2) +           &
+            p2(k)*(bup2s0t0 + bup2s0t1*tq + bup2s0t2*t2) + &
+                   sq*(work3 + work4)
+
+
+         density(k,iCell) = (unt0 + rhosfc)*bulkMod/ &
+                            (bulkMod - p(k))
+
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(p,p2)
+      deallocate(tracerTemp, tracerSalt)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_jm_density_only_gpu!}}}
 
 !***********************************************************************
 !
@@ -538,9 +745,6 @@ contains
       !*** allocate and compute pressure array
 
       allocate(p(nVertLevels),p2(nVertLevels))
-#ifdef MPAS_OPENACC
-      !$acc enter data create(p, p2)
-#endif
 
       ! Determine pressure to use in density calculation
       !  If kDisplaced=0, in-situ density is returned (no displacement)
@@ -572,19 +776,11 @@ contains
 
       if (kDisplacedLocal == 0) then
          ! use pressure at in situ level
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(p, p2, ocnEqStatePRef)
-#endif
          do k=1,nVertLevels
             p (k) = ocnEqStatePRef(k)
             p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
          enddo
       else ! kDisplacedLocal /= 0
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc    present(p, p2, ocnEqStatePRef)
-#endif
          do k=1,nVertLevels
             ! determine level to which parcel is displaced
             !  and thus which pressure (depth) to use in EOS
@@ -605,18 +801,11 @@ contains
       ! For OpenACC, these are device resident only
       allocate(tracerTemp(nVertLevels,nCells), &
                tracerSalt(nVertLevels,nCells))
-      !$acc enter data create(tracerTemp, tracerSalt)
 
       if (displacementType == 'surfaceDisplaced') then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc    present(tracerssurfacelayervalue, &
-         !$acc            tracerTemp, tracerSalt)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
-#endif
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -627,20 +816,13 @@ contains
             tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
          enddo
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       else
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc    present(tracers, tracerTemp, tracerSalt)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
-#endif
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -649,25 +831,16 @@ contains
             tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2)     &
-      !$acc    present(density, tracerTemp, tracerSalt, p, p2, &
-      !$acc            thermalExpansionCoeff,         &
-      !$acc            salineContractionCoeff)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, sq, tq, sqr, t2, rhosfc, bulkMod, &
       !$omp         work1, work2, work3, work4, denomk, &
       !$omp         drdt0, dkdt, drhodt, drds0, dkds, drhods)
-#endif
       do iCell=1,nCells
       do k=1,nVertLevels
 
@@ -759,18 +932,315 @@ contains
 
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
       deallocate(p,p2)
       deallocate(tracerTemp, tracerSalt)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_jm_density_exp!}}}
+
+   subroutine ocn_equation_of_state_jm_density_exp_gpu(nVertLevels,       &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, density, err, &
+                               thermalExpansionCoeff,                 &
+                               salineContractionCoeff,                &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of vertical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      ! Thermal expansion coeff, $-1/\rho d\rho/dT$ (note negative sign)
+      ! Saline contraction coeff, $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion  coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         iCell, k,        &! cell and vertical level loop indices
+         kTmp, kRef,      &! indices to determine ref level for pressure
+         kDisplacedLocal   ! locally modified displacement target level
+
+      character(len=60) :: &
+         displacementTypeLocal ! locally modified displacement type
+
+      real (kind=RKIND) :: &
+         tq, sq,           &! adjusted T,S
+         t2, sqr,          &! T squared and square root salt
+         rhosfc,           &! density at the surface
+         bulkMod,          &! Bulk modulus
+         denomk,           &! temp for avoiding division
+         work1, work2,     &! temporary work space
+         work3, work4,     &!
+         drdt0,            &! d(density)/d(temperature), for surface
+         drds0,            &! d(density)/d(salinity   ), for surface
+         dkdt,             &! d(bulk modulus)/d(pot. temp.)
+         dkds,             &! d(bulk modulus)/d(salinity  )
+         drhodt,           &! derivative of density with respect to temperature
+         drhods             ! derivative of density with respect to salinity
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         p, p2 ! temporary pressure scalars
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,          &! modified temperature
+         tracerSalt            ! modified salinity
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** allocate and compute pressure array
+      allocate(p(nVertLevels),p2(nVertLevels))
+      ! For OpenACC, these are device resident only
+      allocate(tracerTemp(nVertLevels,nCells), &
+               tracerSalt(nVertLevels,nCells))
+
+!$acc data present(ocnEqStatePRef,tracersSurfaceLayerValue,tracers,density,thermalExpansionCoeff,&
+!$acc              salineContractionCoeff) &
+!$acc      create(p,p2,tracerTemp,tracerSalt)
+
+      ! Determine pressure to use in density calculation
+      !  If kDisplaced=0, in-situ density is returned (no displacement)
+      !  If kDisplaced/=0, potential density is returned
+
+      !  if displacementType = 'relative', potential density is calculated
+      !     referenced to level k + kDisplaced
+      !  if displacementType = 'absolute', potential density is calculated
+      !     referenced to level kDisplaced for all k
+      !  NOTE: kDisplaced = 0 or > nVertLevels is incompatible with 'absolute'
+      !     so abort if necessary
+
+      if (displacementType == 'surfaceDisplaced') then
+         displacementTypeLocal = 'relative'
+         kDisplacedLocal = 0
+      else
+         displacementTypeLocal = trim(displacementType)
+         kDisplacedLocal = kDisplaced
+      endif
+
+      ! Eliminate this error check for performance reasons
+      !if (displacementTypeLocal == 'absolute' .and.   &
+      !   (kDisplacedLocal <= 0 .or. kDisplacedLocal > nVertLevels) ) then
+      !
+      !   call mpas_log_write('Abort: In equation_of_state_jm' // &
+      !       ' kDisplaced must be between 1 and nVertLevels for ' // &
+      !       'displacementType = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      if (kDisplacedLocal == 0) then
+         ! use pressure at in situ level
+!$acc parallel
+!$acc loop gang vector
+         do k=1,nVertLevels
+            p (k) = ocnEqStatePRef(k)
+            p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
+         enddo
+!$acc end parallel
+      else ! kDisplacedLocal /= 0
+!$acc parallel
+!$acc loop gang vector private(kTmp,kRef)
+         do k=1,nVertLevels
+            ! determine level to which parcel is displaced
+            !  and thus which pressure (depth) to use in EOS
+            if (displacementTypeLocal == 'relative') then
+               kTmp = min(k + kDisplacedLocal, nVertLevels)
+            else
+               kTmp = min(kDisplacedLocal, nVertLevels)
+            endif
+            kRef  = max(kTmp, 1)  ! make sure index bounded to 1
+            p (k) = ocnEqStatePRef(kRef)
+            p2(k) = ocnEqStatePRef(kRef)*ocnEqStatePRef(kRef)
+         enddo
+!$acc end parallel
+      endif
+
+      !*** compute modified T,S to account for displacement and
+      !*** valid range
+
+      if (displacementType == 'surfaceDisplaced') then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, tq, sq)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(tq,sq)
+         do iCell=1,nCells
+         do k=1,nVertLevels
+            tq = min(tracersSurfaceLayerValue(indexT,iCell), &
+                     ocnEqStateTmax)
+            sq = min(tracersSurfaceLayerValue(indexS,iCell), &
+                     ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         enddo
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, tq, sq)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(tq,sq)
+         do iCell=1,nCells
+         do k = 1, nVertLevels
+            tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
+            sq = min(tracers(indexS,k,iCell), ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      endif
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, sq, tq, sqr, t2, rhosfc, bulkMod, &
+      !$omp         work1, work2, work3, work4, denomk, &
+      !$omp         drdt0, dkdt, drhodt, drds0, dkds, drhods)
+!$acc parallel
+!$acc loop gang vector collapse(2) private(sq,tq,sqr,t2,work1,work2,rhosfc,work3,work4,&
+!$acc                                      bulkMod,denomk,drdt0,dkdt,drhodt,drds0,dkds,drhods)
+      do iCell=1,nCells
+      do k=1,nVertLevels
+
+         sq  = tracerSalt(k,iCell)
+         tq  = tracerTemp(k,iCell)
+
+         sqr = sqrt(sq)
+         t2  = tq*tq
+
+         !***
+         !*** first calculate surface (p=0) values from UNESCO eqns.
+         !***
+
+         work1 = uns1t0 + uns1t1*tq + &
+                (uns1t2 + uns1t3*tq + uns1t4*t2)*t2
+         work2 = sqr*(unsqt0 + unsqt1*tq + unsqt2*t2)
+
+         rhosfc = unt1*tq + (unt2 + unt3*tq + (unt4 + unt5*tq)*t2)*t2 &
+                          + (uns2t0*sq + work1 + work2)*sq
+
+         !***
+         !*** now calculate bulk modulus at pressure p from
+         !*** Jackett and McDougall formula
+         !***
+
+         work3 = bup0s1t0 + bup0s1t1*tq +                    &
+                (bup0s1t2 + bup0s1t3*tq)*t2 +                &
+          p(k) *(bup1s1t0 + bup1s1t1*tq + bup1s1t2*t2) + &
+          p2(k)*(bup2s1t0 + bup2s1t1*tq + bup2s1t2*t2)
+
+         work4 = sqr*(bup0sqt0 + bup0sqt1*tq + bup0sqt2*t2 + &
+                                 bup1sqt0*p(k))
+
+         bulkMod  = bup0s0t0 + bup0s0t1*tq +                    &
+                   (bup0s0t2 + bup0s0t3*tq + bup0s0t4*t2)*t2 + &
+             p(k) *(bup1s0t0 + bup1s0t1*tq +                &
+                   (bup1s0t2 + bup1s0t3*tq)*t2) +           &
+             p2(k)*(bup2s0t0 + bup2s0t1*tq + bup2s0t2*t2) + &
+                                        sq*(work3 + work4)
+
+         !***
+         !*** compute density
+         !***
+
+         denomk = 1.0_RKIND/(bulkMod - p(k))
+
+         density(k, iCell) = (unt0 + rhosfc)*bulkMod*denomk
+
+         !***
+         !*** compute temperature expansion coeff
+         !***  by differentiating above formulae
+         !***
+
+         drdt0 =             unt1 + 2.0_RKIND*unt2*tq +        &
+                  (3.0_RKIND*unt3 + 4.0_RKIND*unt4*tq +        &
+                                    5.0_RKIND*unt5*t2)*t2 +    &
+                          (uns1t1 + 2.0_RKIND*uns1t2*tq +      &
+                (3.0_RKIND*uns1t3 + 4.0_RKIND*uns1t4*tq)*t2 +  &
+                          (unsqt1 + 2.0_RKIND*unsqt2*tq)*sqr )*sq
+
+         dkdt  =            bup0s0t1 + 2.0_RKIND*bup0s0t2*tq +      &
+                 (3.0_RKIND*bup0s0t3 + 4.0_RKIND*bup0s0t4*tq)*t2 +  &
+                     p(k) *(bup1s0t1 + 2.0_RKIND*bup1s0t2*tq +      &
+                                       3.0_RKIND*bup1s0t3*t2) +     &
+                     p2(k)*(bup2s0t1 + 2.0_RKIND*bup2s0t2*tq) +     &
+                        sq*(bup0s1t1 + 2.0_RKIND*bup0s1t2*tq +      &
+                                       3.0_RKIND*bup0s1t3*t2 +      &
+                    p(k)  *(bup1s1t1 + 2.0_RKIND*bup1s1t2*tq) +     &
+                    p2(k) *(bup2s1t1 + 2.0_RKIND*bup2s1t2*tq) +     &
+                       sqr*(bup0sqt1 + 2.0_RKIND*bup0sqt2*tq))
+
+         drhodt = (denomk*(drdt0*bulkMod -                    &
+                  p(k)*(unt0+rhosfc)*dkdt*denomk))
+
+         thermalExpansionCoeff(k,iCell) = -drhodt/density(k,iCell)
+
+         !***
+         !*** compute salinity contraction coeff
+         !***  by differentiating above formulae
+         !***
+
+         drds0  = 2.0_RKIND*uns2t0*sq + work1 + 1.5_RKIND*work2
+         dkds   = work3 + 1.5_RKIND*work4
+
+         drhods = denomk*(drds0*bulkMod -                    &
+                   p(k)*(unt0+rhosfc)*dkds*denomk)
+
+         salineContractionCoeff(k,iCell) = drhods/density(k,iCell)
+
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(p,p2)
+      deallocate(tracerTemp, tracerSalt)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_jm_density_exp_gpu!}}}
 
 !***********************************************************************
 !
@@ -837,7 +1307,7 @@ contains
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
-      call mpas_pool_get_array(meshPool,     'refBottomDepth', &
+      call mpas_pool_get_array_gpu(meshPool,     'refBottomDepth', &
                                               refBottomDepth)
 
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', &
@@ -857,6 +1327,7 @@ contains
 
       allocate(ocnEqStatePRef(nVertLevels))
 
+!$acc update host(refBottomDepth)
       depth = 0.5_RKIND*refBottomDepth(1)
       ocnEqStatePRef(1) = &
            0.059808_RKIND  *(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
@@ -869,9 +1340,7 @@ contains
             + 0.100766_RKIND  *depth                                 &
             + 2.28405e-7_RKIND*depth**2
       enddo
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(ocnEqStatePRef)
-#endif
+!$acc update device(ocnEqStatePRef)
 
    !--------------------------------------------------------------------
 

--- a/src/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/shared/mpas_ocn_equation_of_state_linear.F
@@ -40,11 +40,17 @@ module ocn_equation_of_state_linear
    !--------------------------------------------------------------------
 
    public :: ocn_equation_of_state_linear_density, &
+             ocn_equation_of_state_linear_density_gpu, &
              ocn_equation_of_state_linear_init
 
    interface ocn_equation_of_state_linear_density
       module procedure ocn_equation_of_state_linear_density_only
       module procedure ocn_equation_of_state_linear_density_exp
+   end interface
+
+   interface ocn_equation_of_state_linear_density_gpu
+      module procedure ocn_equation_of_state_linear_density_only_gpu
+      module procedure ocn_equation_of_state_linear_density_exp_gpu
    end interface
 
    !--------------------------------------------------------------------
@@ -167,13 +173,8 @@ contains
 
       if (trim(displacementType) == 'surfaceDisplaced') then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc& present(density, tracersSurfaceLayerValue)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCells
          do k = 1, nVertLevels
 
@@ -186,20 +187,13 @@ contains
                                 ocnEqStateLinearSref)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       else  ! all other displacement types
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc& present(density, tracers)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCells
          do k = 1, nVertLevels
 
@@ -212,16 +206,130 @@ contains
                                 ocnEqStateLinearSref)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
       !-----------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_linear_density_only!}}}
+
+   subroutine ocn_equation_of_state_linear_density_only_gpu(          &
+              nVertLevels, nCells, kDisplaced, displacementType,  &
+              indexT, indexS, tracers, density, err,              &
+              tracersSurfaceLayerValue)
+      !{{{
+      !-----------------------------------------------------------------
+      !
+      ! Input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) ::     &
+         nCells,                 &! num of horizontal cells
+         nVertLevels,            &! num of vertical levels
+         kDisplaced,             &! num of levels to displace parcel
+         indexT, indexS           ! index into tracer array for T,S
+
+      character(len=*), intent(in) :: &
+         displacementType
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers                  ! array containing T,S for calculation
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         tracersSurfaceLayerValue ! optional sfc tracer values for sfc
+                                  ! displacement option
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density
+
+      !-----------------------------------------------------------------
+      !
+      ! Local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k    ! cell and level loop indices
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** check for displacement choice
+      !*** for linear EOS, only choice that impacts the
+      !*** density is surface displacement
+
+      ! ignore this test for performance reasons
+      ! test of request to address out of bounds
+      !if (displacement_type_local == 'absolute' .and.   &
+      !   (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+      !   call mpas_log_write('Abort: In equation_of_state_linear' // &
+      !       ' k_displaced must be between 1 and nVertLevels for ' // &
+      !       'displacement_type = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      ! copy some intent(in) into local work space
+
+      !*** if surfaceDisplaced, then compute density at all levels
+      !*** based on input surface values
+
+      if (trim(displacementType) == 'surfaceDisplaced') then
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+         do k = 1, nVertLevels
+
+            density(k,iCell) =  ocnEqStateLinearRhoRef &
+                             - ocnEqStateLinearAlpha * &
+                               (tracersSurfaceLayerValue(indexT,iCell) - &
+                                ocnEqStateLinearTref)  &
+                             + ocnEqStateLinearBeta  * &
+                               (tracersSurfaceLayerValue(indexS,iCell) - &
+                                ocnEqStateLinearSref)
+         end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      else  ! all other displacement types
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+         do k = 1, nVertLevels
+
+            density(k,iCell) = ocnEqStateLinearRhoRef     &
+                             - ocnEqStateLinearAlpha *    &
+                               (tracers(indexT,k,iCell) - &
+                                ocnEqStateLinearTref)     &
+                             + ocnEqStateLinearBeta  *    &
+                               (tracers(indexS,k,iCell) - &
+                                ocnEqStateLinearSref)
+         end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      endif
+
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_linear_density_only_gpu!}}}
 
 !***********************************************************************
 !
@@ -319,16 +427,8 @@ contains
 
       if (trim(displacementType) == 'surfaceDisplaced') then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc& present(density, &
-         !$acc&         tracersSurfaceLayerValue, &
-         !$acc&         salineContractionCoeff, &
-         !$acc&         thermalExpansionCoeff)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCells
          do k = 1, nVertLevels
 
@@ -347,23 +447,13 @@ contains
                                               density(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       else  ! all other displacement types
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc& present(density, &
-         !$acc&         tracers, &
-         !$acc&         salineContractionCoeff, &
-         !$acc&         thermalExpansionCoeff)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell = 1, nCells
          do k = 1, nVertLevels
 
@@ -382,16 +472,151 @@ contains
                                               density(k,iCell)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
       !-----------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_linear_density_exp!}}}
+
+   subroutine ocn_equation_of_state_linear_density_exp_gpu(           &
+              nVertLevels, nCells, kDisplaced, displacementType,  &
+              indexT, indexS, tracers, density, err,              &
+              thermalExpansionCoeff, salineContractionCoeff,      &
+              tracersSurfaceLayerValue)
+      !{{{
+      !-----------------------------------------------------------------
+      !
+      ! Input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) ::     &
+         nCells,                 &! num of horizontal cells
+         nVertLevels,            &! num of vertical levels
+         kDisplaced,             &! num of levels to displace parcel
+         indexT, indexS           ! index into tracer array for T,S
+
+      character(len=*), intent(in) :: &
+         displacementType
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers                  ! array containing T,S for calculation
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         tracersSurfaceLayerValue ! optional sfc tracer values for sfc
+                                  ! displacement option
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density
+
+      ! Optional expansion (contraction) coefficients
+      ! alpha defined as $-1/\rho d\rho/dT$ (note negative sign)
+      ! beta  defined as $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      !
+      ! Local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k    ! cell and level loop indices
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** check for displacement choice
+      !*** for linear EOS, only choice that impacts the
+      !*** density is surface displacement
+
+      ! ignore this test for performance reasons
+      ! test of request to address out of bounds
+      !if (displacement_type_local == 'absolute' .and.   &
+      !   (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+      !   call mpas_log_write('Abort: In equation_of_state_linear' // &
+      !       ' k_displaced must be between 1 and nVertLevels for ' // &
+      !       'displacement_type = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      ! copy some intent(in) into local work space
+
+      !*** if surfaceDisplaced, then compute density at all levels
+      !*** based on input surface values
+      !*** return fixed values of expansion coefficients
+
+      if (trim(displacementType) == 'surfaceDisplaced') then
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+         do k = 1, nVertLevels
+
+            density(k,iCell) =  ocnEqStateLinearRhoRef &
+                             - ocnEqStateLinearAlpha * &
+                               (tracersSurfaceLayerValue(indexT,iCell) - &
+                                ocnEqStateLinearTref)  &
+                             + ocnEqStateLinearBeta  * &
+                               (tracersSurfaceLayerValue(indexS,iCell) - &
+                                ocnEqStateLinearSref)
+
+            thermalExpansionCoeff(k,iCell) = ocnEqStateLinearAlpha/ &
+                                             density(k,iCell)
+
+            salineContractionCoeff(k,iCell) = ocnEqStateLinearBeta/ &
+                                              density(k,iCell)
+         end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      else  ! all other displacement types
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+         do k = 1, nVertLevels
+
+            density(k,iCell) = ocnEqStateLinearRhoRef     &
+                             - ocnEqStateLinearAlpha *    &
+                               (tracers(indexT,k,iCell) - &
+                                ocnEqStateLinearTref)     &
+                             + ocnEqStateLinearBeta  *    &
+                               (tracers(indexS,k,iCell) - &
+                                ocnEqStateLinearSref)
+
+            thermalExpansionCoeff(k,iCell) = ocnEqStateLinearAlpha/ &
+                                             density(k,iCell)
+
+            salineContractionCoeff(k,iCell) = ocnEqStateLinearBeta/ &
+                                              density(k,iCell)
+         end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      endif
+
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_linear_density_exp_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_equation_of_state_wright.F
+++ b/src/shared/mpas_ocn_equation_of_state_wright.F
@@ -46,6 +46,7 @@ module ocn_equation_of_state_wright
    !--------------------------------------------------------------------
 
    public :: ocn_equation_of_state_wright_density, &
+             ocn_equation_of_state_wright_density_gpu, &
              ocn_equation_of_state_wright_init
 
    !*** generic interface for case of density only or density and
@@ -53,6 +54,11 @@ module ocn_equation_of_state_wright
    interface ocn_equation_of_state_wright_density
       module procedure ocn_equation_of_state_wright_density_only
       module procedure ocn_equation_of_state_wright_density_exp
+   end interface
+
+   interface ocn_equation_of_state_wright_density_gpu
+      module procedure ocn_equation_of_state_wright_density_only_gpu
+      module procedure ocn_equation_of_state_wright_density_exp_gpu
    end interface
 
    !--------------------------------------------------------------------
@@ -197,7 +203,6 @@ contains
       allocate(tracerTemp(nVertLevels, nCells), &
                tracerSalt(nVertLevels, nCells), &
                boussinesqPres(nVertLevels, nCells))
-      !$acc enter data create(tracerTemp, tracerSalt, boussinesqPres)
 
       if (displacementType == 'surfaceDisplaced') then
          call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
@@ -212,15 +217,9 @@ contains
                                 displacementType, zMid, maxLevelCell, &
                                 boussinesqPres)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2) &
-      !$acc    present(density, tracerTemp, tracerSalt, &
-      !$acc            boussinesqPres)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, S, T, p, T2, T3, p0, lambda0, alpha0)
-#endif
 
       do iCell=1,nCells
          do k=1,nVertLevels
@@ -241,17 +240,132 @@ contains
          end do
       end do
 
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(tracerTemp, tracerSalt, boussinesqPres)
       deallocate(tracerTemp, tracerSalt, boussinesqPres)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_wright_density_only!}}}
+
+   subroutine ocn_equation_of_state_wright_density_only_gpu(nVertLevels,  &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, zMid,         &
+                               maxLevelCell, density, err, &
+                               tracersSurfaceLayerValue)
+
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         zMid
+
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+
+      integer :: &
+         iCell, k ! cell and vertical level loop indices
+
+      real (kind=RKIND) :: &
+         T, S, T2, T3,     &! adjusted T, S, T squared, T cubed,
+         p,                &! Boussinesq pressure at reference level,
+         alpha0, lambda0,  &! functions of theta and S defined by Wright (1997)
+         p0
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,    &! local bounded temperature for use in EOS
+         tracerSalt,    &! local bounded salinity    for use in EOS
+         boussinesqPres  ! boussinesq pressure
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      allocate(tracerTemp(nVertLevels, nCells), &
+               tracerSalt(nVertLevels, nCells), &
+               boussinesqPres(nVertLevels, nCells))
+
+      if (displacementType == 'surfaceDisplaced') then
+         call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
+                                            indexS, tracersSurfaceLayerValue, &
+                                            tracerTemp, tracerSalt)
+      else
+         call compute_bounded_T_S(nVertLevels, nCells, indexT, indexS, tracers, &
+                                  tracerTemp, tracerSalt)
+      end if
+
+      call compute_boussinesq_p(nVertLevels, nCells, kDisplaced,      &
+                                displacementType, zMid, maxLevelCell, &
+                                boussinesqPres)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, S, T, p, T2, T3, p0, lambda0, alpha0)
+
+      do iCell=1,nCells
+         do k=1,nVertLevels
+
+            S = tracerSalt(k, iCell)
+            T = tracerTemp(k, iCell)
+            p = boussinesqPres(k, iCell)
+
+            T2 = T*T
+            T3 = T*T2
+
+            p0 = b0 + b1*T + b2*T2 + b3*T3 + b4*S + b5*T*S
+            lambda0 = c0 + c1*T + c2*T2 + c3*T3 + c4*S + c5*T*S
+            alpha0 = a0 + a1*T + a2*S
+
+            density(k, iCell) = (p + p0)/(lambda0 + alpha0*(p + p0))
+
+         end do
+      end do
+
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(tracerTemp, tracerSalt, boussinesqPres)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_wright_density_only_gpu!}}}
 
 !***********************************************************************
 !
@@ -366,7 +480,6 @@ contains
       allocate(tracerTemp(nVertLevels, nCells), &
                tracerSalt(nVertLevels, nCells), &
                boussinesqPres(nVertLevels, nCells))
-      !$acc enter data create(tracerTemp, tracerSalt, boussinesqPres)
 
       if (displacementType == 'surfaceDisplaced') then
          call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
@@ -381,17 +494,11 @@ contains
                                 boussinesqPres)
 
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2)     &
-      !$acc    present(density, tracerTemp, tracerSalt, boussinesqPres,& 
-      !$acc            thermalExpansionCoeff, salineContractionCoeff)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lambda0, &
       !$omp         dlambda0dT, dlambda0dS, alpha0, dalpha0dT, &
       !$omp         dalpha0dS, denom, denom2, drhodT, drhodS)
-#endif
 
       do iCell=1,nCells
          do k=1,nVertLevels
@@ -430,17 +537,167 @@ contains
          end do
       end do
 
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(tracerTemp, tracerSalt, boussinesqPres)
       deallocate(tracerTemp, tracerSalt, boussinesqPres)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_wright_density_exp!}}}
+
+   subroutine ocn_equation_of_state_wright_density_exp_gpu(nVertLevels,         &
+                               nCells, kDisplaced, displacementType,        &
+                               indexT, indexS, tracers, zMid, maxLevelCell, &
+                               density, err, thermalExpansionCoeff,         &
+                               salineContractionCoeff,                      &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         zMid
+
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      ! Thermal expansion coeff, $-1/\rho d\rho/dT$ (note negative sign)
+      ! Saline contraction coeff, $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion  coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k ! cell and vertical level loop indices
+
+      real (kind=RKIND) :: &
+         T, S, T2, T3,     &! adjusted T, S, T squared, T cubed,
+         p,                &! Boussinesq pressure at reference level,
+         alpha0, lambda0,  &! functions of theta and S defined by Wright (1997)
+         p0,               &
+         denom, denom2,    &! denominator of rational polynomial for rho
+         dalpha0dT,        &! d(alpha0)/d(temperature)
+         dalpha0dS,        &! d(alpha0)/d(salinity)
+         dlambda0dT,       &! d(lambda0)/d(temperature)
+         dlambda0dS,       &! d(lambda0)/d(salinity)
+         dp0dT,            &! d(p0)/d(temperature)
+         dp0dS,            &! d(p0)/d(salinity)
+         drhodT,           &! derivative of density with respect to temperature
+         drhodS             ! derivative of density with respect to salinity
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,    &! local bounded temperature for use in EOS
+         tracerSalt,    &! local bounded salinity    for use in EOS
+         boussinesqPres  ! boussinesq pressure
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+
+      allocate(tracerTemp(nVertLevels, nCells), &
+               tracerSalt(nVertLevels, nCells), &
+               boussinesqPres(nVertLevels, nCells))
+
+      if (displacementType == 'surfaceDisplaced') then
+         call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
+                                            indexS, tracersSurfaceLayerValue, &
+                                            tracerTemp, tracerSalt)
+      else
+         call compute_bounded_T_S(nVertLevels, nCells, indexT, indexS, tracers, &
+                                  tracerTemp, tracerSalt)
+      end if
+      call compute_boussinesq_p(nVertLevels, nCells, kDisplaced,      &
+                                displacementType, zMid, maxLevelCell, &
+                                boussinesqPres)
+
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lambda0, &
+      !$omp         dlambda0dT, dlambda0dS, alpha0, dalpha0dT, &
+      !$omp         dalpha0dS, denom, denom2, drhodT, drhodS)
+
+      do iCell=1,nCells
+         do k=1,nVertLevels
+
+            S = tracerSalt(k, iCell)
+            T = tracerTemp(k, iCell)
+            p = boussinesqPres(k, iCell)
+
+            T2 = T*T
+            T3 = T*T2
+
+            p0 = b0 + b1*T + b2*T2 + b3*T3 + b4*S + b5*T*S
+            dp0dT = b1 + 2.0_RKIND*b2*T + 3.0_RKIND*b3*T2 + b5*S
+            dp0dS = b4 + b5*T
+
+            lambda0 = c0 + c1*T + c2*T2 + c3*T3 + c4*S + c5*T*S
+            dlambda0dT = c1 + 2.0_RKIND*c2*T + 3.0_RKIND*c3*T2 + c5*S
+            dlambda0dS = c4 + c5*T
+
+            alpha0 = a0 + a1*T + a2*S
+            dalpha0dT = a1
+            dalpha0dS = a2
+
+            denom = 1.0_RKIND/(lambda0 + alpha0*(p + p0))
+            denom2 = denom*denom
+
+            drhodT = (lambda0*dp0dT - &
+                      (p + p0)*(dlambda0dT + (p + p0)*dalpha0dT))*denom2
+            drhodS = (lambda0*dp0dS - &
+                      (p + p0)*(dlambda0dS + (p + p0)*dalpha0dS))*denom2
+
+            density(k, iCell) = (p + p0)*denom
+            thermalExpansionCoeff(k, iCell) = -drhodT/density(k, iCell)
+            salineContractionCoeff(k, iCell) = drhodS/density(k, iCell)
+
+         end do
+      end do
+
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(tracerTemp, tracerSalt, boussinesqPres)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_wright_density_exp_gpu!}}}
 
 !***********************************************************************
 !
@@ -529,13 +786,8 @@ contains
       real (kind=RKIND) :: &
          T, S               ! adjusted T, S
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2) &
-      !$acc    present(tracers, tracerTemp, tracerSalt)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, T, S)
-#endif
       do iCell=1,nCells
          do k = 1, nVertLevels
             T = min(tracers(indexT, k, iCell), ocnEqStateTmax)
@@ -544,10 +796,8 @@ contains
             tracerSalt(k, iCell) = max(S, ocnEqStateSmin)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
@@ -600,14 +850,8 @@ contains
       real (kind=RKIND) :: &
          T, S               ! adjusted T, S
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector collapse(2), &
-      !$acc    present(tracersSurfaceLayerValue, &
-      !$acc            tracerTemp, tracerSalt)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, T, S)
-#endif
       do iCell=1,nCells
          do k = 1, nVertLevels
             T = min(tracersSurfaceLayerValue(indexT, iCell), ocnEqStateTmax)
@@ -616,10 +860,8 @@ contains
             tracerSalt(k, iCell) = max(S, ocnEqStateSmin)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
@@ -686,13 +928,8 @@ contains
       if ((displacementType == 'relative') .or. &
           (displacementType == 'surfaceDisplaced')) then
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector collapse(2) &
-         !$acc    present(boussinesqPres, maxLevelCell, zMid)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, kPressure)
-#endif
          do iCell=1,nCells
             do k = 1, nVertLevels
                kPressure = min(k + kDisplaced, maxLevelCell(iCell))
@@ -701,28 +938,20 @@ contains
                                            zMid(kPressure, iCell)
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       else ! displacementType == 'absolute'
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) present(boussinesqPres)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-#endif
          do iCell=1,nCells
             do k = 1, nVertLevels
                boussinesqPres(k, iCell) = eos_wright_ref_pressure
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 

--- a/src/shared/mpas_ocn_forcing.F
+++ b/src/shared/mpas_ocn_forcing.F
@@ -127,13 +127,15 @@ contains
 
         call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
-        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+        call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+        call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
 
-        call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+        call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
 
-        call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
-        call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)
+        call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
+        call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)
+!$acc update host(minLevelCell,maxLevelCell,layerThickness,fractionAbsorbed,fractionAbsorbedRunoff,&
+!$acc             sfcFlxAttCoeff,surfaceFluxAttenuationCoefficientRunoff)
 
         nCells = nCellsArray( 2 )
 
@@ -166,6 +168,7 @@ contains
               transmissionCoeffTop = transmissionCoeffBot
            end do
         end do
+!$acc update device(fractionAbsorbed,fractionAbsorbedRunoff)
 
     end subroutine ocn_forcing_build_fraction_absorbed_array!}}}
 

--- a/src/shared/mpas_ocn_frazil_forcing.F
+++ b/src/shared/mpas_ocn_frazil_forcing.F
@@ -49,7 +49,9 @@ module ocn_frazil_forcing
 
    public :: ocn_frazil_forcing_build_arrays, &
              ocn_frazil_forcing_tracers, &
+             ocn_frazil_forcing_tracers_gpu, &
              ocn_frazil_forcing_layer_thickness, &
+             ocn_frazil_forcing_layer_thickness_gpu, &
              ocn_frazil_forcing_init
 
    !--------------------------------------------------------------------
@@ -123,6 +125,52 @@ contains
 
    end subroutine ocn_frazil_forcing_tracers!}}}
 
+   subroutine ocn_frazil_forcing_tracers_gpu(meshPool, tracersPool, groupName, forcingPool, tracersTend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      character (len=*) :: groupName !< Input: Name of tracer group
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input/Output: mesh information
+      type (mpas_pool_type), intent(inout) :: tracersPool !< Input/Output: tracer tendency pool
+      type (mpas_pool_type), intent(inout) :: forcingPool  !< Input/Output: forcing pool holding frazil-induced tendencies
+      real (kind=RKIND), dimension(:,:,:), intent(inout) ::  tracersTend
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if ( .not. frazilFormationOn ) return
+
+      call mpas_timer_start("tracer frazil gpu")
+
+      if ( trim(groupName) == 'activeTracers' ) then
+         call ocn_frazil_forcing_active_tracers_gpu(meshPool, tracersPool, forcingPool, tracersTend, err)
+      end if
+
+      call mpas_timer_stop("tracer frazil gpu")
+
+   end subroutine ocn_frazil_forcing_tracers_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_frazil_forcing_layer_thickness
@@ -180,33 +228,87 @@ contains
       nCells = nCellsHalo( 1 )
 
       ! Build surface fluxes at cell centers
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(frazilLayerThicknessTendency)
-
-      !$acc parallel loop &
-      !$acc     present(layerThicknessTend, minLevelCell, maxLevelCell, frazilLayerThicknessTendency) &
-      !$acc     private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCells
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + frazilLayerThicknessTendency(k,iCell)
         end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(frazilLayerThicknessTendency)
-#endif
 
       call mpas_timer_stop("frazil thickness tendency")
 
    end subroutine ocn_frazil_forcing_layer_thickness!}}}
+
+   subroutine ocn_frazil_forcing_layer_thickness_gpu(forcingPool, layerThicknessTend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      real (kind=RKIND), intent(inout), dimension(:,:) :: layerThicknessTend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, nCells
+      real (kind=RKIND), dimension(:,:), pointer :: frazilLayerThicknessTendency
+
+      err = 0
+
+      if ( .not. frazilFormationOn ) return
+
+      call mpas_timer_start("frazil thickness tendency gpu")
+
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
+
+      ! frazil fields are needed only over 0 and 1 halos
+      nCells = nCellsHalo( 1 )
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              layerThicknessTend,frazilLayerThicknessTendency)
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang
+      do iCell = 1, nCells
+!$acc loop vector
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + frazilLayerThicknessTendency(k,iCell)
+        end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("frazil thickness tendency gpu")
+
+   end subroutine ocn_frazil_forcing_layer_thickness_gpu!}}}
 
 
 !***********************************************************************
@@ -299,6 +401,92 @@ contains
       !$omp end parallel
 
    end subroutine ocn_frazil_forcing_active_tracers!}}}
+
+   subroutine ocn_frazil_forcing_active_tracers_gpu(meshPool, tracersPool, forcingPool, activeTracersTend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      type (mpas_pool_type), intent(inout) :: tracersPool !< Input: tracer tendency pool
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: activeTracersTend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, nCells
+      integer, pointer :: indexTemperaturePtr
+      integer, pointer :: indexSalinityPtr
+      integer :: indexTemperature
+      integer :: indexSalinity
+      integer, pointer, dimension(:) :: nCellsArray
+      integer, pointer, dimension(:) :: minLevelCell, maxLevelCell
+
+      real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
+      real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
+
+      err = 0
+
+      if ( .not. frazilFormationOn ) return
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
+
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
+
+      ! frazil fields are needed only over 0 and 1 halos
+      nCells = nCellsArray( 2 )
+
+!$acc data present(minLevelCell,maxLevelCell,activeTracersTend,frazilTemperatureTendency,frazilSalinityTendency)
+
+      ! add to surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang
+      do iCell = 1, nCells
+!$acc loop vector
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          activeTracersTend(indexTemperature,k,iCell) = activeTracersTend(indexTemperature,k,iCell) &
+                                                      + frazilTemperatureTendency(k,iCell)
+          activeTracersTend(indexSalinity,k,iCell) = activeTracersTend(indexSalinity,k,iCell) + frazilSalinityTendency(k,iCell)
+        end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   end subroutine ocn_frazil_forcing_active_tracers_gpu!}}}
 
 !***********************************************************************
 !
@@ -416,25 +604,31 @@ contains
       indexSalinity    = indexSalinityPtr
 
       ! get mesh information
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
 
       ! get arrays
       ! note: state information is used to produce tendencies, so always grab "new" time level
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassNew, 2)
-      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassOld, 1)
-      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityNew, 2)
-      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityOld, 1)
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-      call mpas_pool_get_array(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
-      call mpas_pool_get_array(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
-      call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, 1)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassOld, 1)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityOld, 1)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
+      call mpas_pool_get_array_gpu(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, 1)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracers, 1)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+!$acc update host(minLevelCell,maxLevelCell,&
+!$acc             layerThickness,accumulatedFrazilIceMassNew,accumulatedFrazilIceMassOld,accumulatedFrazilIceSalinityNew,&
+!$acc             accumulatedFrazilIceSalinityOld,accumulatedLandIceFrazilMassNew,accumulatedLandIceFrazilMassOld,ssh,&
+!$acc             activeTracers,frazilTemperatureTendency,frazilSalinityTendency,frazilLayerThicknessTendency,&
+!$acc             frazilSurfacePressure,landIceMask,&
+!$acc             zMid,pressure,density)
 
       ! get time step in units of seconds
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err)
@@ -607,6 +801,7 @@ contains
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
                                                   + sumNewFrazilIceThickness * config_frazil_ice_density
+!$acc update device(accumulatedLandIceFrazilMassNew)
         end if
 
       enddo   ! do iCell = 1, nCells
@@ -621,8 +816,11 @@ contains
         end do
         !$omp end do
         !$omp end parallel
+!$acc update device(frazilSurfacePressure)
       end if
 
+!$acc update device(frazilTemperatureTendency,frazilSalinityTendency,frazilLayerThicknessTendency,accumulatedFrazilIceMassNew,&
+!$acc               accumulatedFrazilIceSalinityNew)
       call mpas_timer_stop("frazil")
 
    end subroutine ocn_frazil_forcing_build_arrays!}}}

--- a/src/shared/mpas_ocn_gm.F
+++ b/src/shared/mpas_ocn_gm.F
@@ -36,7 +36,8 @@ module ocn_gm
 
    public :: ocn_GM_compute_Bolus_velocity, &
              ocn_GM_init,                   &
-             ocn_GM_add_to_transport_vel
+             ocn_GM_add_to_transport_vel,   &
+             ocn_GM_add_to_transport_vel_gpu
 
    !--------------------------------------------------------------------
    !
@@ -162,30 +163,33 @@ contains
 
       call mpas_timer_start('gm bolus velocity')
 
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, timeLevel)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperaturePtr)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinityPtr)
       indexTemperature = indexTemperaturePtr
       indexSalinity    = indexSalinityPtr
 
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnCell', edgesOnCell)
 
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+!$acc update host(normalVelocity,layerThickness,ssh,activeTracers,&
+!$acc             minLevelEdgeBot,minLevelCell,maxLevelEdgeTop,maxLevelCell,cellsOnEdge,areaCell,dcEdge,dvEdge,nEdgesOnCell,edgesOnCell,&
+!$acc             normalGMBolusVelocity,k33,RediKappaScaling,RediKappaSfcTaper)
 
       allocate (rightHandSide(nVertLevels))
       allocate (tridiagA(nVertLevels))
@@ -219,6 +223,7 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+!$acc update device(normalGMBolusVelocity,k33,RediKappaScaling,RediKappaSfcTaper)
 
       ! The following code computes scaling for Redi mixing terms and the slope triads
       ! It is only needed when Redi mixing is enabled.
@@ -230,7 +235,7 @@ contains
          allocate(k33Norm(nVertLevels + 1))
 
          if ( config_Redi_N2_based_taper_enable ) then
-
+!$acc update host(indMLD,BruntVaisalaFreqTop,RediKappaScaling)
             !$omp parallel
             !$omp do schedule(runtime) private(maxLocation, k, BruntVaisalaFreqTopEdge, maxN)
             do iCell = 1, nCells
@@ -249,11 +254,13 @@ contains
                                                        1.0_RKIND)
                end do
             end do
+!$acc update device(RediKappaScaling)
             !$omp end do
             !$omp end parallel
          end if
 
          if (config_Redi_use_surface_taper) then
+!$acc update host(indMLD,zMid,RediKappaSfcTaper)
             !$omp parallel
             !$omp do schedule (runtime) private(zMLD, k)
             do iCell = 1, nCells
@@ -266,9 +273,11 @@ contains
             end do
             !$omp end do
             !$omp end parallel
+!$acc update device(RediKappaSfcTaper)
          end if
 
          nCells = nCellsArray(3)
+!$acc update host(k33,thermExpCoeff,salineContractCoeff,slopeTriadUp,slopeTriadDown,RediKappaSfcTaper,indMLD,RediKappaScaling)
          !$omp parallel
          !$omp do schedule(runtime)  &
          !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
@@ -393,6 +402,7 @@ contains
          end do ! iCell
          !$omp end do
          !$omp end parallel
+!$acc update device(k33,slopeTriadUp,slopeTriadDown)
 
          deallocate (dzTop)
          deallocate (dTdzTop)
@@ -403,6 +413,7 @@ contains
 
       ! allow disabling of K33 for testing
       if (config_disable_redi_k33) then
+         write(*,*) "config_disable_redi_k33 NOT EXECUTING"
          nCells = nCellsArray(size(nCellsArray))
          !$omp parallel
          !$omp do schedule(runtime)
@@ -425,6 +436,7 @@ contains
          ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
          ! based on stratification relative to the maximum in the column
          if (local_config_GM_kappa_lat_depth_variable) then
+            write(*,*) "local_config_GM_kappa_lat_depth_variable NOT EXECUTING"
             !$omp parallel
             !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
             do iEdge=1,nEdges
@@ -459,6 +471,7 @@ contains
          ! spatially variable baroclinic phase speed, the mode can be specified by
          ! config_GM_spatially_variable_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
+            write(*,*) "local_config_GM_lat_variable_c2 NOT EXECUTING"
             !$omp parallel
             !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, ltSum, c_min)
             do iEdge = 1, nEdges
@@ -498,6 +511,7 @@ contains
             !$omp end parallel
 
          else !constant phase speed for config_GM_closure = 'constant'
+!$acc update host(cGMphaseSpeed)
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
@@ -505,11 +519,13 @@ contains
             end do
             !$omp end do
             !$omp end parallel
+!$acc update device(cGMphaseSpeed)
          end if
 
          ! When config_GM_closure = 'Visbeck' actually modify the value of gmBolusKappa based on
          ! Visbeck et al (1997), JPO as recast by Cessi (2008), JPO
          if (local_config_GM_compute_Visbeck) then
+           write(*,*) "local_config_GM_compute_Visbeck NOT EXECUTING"
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, ltSum, sumRi, countN2, &
@@ -562,6 +578,7 @@ contains
          ! When config_GM_closure = 'EdenGreatbatch' actually modify the value of gmBolusKappa based on
          ! Eden and Greatbach (2008), Ocean Model., but assuming quasi-geostrophy to simplify the EKE budget
          if (local_config_GM_compute_EdenGreatbatch) then
+           write(*,*) "local_config_GM_compute_EdenGreatbatch NOT EXECUTING"
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
            !$omp parallel
@@ -598,6 +615,7 @@ contains
          nEdges = nEdgesArray(3)
          if (config_GM_horizontal_taper == 'RossbyRadius'.or. &
              config_Redi_horizontal_taper == 'RossbyRadius') then
+             write(*,*) "config_GM_horizontal_taper and config_Redi_horizontal_taper NOT EXECUTING"
             allocate (RossbyRadiusTaper(nEdges))
             call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
@@ -675,6 +693,7 @@ contains
          end if
 
          if (config_Redi_closure == 'equalGM') then
+            write(*,*) "config_Redi_closure == 'equalGM' NOT EXECUTING"
             ! Set Redi closure to be the same as the GM closure, i.e. if
             ! config_GM_closure is EdenGreatbatch or Visbeck, you will see those
             ! same closure fields in RediKappa. The horizontal tapering still
@@ -688,6 +707,7 @@ contains
             !$omp end parallel
          else if (config_Redi_closure == 'constant'.and. &
                    config_Redi_horizontal_taper == 'RossbyRadius') then
+            write(*,*) "config_Redi_closure == 'constant' config_Redi_horizontal_taper == 'RossbyRadius' NOT EXECUTING"
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge=1, nEdges
@@ -697,6 +717,8 @@ contains
             !$omp end parallel
          end if
 
+!$acc update host(gmStreamFuncTopOfEdge,BruntVaisalaFreqTop,cGMphaseSpeed,layerThickEdgeMean,gmBolusKappa,gmKappaScaling,&
+!$acc             gradDensityEddy)
          !!$omp parallel
          !!$omp do schedule(runtime) private(cell1, cell2, k, &
          !!$omp             BruntVaisalaFreqTopEdge, N) &
@@ -758,8 +780,10 @@ contains
          end do
          !!$omp end do
          !!$omp end parallel
+!$acc update device(gmStreamFuncTopOfEdge)
 
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here
+!$acc update host(normalGMBolusVelocity,gmHorizontalTaper,gmStreamFuncTopOfEdge,layerThickEdgeMean)
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
@@ -770,6 +794,7 @@ contains
          end do
          !$omp end do
          !$omp end parallel
+!$acc update device(normalGMBolusVelocity)
 
          deallocate (rightHandSide)
          deallocate (tridiagA)
@@ -880,6 +905,37 @@ contains
 
     end subroutine ocn_GM_add_to_transport_vel!}}}
 
+    subroutine ocn_GM_add_to_transport_vel_gpu(normalTransportVelocity, &
+                                           nEdges, nVertLevels)!{{{
+
+       real (kind=RKIND), dimension(:,:), intent(inout) :: &
+            normalTransportVelocity
+
+       integer, intent(in) :: nEdges, nVertLevels
+
+       integer :: iEdge, k
+
+       if (.not. config_use_gm) return
+
+!$acc data present(normalTransportVelocity,normalGMBolusVelocity)
+       !$omp parallel 
+       !$omp do schedule(runtime) &
+       !$omp private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+       do iEdge = 1, nEdges
+          do k = 1, nVertLevels
+             normalTransportVelocity(k,iEdge) = normalTransportVelocity(k,iEdge) + &
+                                    normalGMBolusVelocity(k,iEdge)
+          end do
+       end do
+!$acc end parallel
+       !$omp end do
+       !$omp end parallel
+!$acc end data
+
+    end subroutine ocn_GM_add_to_transport_vel_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_GM_init
@@ -919,9 +975,10 @@ contains
          call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-         call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'fEdge', fEdge)
+!$acc update host(cellsOnEdge,dcEdge,fEdge)
          if (config_Redi_use_slope_taper) then
             slopeTaperFactor = 1.0_RKIND
          else
@@ -950,7 +1007,8 @@ contains
          RediGMinitValue = 1.0_RKIND
          !compute beta
          call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
-         call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'latEdge', latEdge)
+!$acc update host(latEdge)
          !$omp parallel
          !$omp do schedule(runtime)
          do iEdge=1,nEdges
@@ -958,6 +1016,7 @@ contains
          end do
          !$omp end do
          !$omp end parallel
+!$acc update device(betaEdge)
 
          if (config_GM_closure == 'constant') then
             local_config_GM_lat_variable_c2 = .false.
@@ -994,7 +1053,8 @@ contains
             local_config_GM_compute_Visbeck = .true.
             local_config_GM_compute_EdenGreatbatch = .false.
 
-            call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+            call mpas_pool_get_array_gpu(meshPool, 'latEdge', latEdge)
+!$acc update host(latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
             !$omp parallel
             !$omp do schedule(runtime)
@@ -1010,7 +1070,8 @@ contains
             local_config_GM_compute_Visbeck = .false.
             local_config_GM_compute_EdenGreatbatch = .true.
 
-            call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+            call mpas_pool_get_array_gpu(meshPool, 'latEdge', latEdge)
+!$acc update host(latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
             !$omp parallel
             !$omp do schedule(runtime)
@@ -1024,6 +1085,7 @@ contains
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if
+!$acc update device(gmBolusKappa)
 
          ! Initialize horizontal taper
          if (config_GM_horizontal_taper == 'none' .or. &
@@ -1059,6 +1121,7 @@ contains
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if
+!$acc update device(gmHorizontalTaper)
 
          block => block%next
       end do

--- a/src/shared/mpas_ocn_init_routines.F
+++ b/src/shared/mpas_ocn_init_routines.F
@@ -134,81 +134,28 @@ contains
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCellTmp)
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryCell', boundaryCellTmp)
 
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, 1)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, 1)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, 1)
 
-      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIcePressure', seaIcePressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array_gpu(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', activeTracers, 1)
+!$acc update host(boundaryCellTmp,normalVelocity,layerThickness,ssh,seaIcePressure,atmosphericPressure,frazilSurfacePressure)
 
       if (.not. config_do_restart) then
          do iCell=1,nCells
             boundaryLayerDepth(iCell) = layerThickness(minLevelCell(iCell), iCell) * 0.5_RKIND
             indMLD(iCell) = minLevelCell(iCell)
          end do
+!$acc update device(boundaryLayerDepth,indMLD)
       end if
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThickness, normalVelocity)
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
-      !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-      !$acc enter data copyin(ssh)
-      !$acc enter data copyin(activeTracers)
-      !$acc update device(tracersSurfaceValue)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc enter data copyin(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc enter data copyin(landIcePressure)
-         !$acc enter data copyin(landIceDraft)
-      endif
-#endif
       call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, scratchPool, tracersPool)
-#ifdef MPAS_OPENACC
-      !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-      !$acc update host(relativeVorticity, circulation)
-      !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
-      !$acc             relativeVorticityCell, &
-      !$acc             divergence, &
-      !$acc             kineticEnergyCell, &
-      !$acc             tangentialVelocity, &
-      !$acc             vertVelocityTop)
-      !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-      !$acc             normalizedRelativeVorticityCell)
-      !$acc update host (surfacePressure)
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(ssh)
-      !$acc exit data delete(activeTracers)
-      !$acc update host(tracersSurfaceValue)
-      !$acc update host(normalVelocitySurfaceLayer)
-      !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      !$acc update host(density, potentialDensity, displacedDensity)
-      !$acc update host(thermExpCoeff,  &
-      !$acc&            salineContractCoeff)
-      !$acc update host(montgomeryPotential, pressure)
-      !$acc update host(RiTopOfCell, &
-      !$acc             BruntVaisalaFreqTop)
-      !$acc update host(tracersSurfaceLayerValue, &
-      !$acc             indexSurfaceLayerDepth, &
-      !$acc             normalVelocitySurfaceLayer, &
-      !$acc             sfcFlxAttCoeff, &
-      !$acc             surfaceFluxAttenuationCoefficientRunoff)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete(layerThickness, normalVelocity)
-#endif
 
       layerThickness(:, nCells+1) = 0.0_RKIND
 
@@ -220,17 +167,20 @@ contains
          
          normalVelocity(1:minLevelEdgeTop(iEdge)-1,iEdge) = -1.0e34_RKIND
       end do
+!$acc update device(layerThickness,normalVelocity)
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-            call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroup, 1)
+            call mpas_pool_get_array_gpu(tracersPool, groupItr % memberName, tracersGroup, 1)
+!$acc update host(tracersGroup)
             if ( associated(tracersGroup) ) then
                do iCell=1,nCells
                   tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) =  -1.0e34_RKIND
                   tracersGroup(:, 1:minLevelCell(iCell)-1,iCell) =  -1.0e34_RKIND
                end do
             end if
+!$acc update device(tracersGroup)
          end if
       end do
 
@@ -240,6 +190,7 @@ contains
       do iEdge = 1, nEdges
          normalTransportVelocity(:, iEdge) = normalVelocity(:, iEdge)
       end do
+!$acc update device(normalTransportVelocity)
 
       ! ------------------------------------------------------------------
       ! End: Accumulating various parametrizations of the transport velocity
@@ -257,6 +208,7 @@ contains
                        velocityZonal,        &
                        velocityMeridional    &
                       )
+!$acc update device(velocityX,velocityY,velocityZ,velocityZonal,velocityMeridional)
 
       call mpas_pool_initialize_time_levels(statePool)
 

--- a/src/shared/mpas_ocn_mesh.F
+++ b/src/shared/mpas_ocn_mesh.F
@@ -67,6 +67,7 @@ module ocn_mesh
       nCellsHalo, &! number of owned+halo(n) cells in local domain
       nEdgesHalo, &! number of owned+halo(n) edges in local domain
       nVerticesHalo      ! number of owned+halo(n) vertices in local domain
+!$acc declare create(nCellsHalo,nEdgesHalo,nVerticesHalo)
 
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
@@ -157,6 +158,8 @@ module ocn_mesh
    ! Derived mesh values needed
    real(kind=RKIND), public, dimension(:, :), allocatable :: &
       edgeAreaFractionOfCell
+!$acc declare create(invAreaCell,edgeMask,cellMask,vertexMask,boundaryEdge,boundaryCell,&
+!$acc                boundaryVertex,edgeSignOnCell,edgeSignOnVertex,edgeAreaFractionOfCell)
 
    !}}}
 
@@ -341,154 +344,154 @@ contains
       end do
 
       ! set pointers for a lot of connectivity info
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnEdge', &
                                nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnCell', &
                                nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', &
                                minLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeTop', &
                                minLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', &
                                minLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelVertexTop', &
                                minLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelVertexBot', &
                                minLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', &
                                maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', &
                                maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeBot', &
                             maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelVertexTop', &
                                maxLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelVertexBot', &
                                maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'indexToCellID', &
+      call mpas_pool_get_array_gpu(meshPool, 'indexToCellID', &
                                indexToCellID)
-      call mpas_pool_get_array(meshPool, 'indexToEdgeID', &
+      call mpas_pool_get_array_gpu(meshPool, 'indexToEdgeID', &
                                indexToEdgeID)
-      call mpas_pool_get_array(meshPool, 'indexToVertexID', &
+      call mpas_pool_get_array_gpu(meshPool, 'indexToVertexID', &
                                indexToVertexID)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnEdge', &
                                edgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', &
                                cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'verticesOnEdge', &
                                verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnCell', &
                                cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnCell', &
                                edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'verticesOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'verticesOnCell', &
                                verticesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnVertex', &
                                cellsOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnVertex', &
                                edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'kiteIndexOnCell', &
                                kiteIndexOnCell)
 
       ! now set a number of physics and numerical properties of mesh
-      call mpas_pool_get_array(meshPool, 'latCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'latCell', &
                                latCell)
-      call mpas_pool_get_array(meshPool, 'lonCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'lonCell', &
                                lonCell)
-      call mpas_pool_get_array(meshPool, 'xCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'xCell', &
                                xCell)
-      call mpas_pool_get_array(meshPool, 'yCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'yCell', &
                                yCell)
-      call mpas_pool_get_array(meshPool, 'zCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'zCell', &
                                zCell)
-      call mpas_pool_get_array(meshPool, 'latEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'latEdge', &
                                latEdge)
-      call mpas_pool_get_array(meshPool, 'lonEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'lonEdge', &
                                lonEdge)
-      call mpas_pool_get_array(meshPool, 'xEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'xEdge', &
                                xEdge)
-      call mpas_pool_get_array(meshPool, 'yEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'yEdge', &
                                yEdge)
-      call mpas_pool_get_array(meshPool, 'zEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'zEdge', &
                                zEdge)
-      call mpas_pool_get_array(meshPool, 'latVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'latVertex', &
                                latVertex)
-      call mpas_pool_get_array(meshPool, 'lonVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'lonVertex', &
                                lonVertex)
-      call mpas_pool_get_array(meshPool, 'xVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'xVertex', &
                                xVertex)
-      call mpas_pool_get_array(meshPool, 'yVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'yVertex', &
                                yVertex)
-      call mpas_pool_get_array(meshPool, 'zVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'zVertex', &
                                zVertex)
-      call mpas_pool_get_array(meshPool, 'fEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'fEdge', &
                                fEdge)
-      call mpas_pool_get_array(meshPool, 'fVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'fVertex', &
                                fVertex)
-      call mpas_pool_get_array(meshPool, 'fCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'fCell', &
                                fCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'dcEdge', &
                                dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'dvEdge', &
                                dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', &
                                areaCell)
-      call mpas_pool_get_array(meshPool, 'areaTriangle', &
+      call mpas_pool_get_array_gpu(meshPool, 'areaTriangle', &
                                areaTriangle)
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', &
+      call mpas_pool_get_array_gpu(meshPool, 'bottomDepth', &
                                bottomDepth)
-      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
+      call mpas_pool_get_array_gpu(meshPool, 'refBottomDepth', &
                                refBottomDepth)
-      call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'refBottomDepthTopOfCell', &
                                refBottomDepthTopOfCell)
-      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', &
+      call mpas_pool_get_array_gpu(meshPool, 'vertCoordMovementWeights', &
                                vertCoordMovementWeights)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel2', &
+      call mpas_pool_get_array_gpu(meshPool, 'meshScalingDel2', &
                                meshScalingDel2)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
+      call mpas_pool_get_array_gpu(meshPool, 'meshScalingDel4', &
                                meshScalingDel4)
-      call mpas_pool_get_array(meshPool, 'meshDensity', &
+      call mpas_pool_get_array_gpu(meshPool, 'meshDensity', &
                                meshDensity)
-      call mpas_pool_get_array(meshPool, 'angleEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'angleEdge', &
                                angleEdge)
-      call mpas_pool_get_array(meshPool, 'distanceToCoast', &
+      call mpas_pool_get_array_gpu(meshPool, 'distanceToCoast', &
                                distanceToCoast)
 
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'kiteAreasOnVertex', &
                                kiteAreasOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeTangentVectors', &
                                edgeTangentVectors)
-      call mpas_pool_get_array(meshPool, 'edgeNormalVectors', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeNormalVectors', &
                                edgeNormalVectors)
-      call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors', &
+      call mpas_pool_get_array_gpu(meshPool, 'localVerticalUnitVectors', &
                                localVerticalUnitVectors)
-      call mpas_pool_get_array(meshPool, 'cellTangentPlane', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellTangentPlane', &
                                cellTangentPlane)
-      call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', &
+      call mpas_pool_get_array_gpu(meshPool, 'coeffs_reconstruct', &
                                coeffs_reconstruct)
 
       ! For masks, we wish to convert to real multiplicative masks
       ! so retrieve integer version pointers and allocate real masks
       ! Once these are converted in Registry, we can eliminate this.
-      call mpas_pool_get_array(meshPool, 'edgeMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeMask', &
                                edgeMaskTmp)
-      call mpas_pool_get_array(meshPool, 'vertexMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'vertexMask', &
                                vertexMaskTmp)
-      call mpas_pool_get_array(meshPool, 'cellMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellMask', &
                                cellMaskTmp)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCellTmp)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeSignOnVertex', &
                                edgeSignOnVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryEdge', &
                                boundaryEdgeTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryVertex', &
                                boundaryVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryCell', &
                                boundaryCellTmp)
 
       allocate ( &
@@ -567,98 +570,17 @@ contains
       end do
       invAreaCell(nCellsAll+1) = 0.0_RKIND
 
-      !-----------------------------------------------------------------
-      ! Copy mesh data to accelerator if needed.
-      !-----------------------------------------------------------------
-
-         !$acc enter data copyin( &
-         !$acc                   onSphere,                 &
-         !$acc                   sphereRadius,             &
-         !$acc                   nCellsAll,                &
-         !$acc                   nEdgesAll,                &
-         !$acc                   nVerticesAll,             &
-         !$acc                   nCellsOwned,              &
-         !$acc                   nEdgesOwned,              &
-         !$acc                   nVerticesOwned,           &
-         !$acc                   maxEdges,                 &
-         !$acc                   maxEdges2,                &
-         !$acc                   vertexDegree,             &
-         !$acc                   nVertLevels,              &
-         !$acc                   nVertLevelsP1,            &
-         !$acc                   nEdgesHalo,               &
-         !$acc                   nCellsHalo,               &
-         !$acc                   nVerticesHalo,            &
-         !$acc                   nEdgesOnEdge,             &
-         !$acc                   nEdgesOnCell,             &
-         !$acc                   minLevelCell,             &
-         !$acc                   minLevelEdgeTop,          &
-         !$acc                   minLevelEdgeBot,          &
-         !$acc                   minLevelVertexTop,        &
-         !$acc                   minLevelVertexBot,        &
-         !$acc                   maxLevelCell,             &
-         !$acc                   maxLevelEdgeTop,          &
-         !$acc                   maxLevelEdgeBot,          &
-         !$acc                   maxLevelVertexTop,        &
-         !$acc                   maxLevelVertexBot,        &
-         !$acc                   indexToCellID,            &
-         !$acc                   indexToEdgeID,            &
-         !$acc                   indexToVertexID,          &
-         !$acc                   edgesOnEdge,              &
-         !$acc                   cellsOnEdge,              &
-         !$acc                   verticesOnEdge,           &
-         !$acc                   cellsOnCell,              &
-         !$acc                   edgesOnCell,              &
-         !$acc                   verticesOnCell,           &
-         !$acc                   cellsOnVertex,            &
-         !$acc                   edgesOnVertex,            &
-         !$acc                   kiteIndexOnCell,          &
-         !$acc                   latCell,                  &
-         !$acc                   lonCell,                  &
-         !$acc                   xCell,                    &
-         !$acc                   yCell,                    &
-         !$acc                   zCell,                    &
-         !$acc                   latEdge,                  &
-         !$acc                   lonEdge,                  &
-         !$acc                   xEdge,                    &
-         !$acc                   yEdge,                    &
-         !$acc                   zEdge,                    &
-         !$acc                   latVertex,                &
-         !$acc                   lonVertex,                &
-         !$acc                   xVertex,                  &
-         !$acc                   yVertex,                  &
-         !$acc                   zVertex,                  &
-         !$acc                   fEdge,                    &
-         !$acc                   fVertex,                  &
-         !$acc                   fCell,                    &
-         !$acc                   dcEdge,                   &
-         !$acc                   dvEdge,                   &
-         !$acc                   areaCell,                 &
-         !$acc                   invAreaCell,              &
-         !$acc                   areaTriangle,             &
-         !$acc                   bottomDepth,              &
-         !$acc                   refBottomDepth,           &
-         !$acc                   refBottomDepthTopOfCell,  &
-         !$acc                   vertCoordMovementWeights, &
-         !$acc                   meshScalingDel2,          &
-         !$acc                   meshScalingDel4,          &
-         !$acc                   meshDensity,              &
-         !$acc                   angleEdge,                &
-         !$acc                   distanceToCoast,          &
-         !$acc                   edgeMask,                 &
-         !$acc                   cellMask,                 &
-         !$acc                   vertexMask,               &
-         !$acc                   boundaryEdge,             &
-         !$acc                   boundaryCell,             &
-         !$acc                   boundaryVertex,           &
-         !$acc                   edgeSignOnCell,           &
-         !$acc                   edgeSignOnVertex,         &
-         !$acc                   weightsOnEdge,            &
-         !$acc                   kiteAreasOnVertex,        &
-         !$acc                   edgeTangentVectors,       &
-         !$acc                   edgeNormalVectors,        &
-         !$acc                   localVerticalUnitVectors, &
-         !$acc                   cellTangentPlane,         &
-         !$acc                   coeffs_reconstruct)
+!$acc update device(nEdgesHalo,nCellsHalo,nVerticesHalo,nEdgesOnEdge,nEdgesOnCell,minLevelCell,minLevelEdgeTop,minLevelEdgeBot,&
+!$acc               minLevelVertexTop,minLevelVertexBot,maxLevelCell,maxLevelEdgeTop,maxLevelEdgeBot,maxLevelVertexTop,&
+!$acc               maxLevelVertexBot,indexToCellID,indexToEdgeID,indexToVertexID,edgesOnEdge,cellsOnEdge,verticesOnEdge,&
+!$acc               cellsOnCell,edgesOnCell,verticesOnCell,cellsOnVertex,edgesOnVertex,kiteIndexOnCell,latCell,lonCell,xCell,&
+!$acc               yCell,zCell,latEdge,lonEdge,xEdge,yEdge,zEdge,latVertex,lonVertex,xVertex,yVertex,zVertex,fEdge,fVertex,&
+!$acc               fCell,dcEdge,dvEdge,areaCell,invAreaCell,areaTriangle,bottomDepth,refBottomDepth,refBottomDepthTopOfCell,&
+!$acc               vertCoordMovementWeights,meshScalingDel2,meshScalingDel4,meshDensity,angleEdge,distanceToCoast,edgeMask,&
+!$acc               cellMask,vertexMask,boundaryEdge,boundaryCell,boundaryVertex,edgeSignOnCell,edgeSignOnVertex,weightsOnEdge,&
+!$acc               kiteAreasOnVertex,edgeTangentVectors,edgeNormalVectors,localVerticalUnitVectors,cellTangentPlane,coeffs_reconstruct,&
+!$acc               cellMaskTmp,boundaryCellTmp,edgeSignOnCellTmp,edgeMaskTmp,boundaryEdgeTmp,vertexMaskTmp,boundaryVertexTmp,&
+!$acc               edgeSignOnVertexTmp)
 
 !-------------------------------------------------------------------------------
 
@@ -698,97 +620,6 @@ contains
       !***
 
       err = 0
-
-      ! First remove data from the device. Must remove components first,
-      ! then remove the mesh type itself.
-
-      !$acc exit data delete(onSphere,          &
-      !$acc                  sphereRadius,      &
-      !$acc                  nCellsAll,         &
-      !$acc                  nEdgesAll,         &
-      !$acc                  nVerticesAll,      &
-      !$acc                  nCellsOwned,       &
-      !$acc                  nEdgesOwned,       &
-      !$acc                  nVerticesOwned,    &
-      !$acc                  maxEdges,          &
-      !$acc                  maxEdges2,         &
-      !$acc                  vertexDegree,      &
-      !$acc                  nVertLevels,       &
-      !$acc                  nVertLevelsP1,     &
-      !$acc                  nEdgesHalo,        &
-      !$acc                  nCellsHalo,        &
-      !$acc                  nVerticesHalo,     &
-      !$acc                  nEdgesOnEdge,      &
-      !$acc                  nEdgesOnCell,      &
-      !$acc                  minLevelCell,      &
-      !$acc                  minLevelEdgeTop,   &
-      !$acc                  minLevelEdgeBot,   &
-      !$acc                  minLevelVertexTop, &
-      !$acc                  minLevelVertexBot, &
-      !$acc                  maxLevelCell,      &
-      !$acc                  maxLevelEdgeTop,   &
-      !$acc                  maxLevelEdgeBot,   &
-      !$acc                  maxLevelVertexTop, &
-      !$acc                  maxLevelVertexBot, &
-      !$acc                  indexToCellID,     &
-      !$acc                  indexToEdgeID,     &
-      !$acc                  indexToVertexID,   &
-      !$acc                  edgesOnEdge,       &
-      !$acc                  cellsOnEdge,       &
-      !$acc                  verticesOnEdge,    &
-      !$acc                  cellsOnCell,       &
-      !$acc                  edgesOnCell,       &
-      !$acc                  verticesOnCell,    &
-      !$acc                  cellsOnVertex,     &
-      !$acc                  edgesOnVertex,     &
-      !$acc                  kiteIndexOnCell,   &
-      !$acc                  latCell,           &
-      !$acc                  lonCell,           &
-      !$acc                  xCell,             &
-      !$acc                  yCell,             &
-      !$acc                  zCell,             &
-      !$acc                  latEdge,           &
-      !$acc                  lonEdge,           &
-      !$acc                  xEdge,             &
-      !$acc                  yEdge,             &
-      !$acc                  zEdge,             &
-      !$acc                  latVertex,         &
-      !$acc                  lonVertex,         &
-      !$acc                  xVertex,           &
-      !$acc                  yVertex,           &
-      !$acc                  zVertex,           &
-      !$acc                  fEdge,             &
-      !$acc                  fVertex,           &
-      !$acc                  fCell,             &
-      !$acc                  dcEdge,            &
-      !$acc                  dvEdge,            &
-      !$acc                  areaCell,          &
-      !$acc                  invAreaCell,       &
-      !$acc                  areaTriangle,      &
-      !$acc                  bottomDepth,       &
-      !$acc                  refBottomDepth,    &
-      !$acc                  refBottomDepthTopOfCell, &
-      !$acc                  vertCoordMovementWeights, &
-      !$acc                  meshScalingDel2,   &
-      !$acc                  meshScalingDel4,   &
-      !$acc                  meshDensity,       &
-      !$acc                  angleEdge,         &
-      !$acc                  distanceToCoast,   &
-      !$acc                  edgeMask,          &
-      !$acc                  cellMask,          &
-      !$acc                  vertexMask,        &
-      !$acc                  boundaryEdge,      &
-      !$acc                  boundaryCell,      &
-      !$acc                  boundaryVertex,    &
-      !$acc                  edgeSignOnCell,    &
-      !$acc                  edgeSignOnVertex,  &
-      !$acc                  weightsOnEdge,     &
-      !$acc                  kiteAreasOnVertex, &
-      !$acc                  edgeTangentVectors,&
-      !$acc                  edgeNormalVectors, &
-      !$acc                  localVerticalUnitVectors, &
-      !$acc                  cellTangentPlane,  &
-      !$acc                  coeffs_reconstruct)
 
       ! Reset all scalars to zero
       onSphere  = .false.
@@ -872,9 +703,6 @@ contains
                cellTangentPlane, &
                coeffs_reconstruct)
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(edgeAreaFractionOfCell)
-#endif
       deallocate (nEdgesHalo, &
                   nCellsHalo, &
                   nVerticesHalo, &
@@ -1074,22 +902,23 @@ contains
       ! For masks, we converted to real masks, so need to recompute for
       ! updated values. Probably only the edgeSign masks need updating, but
       ! do them all to be sure.
-      call mpas_pool_get_array(meshPool, 'edgeMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeMask', &
                                edgeMaskTmp)
-      call mpas_pool_get_array(meshPool, 'vertexMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'vertexMask', &
                                vertexMaskTmp)
-      call mpas_pool_get_array(meshPool, 'cellMask', &
+      call mpas_pool_get_array_gpu(meshPool, 'cellMask', &
                                cellMaskTmp)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCellTmp)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'edgeSignOnVertex', &
                                edgeSignOnVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryEdge', &
                                boundaryEdgeTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryVertex', &
                                boundaryVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', &
+      call mpas_pool_get_array_gpu(meshPool, 'boundaryCell', &
                                boundaryCellTmp)
+!$acc update host(edgeMaskTmp,vertexMaskTmp,cellMaskTmp,edgeSignOnCellTmp,edgeSignOnVertexTmp,boundaryEdgeTmp,boundaryVertexTmp,boundaryCellTmp)
 
       do n = 1, nCellsAll+1
       do k = 1, nVertLevels
@@ -1133,20 +962,7 @@ contains
       ! NOTE: if we end up computing some fields on the device during
       !       init, the update must go the opposite direction (update host)
 
-      !$acc update device(onSphere,                 &
-      !$acc               sphereRadius,             &
-      !$acc               nCellsAll,                &
-      !$acc               nEdgesAll,                &
-      !$acc               nVerticesAll,             &
-      !$acc               nCellsOwned,              &
-      !$acc               nEdgesOwned,              &
-      !$acc               nVerticesOwned,           &
-      !$acc               maxEdges,                 &
-      !$acc               maxEdges2,                &
-      !$acc               vertexDegree,             &
-      !$acc               nVertLevels,              &
-      !$acc               nVertLevelsP1,            &
-      !$acc               nEdgesHalo,               &
+      !$acc update device(nEdgesHalo,               &
       !$acc               nCellsHalo,               &
       !$acc               nVerticesHalo,            &
       !$acc               nEdgesOnEdge,             &
@@ -1219,7 +1035,9 @@ contains
       !$acc               edgeNormalVectors,        &
       !$acc               localVerticalUnitVectors, &
       !$acc               cellTangentPlane,         &
-      !$acc               coeffs_reconstruct)
+      !$acc               coeffs_reconstruct,&
+!$acc                     edgeSignOnCellTmp,&
+!$acc                     edgeSignOnVertexTmp)
 
 !-------------------------------------------------------------------------------
 
@@ -1533,14 +1351,15 @@ contains
       call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
 
       ! Extract needed variables from pools
-      call mpas_pool_get_array(statePool, 'layerThickness', &
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', &
                                            layerThickness, 1)
 
-      call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
-      call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', &
+      call mpas_pool_get_array_gpu(verticalMeshPool, 'refZMid', refZMid)
+      call mpas_pool_get_array_gpu(verticalMeshPool, 'refLayerThickness', &
                                                   refLayerThickness)
 
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+!$acc update host(layerThickness,refZMid,refLayerThickness,landIceMask)
       if (associated(landIceMask)) then
          landIceFlag = .true.  ! ice shelves
       else
@@ -1687,6 +1506,7 @@ contains
           MPAS_LOG_CRIT)
       endif
 
+!$acc update device(refZMid,refLayerThickness,landIceMask)
    !--------------------------------------------------------------------
 
    end subroutine ocn_meshVertCoordInit !}}}
@@ -1726,9 +1546,6 @@ contains
 
       ! Allocate space
       allocate (edgeAreaFractionOfCell(maxEdges,nCellsAll), STAT=ierr)
-#ifdef MPAS_OPENACC
-      !$acc enter data create(edgeAreaFractionOfCell)
-#endif
       if (ierr /= 0) call mpas_log_write( &
          'Error allocating edgeAreaFractionOfCell in ocn_mesh', &
           MPAS_LOG_CRIT)
@@ -1740,9 +1557,7 @@ contains
                dcEdge(iEdge)*dvEdge(iEdge)/areaCell(iCell)
       end do
       end do
-#ifdef MPAS_OPENACC
       !$acc update device(edgeAreaFractionOfCell)
-#endif
 
    !--------------------------------------------------------------------
 

--- a/src/shared/mpas_ocn_stokes_drift.F
+++ b/src/shared/mpas_ocn_stokes_drift.F
@@ -59,6 +59,7 @@ module ocn_stokes_drift
    !--------------------------------------------------------------------
 
    real (kind=RKIND), dimension(:), allocatable :: stokesDriftWavenumbers
+!$acc declare create(stokesDriftWavenumbers)
 
 
 !***********************************************************************
@@ -525,6 +526,7 @@ contains
            err = 1
 
       end select
+!$acc update device(stokesDriftWavenumbers)
 
    !--------------------------------------------------------------------
 

--- a/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -38,10 +38,12 @@ module ocn_submesoscale_eddies
    public :: ocn_submesoscale_compute_velocity, &
              ocn_submesoscale_init,             &
              ocn_submesoscale_finalize,         &
-             ocn_MLE_add_to_transport_vel
+             ocn_MLE_add_to_transport_vel,      &
+             ocn_MLE_add_to_transport_vel_gpu
 
    real(kind=RKIND) :: tau, LfMin, Ce, dsMax
    real(kind=RKIND),dimension(:),allocatable :: time_scale
+!$acc declare create(time_scale)
 
   !***********************************************************************
 
@@ -204,6 +206,33 @@ module ocn_submesoscale_eddies
 
   end subroutine ocn_MLE_add_to_transport_vel
 
+  subroutine ocn_MLE_add_to_transport_vel_gpu(normalTransportVelocity, nEdges)
+
+     real(kind=RKIND), dimension(:,:), intent(inout) :: &
+         normalTransportVelocity
+
+     integer, intent(in) :: nEdges
+
+     integer :: iEdge, k
+
+     if (.not. config_submesoscale_enable) return
+!NV! !!! NOT EXECUTING !!!
+     write(*,*) "config_submesoscale_enable NOT EXECUTING"
+
+     !$omp parallel
+     !$omp do schedule(runtime) &
+     !$omp private(k)
+     do iEdge = 1, nEdges
+        do k = 1, nVertLevels
+           normalTransportVelocity(k,iEdge) = normalTransportVelocity(k,iEdge) + &
+               normalMLEvelocity(k,iEdge)
+        end do
+     end do
+     !$omp end do
+     !$omp end parallel
+
+  end subroutine ocn_MLE_add_to_transport_vel_gpu
+
   !***********************************************************************
   !
   !  routine ocn_submesoscale_init
@@ -235,6 +264,7 @@ module ocn_submesoscale_eddies
      end do
      !$omp end do
      !$omp end parallel
+!$acc update device(time_scale)
 
    end subroutine ocn_submesoscale_init
 

--- a/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -47,8 +47,11 @@ module ocn_surface_bulk_forcing
    !--------------------------------------------------------------------
 
    public :: ocn_surface_bulk_forcing_tracers, &
+             ocn_surface_bulk_forcing_tracers_gpu, &
              ocn_surface_bulk_forcing_vel, &
+             ocn_surface_bulk_forcing_vel_gpu, &
              ocn_surface_bulk_forcing_thick, &
+             ocn_surface_bulk_forcing_thick_gpu, &
              ocn_surface_bulk_forcing_init
 
    !--------------------------------------------------------------------
@@ -128,6 +131,57 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
 
+   subroutine ocn_surface_bulk_forcing_tracers_gpu(meshPool, groupName, forcingPool, tracerGroup,   &
+      tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, dt, layerThickness, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      character (len=*) :: groupName !< Input: Name of tracer group
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux !< Input/Output: Surface flux for tracer group
+      real (kind=RKIND), dimension(:,:), intent(inout) ::   &
+         tracersSurfaceFluxRunoff !< Input/Output: Surface flux for tracer group due to river runoff
+      real (kind=RKIND), dimension(:,:), intent(inout) ::   &
+         tracersSurfaceFluxRemoved !< Input/Output: Accumulator for ignored Surface flux for tracer group
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: dt
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      call mpas_timer_start("bulk_" // trim(groupName) //" gpu")
+      if ( trim(groupName) == 'activeTracers' ) then
+         call ocn_surface_bulk_forcing_active_tracers_gpu(meshPool, forcingPool, tracerGroup,  &
+            tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)
+      end if
+      call mpas_timer_stop("bulk_" // trim(groupName) //" gpu")
+
+   end subroutine ocn_surface_bulk_forcing_tracers_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_surface_bulk_forcing_vel
@@ -198,10 +252,6 @@ contains
       call mpas_pool_get_array(forcingPool, 'windStressZonal', windStressZonal)
       call mpas_pool_get_array(forcingPool, 'windStressMeridional', windStressMerid)
 
-      !*** Transfer data to device
-      !$acc enter data &
-      !$acc    copyin(windStressZonal, windStressMerid)
-
       !*** Forcing needed over halo regions
 
       nEdges = nEdgesHalo(3)
@@ -211,16 +261,9 @@ contains
       !*** ocean model wind stress by averaging cell-centered wind
       !*** stress to edges and then rotating vectors
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, angleEdge, sfcStress, &
-      !$acc            windStressZonal, windStressMerid) &
-      !$acc    private(cell1, cell2, zonalWSEdge, meridWSEdge)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(cell1, cell2, zonalWSEdge, meridWSEdge)
-#endif
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1, iEdge)
         cell2 = cellsOnEdge(2, iEdge)
@@ -234,38 +277,136 @@ contains
                            cos(angleEdge(iEdge))*zonalWSEdge + &
                            sin(angleEdge(iEdge))*meridWSEdge
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! Calculate surface flux magnitude at cell centers
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(sfcStressMag, windStressZonal, &
-      !$acc                          windStressMerid)
-#else
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCells
         sfcStressMag(iCell) = sfcStressMag(iCell) + &
                               sqrt( windStressZonal(iCell)**2 &
                                   + windStressMerid(iCell)**2 )
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-      !*** Transfer any needed data back to host and delete inputs
-      !$acc exit data &
-      !$acc    delete(windStressZonal, windStressMerid)
 
       call mpas_timer_stop("bulk_ws")
 
       !-----------------------------------------------------------------
 
    end subroutine ocn_surface_bulk_forcing_vel!}}}
+
+   subroutine ocn_surface_bulk_forcing_vel_gpu( &
+                               forcingPool, sfcStress, &
+                               sfcStressMag, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         forcingPool         !< [in] Forcing structure w/ sfc stresses
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         sfcStress, & !< [inout] Array for surface stress
+         sfcStressMag !< [inout] Array for magnitude of surface stress
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::         &
+         iEdge, iCell,   &! loop indices for edge, cell loops
+         nCells, nEdges, &! number of cells, edges participating
+         cell1, cell2     ! neighbor cell indices across edge
+
+      real (kind=RKIND) :: &
+         meridWSEdge,      &! meridional wind stress avg to edge
+         zonalWSEdge        ! zonal wind stress averaged to edge
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         windStressZonal, &! zonal wind stress from forcing
+         windStressMerid   ! meridional wind stress from forcing
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set error code and exit early if bulk wind stress not on
+      !*** Otherwise start timer
+
+      err = 0
+      if (bulkWindStressOff) return
+
+      call mpas_timer_start("bulk_ws gpu", .false.)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'windStressZonal', windStressZonal)
+      call mpas_pool_get_array_gpu(forcingPool, 'windStressMeridional', windStressMerid)
+
+      !*** Forcing needed over halo regions
+
+      nEdges = nEdgesHalo(3)
+      nCells = nCellsHalo(2)
+
+!$acc data present(cellsOnEdge,angleEdge,&
+!$acc              windStressZonal,windStressMerid,sfcStress,sfcStressMag)
+
+      !*** Convert coupled climate model wind stress to internal
+      !*** ocean model wind stress by averaging cell-centered wind
+      !*** stress to edges and then rotating vectors
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, zonalWSEdge, meridWSEdge)
+!$acc parallel
+!$acc loop gang vector private(cell1,cell2,zonalWSEdge,meridWSEdge)
+      do iEdge = 1, nEdges
+        cell1 = cellsOnEdge(1, iEdge)
+        cell2 = cellsOnEdge(2, iEdge)
+
+        zonalWSEdge = 0.5_RKIND * (windStressZonal(cell1) + &
+                                   windStressZonal(cell2))
+        meridWSEdge = 0.5_RKIND * (windStressMerid(cell1) + &
+                                   windStressMerid(cell2))
+
+        sfcStress(iEdge) = sfcStress(iEdge) + &
+                           cos(angleEdge(iEdge))*zonalWSEdge + &
+                           sin(angleEdge(iEdge))*meridWSEdge
+      end do
+!$acc end parallel
+      !$omp end do
+
+      ! Calculate surface flux magnitude at cell centers
+
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+      do iCell = 1, nCells
+        sfcStressMag(iCell) = sfcStressMag(iCell) + &
+                              sqrt( windStressZonal(iCell)**2 &
+                                  + windStressMerid(iCell)**2 )
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("bulk_ws gpu")
+
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_surface_bulk_forcing_vel_gpu!}}}
 
 !***********************************************************************
 !
@@ -328,35 +469,90 @@ contains
       nCells = nCellsHalo( 2 )
 
       ! Build surface fluxes at cell centers
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(evaporationFlux, snowFlux, seaIceFreshWaterFlux, icebergFreshWaterFlux, &
-      !$acc     riverRunoffFlux, iceRunoffFlux, rainFlux)
-
-      !$acc parallel loop &
-      !$acc     present(surfaceThicknessFlux, surfaceThicknessFluxRunoff, evaporationFlux, snowFlux, &
-      !$acc     seaIceFreshWaterFlux, icebergFreshWaterFlux, riverRunoffFlux, iceRunoffFlux, rainFlux)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCells
         surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) &
                                     + seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell) + iceRunoffFlux(iCell) ) / rho_sw
         surfaceThicknessFluxRunoff(iCell) = riverRunoffFlux(iCell) / rho_sw
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(evaporationFlux, snowFlux, seaIceFreshWaterFlux, icebergFreshWaterFlux, &
-      !$acc     riverRunoffFlux, iceRunoffFlux, rainFlux)
-#endif
 
       call mpas_timer_stop("bulk_thick")
 
    end subroutine ocn_surface_bulk_forcing_thick!}}}
+
+   subroutine ocn_surface_bulk_forcing_thick_gpu(forcingPool, surfaceThicknessFlux, surfaceThicknessFluxRunoff, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:), intent(inout) :: surfaceThicknessFlux !< Input/Output: Array for surface thickness flux
+      real (kind=RKIND), dimension(:), intent(inout) ::  &
+         surfaceThicknessFluxRunoff !< Input/Output: Array for surface thickness flux due to river runoff
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, nCells
+
+      real (kind=RKIND), dimension(:), pointer :: evaporationFlux, snowFlux
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: rainFlux
+
+      err = 0
+
+      if (bulkThicknessFluxOff) return
+
+      call mpas_timer_start("bulk_thick gpu", .false.)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'evaporationFlux', evaporationFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'snowFlux', snowFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'rainFlux', rainFlux)
+
+      nCells = nCellsHalo( 2 )
+
+      ! Build surface fluxes at cell centers
+!$acc data present(surfaceThicknessFlux,surfaceThicknessFluxRunoff,&
+!$acc              snowFlux,rainFlux,evaporationFlux,seaIceFreshWaterFlux, &
+!$acc              icebergFreshWaterFlux,iceRunoffFlux,riverRunoffFlux)
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+      do iCell = 1, nCells
+        surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) &
+                                    + seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell) + iceRunoffFlux(iCell) ) / rho_sw
+        surfaceThicknessFluxRunoff(iCell) = riverRunoffFlux(iCell) / rho_sw
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("bulk_thick gpu")
+
+   end subroutine ocn_surface_bulk_forcing_thick_gpu!}}}
 
 !***********************************************************************
 !
@@ -602,6 +798,210 @@ contains
       !$omp end parallel
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
+
+   subroutine ocn_surface_bulk_forcing_active_tracers_gpu(meshPool, forcingPool, tracerGroup,  &
+      tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFluxRunoff
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFluxRemoved
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: dt
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, nCells
+      integer, pointer :: index_temperature_fluxPtr, index_salinity_fluxPtr
+      integer :: index_temperature_flux, index_salinity_flux
+      integer, dimension(:), pointer :: nCellsArray
+
+      type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
+
+      real (kind=RKIND), dimension(:), pointer :: latentHeatFlux, sensibleHeatFlux, longWaveHeatFluxUp, longWaveHeatFluxDown, &
+                                                  seaIceHeatFlux, icebergHeatFlux, evaporationFlux, riverRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
+      real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
+      real (kind=RKIND), dimension(:), pointer :: rainTemperatureFlux, evapTemperatureFlux, &
+                                                  seaIceTemperatureFlux, icebergTemperatureFlux, &
+                                                  totalFreshWaterTemperatureFlux
+      real (kind=RKIND) :: requiredSalt, allowedSalt, surfaceTemperatureFluxWithoutRunoff
+
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
+
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_temperatureSurfaceFlux', &
+                                   index_temperature_fluxPtr)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_salinitySurfaceFlux', &
+                                   index_salinity_fluxPtr)
+      index_temperature_flux = index_temperature_fluxPtr
+      index_salinity_flux    = index_salinity_fluxPtr
+
+      call mpas_pool_get_array_gpu(forcingPool, 'latentHeatFlux', latentHeatFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'sensibleHeatFlux', sensibleHeatFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'longWaveHeatFluxUp', longWaveHeatFluxUp)
+      call mpas_pool_get_array_gpu(forcingPool, 'longWaveHeatFluxDown', longWaveHeatFluxDown)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceHeatFlux', seaIceHeatFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'icebergHeatFlux', icebergHeatFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'rainFlux', rainFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'snowFlux', snowFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'shortWaveHeatFlux', shortWaveHeatFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'evaporationFlux', evaporationFlux)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceSalinityFlux', seaIceSalinityFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'rainTemperatureFlux', rainTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'evapTemperatureFlux', evapTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'seaIceTemperatureFlux', seaIceTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'icebergTemperatureFlux', icebergTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'totalFreshWaterTemperatureFlux', totalFreshWaterTemperatureFlux)
+
+      nCells = nCellsArray( 3 )
+
+!$acc data present(minLevelCell,&
+!$acc              tracerGroup,tracersSurfaceFlux,tracersSurfaceFluxRunoff,tracersSurfaceFluxRemoved,layerThickness,&
+!$acc              latentHeatFlux,sensibleHeatFlux,longWaveHeatFluxUp,longWaveHeatFluxDown,&
+!$acc              seaIceHeatFlux,icebergHeatFlux,snowFlux,iceRunoffFlux,seaIceSalinityFlux,&
+!$acc              rainTemperatureFlux,evapTemperatureFlux,rainFlux,evaporationFlux,&
+!$acc              riverRunoffFlux,seaIceTemperatureFlux,seaIceFreshWaterFlux,icebergTemperatureFlux,icebergFreshWaterFlux,&
+!$acc              totalFreshWaterTemperatureFlux,penetrativeTemperatureFlux,shortWaveHeatFlux)
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) private(allowedSalt, requiredSalt)
+!$acc parallel
+!$acc loop gang vector private(requiredSalt,allowedSalt)
+      do iCell = 1, nCells
+        tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
+                                                           + (latentHeatFlux(iCell) + sensibleHeatFlux(iCell) &
+                                                           + longWaveHeatFluxUp(iCell) + longWaveHeatFluxDown(iCell) &
+                                                           + seaIceHeatFlux(iCell) + icebergHeatFlux(iCell) &
+                                                           - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
+                                                           * latent_heat_fusion_mks) * hflux_factor
+
+        ! Negative seaIceSalinityFlux is an extraction of salt from the ocean
+        ! So, we negate seaIceSalinityFlux when determining how much salt this flux needs.
+        requiredSalt = - seaIceSalinityFlux(iCell) * sflux_factor * dt / layerThickness(minLevelCell(iCell), iCell)
+        allowedSalt = min( 4.0_RKIND, tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell) )
+
+        if ( allowedSalt < requiredSalt ) then
+           tracersSurfaceFluxRemoved(index_salinity_flux, iCell) = tracersSurfaceFluxRemoved(index_salinity_flux, iCell)  &
+                                                                 + ( 1 - allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                                 * sflux_factor
+
+           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+                                                          + ( allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                          * sflux_factor
+        else
+           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+                                                          + seaIceSalinityFlux(iCell) * sflux_factor
+        end if
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+      ! assume that snow comes in at 0 C
+
+      ! Surface fluxes of water have an associated heat content, but the coupled system does not account for this
+      ! Assume surface fluxes of water have a temperature dependent on the incoming mass flux.
+      ! Assume surface fluxes of water have zero salinity. So the RHS forcing is zero for salinity.
+      ! Only include this heat forcing when bulk thickness is turned on
+      ! indices on tracerGroup are (iTracer, iLevel, iCell)
+      if (.not. bulkThicknessFluxOff) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(surfaceTemperatureFluxWithoutRunoff)
+!$acc parallel 
+!$acc loop gang vector private(surfaceTemperatureFluxWithoutRunoff)
+         do iCell = 1, nCells
+
+           ! Accumulate fluxes that use the surface temperature
+           rainTemperatureFlux(iCell) = rainFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
+           evapTemperatureFlux(iCell) = evaporationFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
+
+           ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
+           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
+                      * max(tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell), 0.0_RKIND) / rho_sw
+
+           ! Accumulate fluxes that use the freezing point
+! mrp performance note: should call ocn_freezing_temperature just once here 
+           seaIceTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
+               ocn_freezing_temperature_gpu( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
+                                         inLandIceCavity=.false.) / rho_sw
+           icebergTemperatureFlux(iCell) = icebergFreshWaterFlux(iCell) * &
+               ocn_freezing_temperature_gpu( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
+                                         inLandIceCavity=.false.) / rho_sw
+
+           surfaceTemperatureFluxWithoutRunoff = rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
+                                                 seaIceTemperatureFlux(iCell) + icebergTemperatureFlux(iCell)
+
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
+              + surfaceTemperatureFluxWithoutRunoff
+
+           ! add runoff contribution for sending through coupler
+           totalFreshWaterTemperatureFlux(iCell) = surfaceTemperatureFluxWithoutRunoff &
+              + tracersSurfaceFluxRunoff(index_temperature_flux,iCell)
+
+           ! Fields with zero temperature are not accumulated. These include:
+           !    snowFlux
+           !    iceRunoffFlux
+
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      endif ! bulkThicknessFluxOn
+
+      ! convert short wave heat flux to a temperature flux
+      !$omp parallel
+      !$omp do schedule(runtime)
+!$acc parallel 
+!$acc loop gang vector
+      do iCell = 1, nCells
+         penetrativeTemperatureFlux(iCell) = shortWaveHeatFlux(iCell) * hflux_factor
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   end subroutine ocn_surface_bulk_forcing_active_tracers_gpu!}}}
 
 end module ocn_surface_bulk_forcing
 

--- a/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -55,8 +55,11 @@ module ocn_surface_land_ice_fluxes
    !--------------------------------------------------------------------
 
    public :: ocn_surface_land_ice_fluxes_tracers, &
+             ocn_surface_land_ice_fluxes_tracers_gpu, &
              ocn_surface_land_ice_fluxes_vel, &
+             ocn_surface_land_ice_fluxes_vel_gpu, &
              ocn_surface_land_ice_fluxes_thick, &
+             ocn_surface_land_ice_fluxes_thick_gpu, &
              ocn_surface_land_ice_fluxes_build_arrays, &
              ocn_surface_land_ice_fluxes_init
 
@@ -138,6 +141,54 @@ contains
 
    end subroutine ocn_surface_land_ice_fluxes_tracers!}}}
 
+   subroutine ocn_surface_land_ice_fluxes_tracers_gpu(meshPool, groupName, forcingPool, tracersSurfaceFlux, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      character (len=*) :: groupName !< Input: Name of tracer group
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux !< Input/Output: Surface flux for tracer group
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if (.not.landIceFluxesOn) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_surface_land_ice_fluxes_tracers_gpu NOT EXECUTING"
+
+      call mpas_timer_start("land_ice_" // trim(groupName) //" gpu")
+
+      if ( trim(groupName) == 'activeTracers' ) then
+         call ocn_surface_land_ice_fluxes_active_tracers_gpu(meshPool, forcingPool, tracersSurfaceFlux, err)
+      end if
+
+      call mpas_timer_stop("land_ice_" // trim(groupName) //" gpu")
+
+   end subroutine ocn_surface_land_ice_fluxes_tracers_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_surface_land_ice_fluxes_vel
@@ -191,38 +242,21 @@ contains
 
       call mpas_timer_start("top_drag", .false.)
 
-      !*** Transfer data to device
-      !$acc update device (topDrag, topDragMag)
-
       !*** simply add input values to accumulated stresses
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(sfcStress, topDrag)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iEdge = 1, nEdgesAll
         sfcStress(iEdge) = sfcStress(iEdge) + topDrag(iEdge)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(sfcStressMag, topDragMag)
-#else
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
         sfcStressMag(iCell) = sfcStressMag(iCell) + topDragMag(iCell)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !*** Transfer any needed data back to host and delete inputs
 
@@ -231,6 +265,72 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_surface_land_ice_fluxes_vel!}}}
+
+   subroutine ocn_surface_land_ice_fluxes_vel_gpu(&
+                                      sfcStress, sfcStressMag, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         sfcStress,  &!< [inout] accumulated surface stress
+         sfcStressMag !< [inout] accumulated surface stress magnitude
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge, iCell  ! loop indices for edge, cell loops
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** set error flag and return early if land ice fluxes not on
+      !*** otherwise, start timer
+
+      err = 0
+      if (.not.landIceFluxesOn) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_surface_land_ice_fluxes_vel_gpu NOT EXECUTING"
+
+      call mpas_timer_start("top_drag gpu", .false.)
+
+      !*** simply add input values to accumulated stresses
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdgesAll
+        sfcStress(iEdge) = sfcStress(iEdge) + topDrag(iEdge)
+      end do
+      !$omp end do
+
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+        sfcStressMag(iCell) = sfcStressMag(iCell) + topDragMag(iCell)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      !*** Transfer any needed data back to host and delete inputs
+
+      call mpas_timer_stop("top_drag gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_surface_land_ice_fluxes_vel_gpu!}}}
 
 !***********************************************************************
 !
@@ -282,28 +382,68 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
 
       ! Build surface fluxes at cell centers
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceFreshwaterFlux)
-
-      !$acc parallel loop present(surfaceThicknessFlux, landIceFreshwaterFlux)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
         surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + landIceFreshwaterFlux(iCell) / rho_sw
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(landIceFreshwaterFlux)
-#endif
       call mpas_timer_stop("land_ice_thick")
 
    end subroutine ocn_surface_land_ice_fluxes_thick!}}}
+
+   subroutine ocn_surface_land_ice_fluxes_thick_gpu(forcingPool, surfaceThicknessFlux, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:), intent(inout) :: surfaceThicknessFlux !< Input/Output: Array for surface thickness flux
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell
+
+      real (kind=RKIND), dimension(:), pointer :: landIceFreshwaterFlux
+
+      err = 0
+
+      if (.not.landIceFluxesOn) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_surface_land_ice_fluxes_thick_gpu NOT EXECUTING"
+
+      call mpas_timer_start("land_ice_thick gpu")
+
+      call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+        surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + landIceFreshwaterFlux(iCell) / rho_sw
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("land_ice_thick gpu")
+
+   end subroutine ocn_surface_land_ice_fluxes_thick_gpu!}}}
 
 !***********************************************************************
 !
@@ -372,6 +512,61 @@ contains
       !$omp end parallel
 
    end subroutine ocn_surface_land_ice_fluxes_active_tracers!}}}
+
+   subroutine ocn_surface_land_ice_fluxes_active_tracers_gpu(meshPool, forcingPool, tracersSurfaceFlux, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell
+      integer, pointer :: nCells
+
+      real (kind=RKIND), dimension(:), pointer :: landIceHeatFlux
+
+      err = 0
+
+      if (.not.landIceFluxesOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+      call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
+
+      ! add to surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+        tracersSurfaceFlux(1, iCell) = tracersSurfaceFlux(1, iCell) + landIceHeatFlux(iCell)/(rho_sw*cp_sw)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_surface_land_ice_fluxes_active_tracers_gpu!}}}
 
 
 !***********************************************************************
@@ -461,6 +656,7 @@ contains
       err = 0
 
       if (.not.landIceStandaloneOn) return
+      write(*,*) "ocn_surface_land_ice_fluxes_build_arrays NOT EXECUTING"
 
       call mpas_timer_start("land_ice_build_arrays")
 

--- a/src/shared/mpas_ocn_tendency.F
+++ b/src/shared/mpas_ocn_tendency.F
@@ -90,8 +90,11 @@ module ocn_tendency
    !--------------------------------------------------------------------
 
    public :: ocn_tend_thick, &
+             ocn_tend_thick_gpu, &
              ocn_tend_vel, &
+             ocn_tend_vel_gpu, &
              ocn_tend_tracer, &
+             ocn_tend_tracer_gpu, &
              ocn_tend_freq_filtered_thickness, &
              ocn_tendency_init, &
              ocn_tend_vvel
@@ -168,16 +171,8 @@ contains
       ! layer thickness tendency: 
       !    initialize to zero and start accumulating tendency terms
       !
-#ifdef MPAS_OPENACC
-      !$acc enter data create(tendThick, surfaceThicknessFlux, surfaceThicknessFluxRunoff)
-
-      !$acc parallel loop &
-      !$acc     present(tendThick, surfaceThicknessFlux, surfaceThicknessFluxRunoff) &
-      !$acc     private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCellsAll
          surfaceThicknessFlux(iCell) = 0.0_RKIND
          surfaceThicknessFluxRunoff(iCell) = 0.0_RKIND
@@ -185,10 +180,8 @@ contains
             tendThick(k, iCell) = 0.0_RKIND
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       ! If turned off, return with zero fluxes, tendencies
       ! Otherwise, start time and call routines to accumulate
@@ -231,15 +224,128 @@ contains
       call ocn_tidal_forcing_layer_thickness(forcingPool, &
                                              tendThick, err)
 
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout(tendThick, surfaceThicknessFlux, surfaceThicknessFluxRunoff)
-#endif
-
       call mpas_timer_stop("ocn_tend_thick")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_tend_thick!}}}
+
+   subroutine ocn_tend_thick_gpu(tendPool, forcingPool)!{{{
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         tendPool,          &!< [inout] Pool with accumulated tendencies
+         forcingPool         !< [inout] Forcing information
+
+      ! pointers for the actual output variables within the pools above
+      real (kind=RKIND), dimension(:), pointer, contiguous :: &
+         surfaceThicknessFlux,     &! surface thickness flux
+         surfaceThicknessFluxRunoff ! surface thickness flux from runoff
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         tendThick,        &! accumulated layer thickness tendency
+         fractionAbsorbed, &! fraction of sfc flux absorbed
+         fractionAbsorbedRunoff ! fraction of runoff flux absorbed
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::   &
+         err,      &! internal error flag
+         k, iCell   ! loop iterators for vertical, cell loops
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! retrieve variables from pools
+      call mpas_pool_get_array_gpu(tendPool,    'layerThickness', &
+                                             tendThick)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceThicknessFlux', &
+                                             surfaceThicknessFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceThicknessFluxRunoff', &
+                                             surfaceThicknessFluxRunoff)
+      call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbed', &
+                                             fractionAbsorbed)
+      call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbedRunoff', &
+                                             fractionAbsorbedRunoff)
+
+!$acc data present(surfaceThicknessFlux,surfaceThicknessFluxRunoff,tendThick,&
+!$acc               normalTransportVelocity,layerThickEdgeFlux,vertAleTransportTop,&
+!$acc               fractionAbsorbed,fractionAbsorbedRunoff)
+      !
+      ! layer thickness tendency: 
+      !    initialize to zero and start accumulating tendency terms
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang 
+      do iCell = 1, nCellsAll
+         surfaceThicknessFlux(iCell) = 0.0_RKIND
+         surfaceThicknessFluxRunoff(iCell) = 0.0_RKIND
+!$acc loop vector
+         do k=1,nVertLevels
+            tendThick(k, iCell) = 0.0_RKIND
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      ! If turned off, return with zero fluxes, tendencies
+      ! Otherwise, start time and call routines to accumulate
+      if (config_disable_thick_all_tend) return
+      call mpas_timer_start("ocn_tend_thick gpu")
+
+      ! Compute surface mass flux array from bulk forcing
+      call ocn_surface_bulk_forcing_thick_gpu(forcingPool, &
+                                          surfaceThicknessFlux, &
+                                          surfaceThicknessFluxRunoff, err)
+
+      ! Compute surface thickness flux from land ice
+!NV!  !!! NOT EXECUTING !!!
+      call ocn_surface_land_ice_fluxes_thick_gpu(forcingPool, &
+                                             surfaceThicknessFlux, err)
+
+      !
+      ! Compute horizontal advection term -\nabla\cdot ( hu)
+      ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
+      ! for explanation of divergence operator.
+      !
+      call ocn_thick_hadv_tend_gpu(normalTransportVelocity, &
+                               layerThickEdgeFlux, tendThick, err)
+
+      ! Compute vertical advection term -d/dz(hw)
+      call ocn_thick_vadv_tend_gpu(vertAleTransportTop, &
+                               tendThick, err)
+
+      ! Compute surface flux tendency
+      call ocn_thick_surface_flux_tend_gpu(fractionAbsorbed, &
+                                       fractionAbsorbedRunoff, &
+                                       surfaceThicknessFlux, &
+                                       surfaceThicknessFluxRunoff, &
+                                       tendThick, err)
+
+      ! Compute contribution from frazil ice formation
+      call ocn_frazil_forcing_layer_thickness_gpu(forcingPool, &
+                                              tendThick, err)
+
+      ! Compute thickness change due to tidal forcing
+!NV!  !!! NOT EXECUTING !!!
+      call ocn_tidal_forcing_layer_thickness_gpu(forcingPool, &
+                                             tendThick, err)
+
+      call mpas_timer_stop("ocn_tend_thick gpu")
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tend_thick_gpu!}}}
 
 !***********************************************************************
 !
@@ -480,48 +586,24 @@ end subroutine ocn_tend_vvel!}}}
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
                                              sfcStressMag)
 
-      !*** Transfer data to device
-      !$acc update device(zMid, divergence, relativeVorticity, normPlanetVortEdge, &
-      !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
-      !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
-      !$acc               layerThickEdgeFlux, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
-      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity, &
-      !$acc               nhPressureCorrection)
-      !$acc enter data &
-      !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
-      !$acc    ssh, normalVelocity, &
-      !$acc    layerThickness, activeTracers)
-
       !*** Set output variables to zero before accumulating results
       
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(sfcStress, tendVel) private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iEdge = 1, nEdgesAll
          sfcStress(iEdge) = 0.0_RKIND
          do k=1,nVertLevels
             tendVel(k,iEdge) = 0.0_RKIND
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(sfcStressMag)
-#else
       !$omp do schedule(runtime)
-#endif
       do iCell = 1, nCellsAll
          sfcStressMag(iCell) = 0.0_RKIND
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !*** Return early if all vel tendencies disabled
       !*** Otherwise, start timer
@@ -566,7 +648,6 @@ end subroutine ocn_tend_vvel!}}}
           call ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, ssh, err)
           call mpas_reset_clock_alarm(domain % clock, 'salComputeAlarm', ierr=err)
       endif
-      !$acc update device(ssh_sal)
 
       ! Add tidal potential (if needed) 
       call ocn_compute_tidal_potential_forcing(err)
@@ -586,30 +667,16 @@ end subroutine ocn_tend_vvel!}}}
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) &
-      !$acc    present(tendVel, wettingVelocity)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iEdge = 1, nEdgesAll
       do k=1,nVertLevels
          tendVel(k,iEdge) = tendVel(k,iEdge)* &
                             (1.0_RKIND - wettingVelocity(k,iEdge))
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-      !*** Transfer any needed data back to host and delete inputs
-      !$acc exit data &
-      !$acc    copyout(tendVel, sfcStress, sfcStressMag) &
-      !$acc    delete( &
-      !$acc    ssh, normalVelocity, &
-      !$acc    layerThickness, activeTracers)
 
       ! stop the timer and exit
 
@@ -618,6 +685,233 @@ end subroutine ocn_tend_vvel!}}}
    !--------------------------------------------------------------------
 
    end subroutine ocn_tend_vel!}}}
+
+   subroutine ocn_tend_vel_gpu(domain, tendPool, statePool, forcingPool, &
+                           timeLevelIn, dminfo, dt)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain !< Input/Output: domain information
+
+      real (kind=RKIND), intent(in) :: &
+         dt             !< [in] time step
+
+      integer, intent(in), optional :: &
+         timeLevelIn    !< [in] Time level for state fields
+
+      ! Input structures with lots of fields
+      type (mpas_pool_type), intent(in) :: statePool ! replace
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      ! currently updated as pool variables - change to args?
+
+      type (mpas_pool_type), intent(inout) :: &
+         tendPool,          &!< [out] Tendency structure w/ vel tend
+         forcingPool         !< [out] Forcing structure w/ sfc stresses
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         tendVel             !< [out] normal velocity tendency at edges
+
+      real (kind=RKIND), dimension(:), pointer, contiguous :: &
+         sfcStress,         &!< [out] surface stress at edges
+         sfcStressMag        !< [out] surface stress magnitude (on cell)
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::           &
+         err,              &! local error flag
+         iEdge, iCell, k,  &! loop indices for edge, cell and vertical
+         indxTemp,         &! tracer index for temperature
+         indxSalt,         &! tracer index for salinity
+         timeLevel          ! time level to use for state variables
+
+      ! various pointers for array retrievals
+
+      integer, pointer :: indexTemperature, indexSalinity
+      type (mpas_pool_type), pointer :: tracersPool
+      type (dm_info), intent(in) :: dminfo
+
+      real (kind=RKIND), dimension(:), pointer, contiguous :: &
+         ssh               ! sea surface height
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         normalVelocity,     &! normal velocity
+         layerThickness, &
+         nonhydrostaticPressure
+
+      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+         activeTracers
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Initialize error code and determine time level
+
+      err = 0
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      !*** Retrieve pool variables
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+
+      call mpas_pool_get_array_gpu(statePool,   'normalVelocity', &
+                                             normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool,   'layerThickness', &
+                                             layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool,   'ssh', ssh, timeLevel)
+      call mpas_pool_get_array_gpu(tracersPool, 'activeTracers', &
+                                             activeTracers, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'nonhydrostaticPressure', &
+                                             nonhydrostaticPressure, timeLevel)
+
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinity)
+      indxTemp = indexTemperature
+      indxSalt = indexSalinity
+
+      call mpas_pool_get_array_gpu(tendPool, 'normalVelocity', tendVel)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceStress', &
+                                             sfcStress)
+      call mpas_pool_get_array_gpu(forcingPool, 'surfaceStressMagnitude', &
+                                             sfcStressMag)
+
+      !*** Set output variables to zero before accumulating results
+     
+!$acc data present(sfcStress,tendVel,sfcStressMag,wettingVelocity,normRelVortEdge,&
+!$acc              normPlanetVortEdge,normalVelocity,layerThickEdgeFlux,kineticEnergyCell,&
+!$acc              vertAleTransportTop,ssh,nonhydrostaticPressure,pressure,surfacePressure,&
+!$acc              montgomeryPotential,zMid,density,potentialDensity,activeTracers,&
+!$acc              thermExpCoeff,salineContractCoeff,divergence,relativeVorticity,&
+!$acc              sfcFlxAttCoeff,layerThickEdgeMean)
+ 
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang worker
+      do iEdge = 1, nEdgesAll
+         sfcStress(iEdge) = 0.0_RKIND
+!$acc loop vector
+         do k=1,nVertLevels
+            tendVel(k,iEdge) = 0.0_RKIND
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+
+      !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector
+      do iCell = 1, nCellsAll
+         sfcStressMag(iCell) = 0.0_RKIND
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !*** Return early if all vel tendencies disabled
+      !*** Otherwise, start timer
+
+      if (config_disable_vel_all_tend) return
+      call mpas_timer_start("ocn_tend_vel_gpu")
+
+      ! Compute bulk forcing surface stress
+      call ocn_surface_bulk_forcing_vel_gpu( &
+                                    forcingPool, sfcStress, &
+                                    sfcStressMag, err)
+
+      ! Add top drag to surface stress
+!NV!  !!! NOT EXECUTING !!!
+      call ocn_surface_land_ice_fluxes_vel_gpu( &
+                                       sfcStress, sfcStressMag, err)
+
+      ! Add nonlinear Coriolis term and horizontal advection of
+      ! momentum, formulated as grad of kinetic energy
+      call ocn_vel_hadv_coriolis_tend_gpu(normRelVortEdge, &
+                                      normPlanetVortEdge, &
+                                      layerThickEdgeFlux, normalVelocity, &
+                                      kineticEnergyCell, tendVel, err)
+
+      ! Add vertical advection term -w du/dz
+      call ocn_vel_vadv_tend_gpu(normalVelocity, layerThickEdgeFlux, &
+                             vertAleTransportTop, tendVel, err)
+
+      ! Add pressure gradient
+      call ocn_vel_pressure_grad_tend_gpu(ssh, nonhydrostaticPressure, &
+                               pressure, surfacePressure, &
+                               montgomeryPotential, zMid, &
+                               density, potentialDensity, &
+                               indxTemp, indxSalt, activeTracers, &
+                               thermExpCoeff, salineContractCoeff, &
+                               tendVel, err)
+
+      ! Compute ssh additions due to self-attraction and loading
+      if(mpas_is_alarm_ringing(domain % clock, 'salComputeAlarm', ierr=err)) then 
+!NV!      !!! NOT EXECUTING !!!
+          write(*,*) "ocn_tend_vel_gpu Computing SAL"
+#ifdef MPAS_DEBUG
+          call mpas_log_write('       Computing SAL')
+#endif
+          call ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, ssh, err)
+          call mpas_reset_clock_alarm(domain % clock, 'salComputeAlarm', ierr=err)
+      endif
+
+      ! Add tidal potential (if needed)
+!NV!  !!! NOT EXECUTING !!! 
+      call ocn_compute_tidal_potential_forcing_gpu(err)
+      if (config_time_integrator == 'RK4') then
+!NV!    !!! NOT EXECUTING !!!
+        write(*,*) "ocn_tend_vel_gpu ocn_vel_tidal_potential_tend"
+        ! for split explicit, tidal forcing is added in barotropic subcycles
+        call ocn_vel_tidal_potential_tend(ssh,surfacePressure, tendVel, err)
+      endif
+
+      ! Add horizontal mixing
+      call ocn_vel_hmix_tend_gpu(divergence, relativeVorticity, tendVel,err)
+
+      ! Add forcing and bottom drag
+      call ocn_vel_forcing_tend_gpu(normalVelocity, sfcFlxAttCoeff, &
+                                sfcStress, kineticEnergyCell, &
+                                layerThickEdgeMean, tendVel, err)
+
+      ! vertical mixing treated implicitly in a later routine
+      ! adjust total velocity tendency based on wetting/drying
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iEdge = 1, nEdgesAll
+      do k=1,nVertLevels
+         tendVel(k,iEdge) = tendVel(k,iEdge)* &
+                            (1.0_RKIND - wettingVelocity(k,iEdge))
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      ! stop the timer and exit
+
+      call mpas_timer_stop("ocn_tend_vel_gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tend_vel_gpu!}}}
 
 !***********************************************************************
 !
@@ -795,22 +1089,9 @@ end subroutine ocn_tend_vvel!}}}
       ! allocate and transfer data not specific to tracer groups
       allocate(normalThicknessFlux(nVertLevels, nEdgesAll+1))
 
-      !$acc enter data create(normalThicknessFlux) &
-      !$acc            copyin(layerThickness)
-      !TEMPORARY - once diagnotics module ported, these should already
-      !            be on the device
-      !$acc update device (normalTransportVelocity, layerThickEdgeFlux, &
-      !$acc                vertAleTransportTop)
-
       ! compute transport velocity to use for all tracers
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) &
-      !$acc    present(normalThicknessFlux, normalTransportVelocity, &
-      !$acc            layerThickEdgeFlux)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
          normalThicknessFlux(k,iEdge) = &
@@ -818,10 +1099,8 @@ end subroutine ocn_tend_vvel!}}}
                  layerThickEdgeFlux(k, iEdge)
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !
       ! Start computation of tracer tendencies.
@@ -1222,9 +1501,6 @@ end subroutine ocn_tend_vvel!}}}
             call mpas_timer_stop("TTD " // groupName)
          endif ! TTD
 
-         !$acc enter data &
-         !$acc    copyin(tracerGroup, tracerGroupTend)
-
          !
          ! Accumulate tendencies for all tracers
          ! First is the horizontal advection term
@@ -1235,15 +1511,6 @@ end subroutine ocn_tend_vvel!}}}
                             normalThicknessFlux, vertAleTransportTop, &
                             layerThickness, dt, tracerGroupTend, &
                             computeBudgets)
-
-         !$acc update host (activeTracerHorizontalAdvectionEdgeFlux, &
-         !$acc              activeTracerHorizontalAdvectionTendency, &
-         !$acc              activeTracerVerticalAdvectionTopFlux, &
-         !$acc              activeTracerVerticalAdvectionTendency)
-
-         !$acc exit data &
-         !$acc    copyout(tracerGroupTend) &
-         !$acc    delete(tracerGroup)
 
          !
          ! Add horizontal tracer diffusion,
@@ -1432,8 +1699,6 @@ end subroutine ocn_tend_vvel!}}}
       end if ! member is field
       end do ! loop over tracer groups
 
-      !$acc exit data delete (normalThicknessFlux, layerThickness)
-
       deallocate(normalThicknessFlux)
 
       call mpas_timer_stop("ocn_tend_tracer")
@@ -1441,6 +1706,863 @@ end subroutine ocn_tend_vvel!}}}
    !--------------------------------------------------------------------
 
    end subroutine ocn_tend_tracer!}}}
+
+   subroutine ocn_tend_tracer_gpu(tendPool, statePool, forcingPool, &
+                              meshPool, swForcingPool, &
+                              dt, activeTracersOnlyIn, timeLevelIn )!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,          &!< [in] ocean state variables
+         meshPool             !< [in] mesh information
+
+      real (kind=RKIND), intent(in) :: &
+         dt                   !< [in] time step (seconds)
+
+      logical, intent(in), optional :: &
+         activeTracersOnlyIn  !< [in] only compute for active tracers
+
+      integer, intent(in), optional :: &
+         timeLevelIn          !< [in] time index to use for state vars
+
+      ! these variables input from shared diagnostics module:
+      !    normalTransportVelocity - transport velocity across edge
+      !    layerThickEdgeFlux      - flux-related layer thickness on edge
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         forcingPool,   &!< [inout] forcing data
+         swForcingPool, &!< [inout] shortwave forcing data
+         tendPool        !< [inout] Tendency terms for all variables
+
+      integer :: &
+         iCell, iEdge, k, n, &! loop counters for cell,edge,vert,tracer
+         err,                &! internal error flag 
+         timeLevel,          &! time level to use for state variables
+         indxTemp, indxSalt, &! tracer index for temperature, salinity
+         indxCFC11,          &! tracer index for CFC11
+         indxCFC12,          &! tracer index for CFC12
+         nTracersGroup,      &! number of tracers in each tracer group
+         nTracersEcosys       ! number of ecosystem tracers
+
+      logical :: &
+         activeTracersOnly,  &! only compute tend for active tracers
+         isActiveTracer,     &! is this group the active tracer group
+         computeBudgets       ! compute active tracer budgets
+
+      ! iterator and modified strings for tracer categories
+      type (mpas_pool_iterator_type) :: groupItr
+      character (len=:), allocatable :: &
+         groupName,            &! tracer group name
+         configBase,           &! base name for config options
+         modifiedGroupName,    &! variations on group name for options
+         modifiedConfigName     ! string to construct config var names
+
+      ! sub-pools with various data sets
+      type (mpas_pool_type), pointer :: &
+         tracersPool,            &! tracer variables
+         tracersTendPool,        &! tracer tendencies
+         tracersSurfaceFluxPool, &! surface fluxes
+         tracersSurfaceRestoringFieldsPool, &! surface restoring
+         tracersInteriorRestoringFieldsPool,&! interior restoring
+         tracersExponentialDecayFieldsPool, &! exponential decay
+         tracersIdealAgeFieldsPool,         &! ideal age
+         tracersTTDFieldsPool     ! transit time distribution
+
+      ! pointers for retrieving data from pools
+      integer, pointer :: &
+         indexTemperature, indexSalinity ! tracer index for temp,salt
+      integer, pointer :: &
+         indexCFC11, indexCFC12 ! tracer indicies for CFCs
+
+      logical, pointer :: & ! option configuration flags
+         config_use_tracerGroup, &
+         config_use_tracerGroup_surface_bulk_forcing, &
+         config_use_tracerGroup_surface_restoring,    &
+         config_use_tracerGroup_interior_restoring,   &
+         config_use_tracerGroup_exponential_decay,    &
+         config_use_tracerGroup_idealAge_forcing,     &
+         config_use_tracerGroup_ttd_forcing
+
+      real (kind=RKIND), dimension(:), pointer, contiguous :: &
+         penetrativeTemperatureFlux, &! heat flux penetrating below sfc
+         tracerGroupExponentialDecayRate ! exp decay rate for forcing
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         tracerGroupPistonVelocity,        &! forcing piston velocity
+         tracerGroupSurfaceRestoringValue, &! restore sfc to this value
+         tracerGroupIdealAgeMask,          &! mask to reset ideal age
+         tracerGroupTTDMask                 ! mask for TTD values
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         layerThickness,               &! layer thickness
+         tracerGroupSurfaceFlux,       &! tracer flux at surface
+         fractionAbsorbed,             &! frac sfc flux aborbed
+         fractionAbsorbedRunoff,       &! frac runoff flux aborbed
+         tracerGroupSurfaceFluxRunoff, &! runoff flux
+         tracerGroupSurfaceFluxRemoved,&! total sfc flux absorbed
+         nonLocalSurfaceTracerFlux      ! non-local fluxes (eg KPP)
+
+      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+         tracerGroup,     &! tracers in current tracer group
+         tracerGroupTend, &! tendencies for current tracer group
+         activeTracers,   &! retain active tracers
+         ecosysTracers,   &! retain ecosys tracers for DMS, MacroMols
+         tracerGroupInteriorRestoringRate, &! int restoring timescale 
+         tracerGroupInteriorRestoringValue  ! int restoring value
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         normalThicknessFlux ! Flux of thickness through edge (m^2/s)
+!$acc declare create(normalThicknessFlux)
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! return if all tracer tendencies disabled
+      ! otherwise start timer and proceed
+   
+      if (config_disable_tr_all_tend) return
+      call mpas_timer_start("ocn_tend_tracer gpu")
+
+      ! set time level to default 1 or override with input arg
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      ! set flag to compute only active tracers (default false)
+      if (present(activeTracersOnlyIn)) then
+         activeTracersOnly = activeTracersOnlyIn
+      else
+         activeTracersOnly = .false.
+      end if
+
+      ! retrieve data from pools 
+      call mpas_pool_get_subpool(statePool,   'tracers', &
+                                               tracersPool)
+      call mpas_pool_get_subpool(tendPool,    'tracersTend', &
+                                               tracersTendPool)
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', &
+                                               tracersSurfaceFluxPool)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinity)
+      indxTemp = indexTemperature ! convert to int scalar due to
+      indxSalt = indexSalinity    ! problems with int scalar pointers
+
+      call mpas_pool_get_array_gpu(statePool,   'layerThickness', &
+                                             layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(forcingPool, 'penetrativeTemperatureFlux', &
+                                             penetrativeTemperatureFlux)
+      call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbed', &
+                                             fractionAbsorbed)
+      call mpas_pool_get_array_gpu(forcingPool, 'fractionAbsorbedRunoff', &
+                                             fractionAbsorbedRunoff)
+
+      ! allocate and transfer data not specific to tracer groups
+      allocate(normalThicknessFlux(nVertLevels, nEdgesAll+1))
+
+!$acc data present(normalTransportVelocity,layerThickEdgeFlux,layerThickness,vertAleTransportTop,&
+!$acc               activeTracerHorMixTendency,layerThickEdgeMean,zMid,RediKappa,slopeTriadUp,slopeTriadDown,&
+!$acc               RediKappaScaling,rediLimiterCount,activeTracerSurfaceFluxTendency,fractionAbsorbed,&
+!$acc               fractionAbsorbedRunoff,temperatureShortWaveTendency,penetrativeTemperatureFlux,&
+!$acc               penetrativeTemperatureFluxOBL,bottomLayerShortwaveTemperatureFlux,activeTracerNonLocalTendency,&
+!$acc               vertNonLocalFlux)&
+!$acc      create(normalThicknessFlux)
+
+      ! compute transport velocity to use for all tracers
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!NV! Kernel 1 - 1886
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iEdge = 1,nEdgesAll
+      do k = 1,nVertLevels
+         normalThicknessFlux(k,iEdge) = &
+                 normalTransportVelocity(k,iEdge)* &
+                 layerThickEdgeFlux(k, iEdge)
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !
+      ! Start computation of tracer tendencies.
+      ! Loop over tracer groups and only compute if:
+      !  - the pool member is a field
+      !  - the group is the active tracer group
+      !  - other groups if the active tracer only flag not on
+      !  - the specific use flag for the given group is enabled 
+      ! We do not indent these various loops/conditions to avoid
+      ! excessive indentation.
+      !
+
+      ! loop over groups
+      call mpas_pool_begin_iteration(tracersPool)
+      do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
+
+      ! make sure group member is a field
+      if ( groupItr % memberType == MPAS_POOL_FIELD ) then
+
+      ! Set active tracer flag and compute if this is the active tracer
+      ! group. If not active tracer, check active tracer only flag.
+
+      groupName = trim(groupItr%memberName)
+      if (groupName=='activeTracers') then
+         isActiveTracer = .true.
+      else
+         isActiveTracer = .false.
+      endif
+      if (isActiveTracer .or. (.not. activeTracersOnly)) then
+
+      ! Finally, check config_use flag for this tracer group
+      configBase = 'config_use_' // groupName
+      call mpas_pool_get_config(ocnConfigs, configBase, &
+                                config_use_tracerGroup)
+
+      if ( config_use_tracerGroup ) then
+
+         ! This group meets all requirements, now check for 
+         ! requested options
+
+         computeBudgets =  (isActiveTracer .and.  &
+                            config_compute_active_tracer_budgets)
+
+         modifiedConfigName = configBase // '_surface_bulk_forcing'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_surface_bulk_forcing)
+         modifiedConfigName = configBase // '_surface_restoring'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_surface_restoring)
+         modifiedConfigName = configBase // '_interior_restoring'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_interior_restoring)
+         modifiedConfigName = configBase // '_exponential_decay'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_exponential_decay)
+         modifiedConfigName = configBase // '_idealAge_forcing'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_idealAge_forcing)
+         modifiedConfigName = configBase // '_ttd_forcing'
+         call mpas_pool_get_config(ocnConfigs, modifiedConfigName, &
+                            config_use_tracerGroup_ttd_forcing)
+
+         ! Get tracers from pool, determine number of tracers in group
+         call mpas_pool_get_array_gpu(tracersPool, groupName, &
+                                  tracerGroup, timeLevel)
+         nTracersGroup = size(tracerGroup, dim=1)
+
+         ! Get Tendency array
+         modifiedGroupName = groupName // "Tend"
+         call mpas_pool_get_array_gpu(tracersTendPool, &
+                                  modifiedGroupName, &
+                                  tracerGroupTend)
+
+         ! Get surface flux array
+         modifiedGroupName = groupName // "SurfaceFlux"
+         call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                                  modifiedGroupName, &
+                                  tracerGroupSurfaceFlux)
+
+         ! Get Array of total surface temp/salt flux 
+         ! (includes thickness tendencies)
+         call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                                  'nonLocalSurfaceTracerFlux', &
+                                   nonLocalSurfaceTracerFlux)
+
+         ! Get surface flux due to river runoff array
+         !maltrud only active tracers have runoff flux for now,
+         ! but we still need to associate for ALL tracers
+         modifiedGroupName = groupName // "SurfaceFluxRunoff"
+         call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                                  modifiedGroupName, &
+                                  tracerGroupSurfaceFluxRunoff)
+
+         ! Get surface flux removed array to keep track of how much
+         ! flux is ignored
+         modifiedGroupName = groupName // "SurfaceFluxRemoved"
+         call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, &
+                                  modifiedGroupName, &
+                                  tracerGroupSurfaceFluxRemoved)
+
+         !
+         ! initialize tracer surface fluxes and tendencies to zero.
+         !
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 2 - 2004
+!$acc parallel
+!$acc loop gang vector collapse(3)
+         do iCell = 1, nCellsAll
+         do k=1,nVertLevels
+         do n=1,nTracersGroup
+            tracerGroupTend(n,k,iCell) = 0.0_RKIND
+         end do
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+
+         !$omp do schedule(runtime) private(n)
+!NV! Kernel 3 - 2017
+!$acc parallel
+!$acc loop gang vector collapse(2)
+         do iCell = 1, nCellsAll
+         do n=1,nTracersGroup
+            tracerGroupSurfaceFlux       (n,iCell) = 0.0_RKIND
+            tracerGroupSurfaceFluxRunoff (n,iCell) = 0.0_RKIND
+            tracerGroupSurfaceFluxRemoved(n,iCell) = 0.0_RKIND
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+         !
+         ! compute surface tracer flux from bulk forcing
+         !
+         if (config_use_tracerGroup_surface_bulk_forcing) then
+!NV!        !!! EXECUTING !!!
+            call ocn_surface_bulk_forcing_tracers_gpu(meshPool, groupName, &
+                                  forcingPool, tracerGroup, &
+                                  tracerGroupSurfaceFlux, &
+                                  tracerGroupSurfaceFluxRunoff, &
+                                  tracerGroupSurfaceFluxRemoved, &
+                                  dt, layerThickness, err)
+
+         end if ! sfc bulk forcing
+
+         !
+         ! compute ecosystem source-sink tendencies and net surface fluxes
+         ! NOTE: must be called before ocn_tracer_surface_flux_tend
+         !
+         if ( groupName == 'ecosysTracers' ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "groupName == 'ecosysTracers' NOT EXECUTING"
+
+            call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                     activeTracers, timeLevel)
+            call ocn_tracer_ecosys_compute(activeTracers, tracerGroup, &
+                                           forcingPool, nTracersGroup, &
+                                           nCellsOwned, latCell, minLevelCell, &
+                                           maxLevelCell, nVertLevels, &
+                                           layerThickness, zMid, &
+                                           indxTemp, indxSalt, &
+                                           tracerGroupTend, err)
+
+            call ocn_tracer_ecosys_surface_flux_compute(activeTracers, &
+                                           tracerGroup, forcingPool,  &
+                                           nTracersGroup, nCellsOwned, &
+                                           zMid, minLevelCell, indxTemp, &
+                                           indxSalt, tracerGroupSurfaceFlux, &
+                                           err)
+                                           
+         endif ! ecosys tracers
+
+         !
+         ! compute DMS source-sink tendencies and net surface fluxes
+         ! NOTE: must be called before ocn_tracer_surface_flux_tend
+         !
+         if ( groupName == 'DMSTracers' ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "groupName == 'DMSTracers' NOT EXECUTING"
+
+            call mpas_pool_get_array(tracersPool, 'ecosysTracers', &
+                                     ecosysTracers, timeLevel)
+            nTracersEcosys = size(ecosysTracers, dim=1)
+            call ocn_tracer_DMS_compute(activeTracers, tracerGroup, &
+                                        nTracersGroup, ecosysTracers, &
+                                        nTracersEcosys, forcingPool, &
+                                        nCellsOwned, minLevelCell, &
+                                        maxLevelCell, nVertLevels, &
+                                        layerThickness, indxTemp, &
+                                        indxSalt, tracerGroupTend, &
+                                        err)
+
+            call ocn_tracer_DMS_surface_flux_compute(activeTracers, &
+                                        tracerGroup, forcingPool,  &
+                                        nTracersGroup, nCellsOwned, &
+                                        zMid, minLevelCell, indxTemp, &
+                                        indxSalt, tracerGroupSurfaceFlux,  &
+                                        tracerGroupSurfaceFluxRemoved, err)
+         endif ! DMS
+
+         !
+         ! compute MacroMolecules source-sink tendencies and net surface fluxes
+         ! NOTE: must be called before ocn_tracer_surface_flux_tend
+         !
+         if ( groupName == 'MacroMoleculesTracers' ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "groupName == 'MacroMoleculesTracers' NOT EXECUTING"
+
+            call mpas_pool_get_array(tracersPool, 'ecosysTracers', &
+                                     ecosysTracers, timeLevel)
+            nTracersEcosys = size(ecosysTracers, dim=1)
+            call ocn_tracer_MacroMolecules_compute(tracerGroup, &
+                                  nTracersGroup, ecosysTracers, &
+                                  nTracersEcosys, forcingPool, &
+                                  nCellsOwned, minLevelCell, &
+                                  maxLevelCell, nVertLevels, &
+                                  layerThickness,  &
+                                  tracerGroupTend, err)
+
+            call ocn_tracer_MacroMolecules_surface_flux_compute( &
+                                  activeTracers, tracerGroup, &
+                                  forcingPool, nTracersGroup, &
+                                  nCellsOwned, zMid, &
+                                  indxTemp, indxSalt, &
+                                  tracerGroupSurfaceFlux, err)
+
+         endif ! MacroMolecules
+
+         !
+         ! compute CFC surface fluxes, there are no interior sources/sinks
+         !
+         if ( groupName == 'CFCTracers' ) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "groupName == 'CFCTracers' NOT EXECUTING"
+
+            call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                     activeTracers, timeLevel)
+
+            indxCFC11 = 0
+            indxCFC12 = 0
+            if (config_use_CFC11) then
+              call mpas_pool_get_dimension(tracersPool, 'index_CFC11', indexCFC11)
+              indxCFC11 = indexCFC11 ! convert to int scalar due to problems with int scalar pointers
+            endif
+            if (config_use_CFC12) then
+              call mpas_pool_get_dimension(tracersPool, 'index_CFC12', indexCFC12)
+              indxCFC12 = indexCFC12 ! convert to int scalar due to problems with int scalar pointers
+            endif
+                                                 
+            call ocn_tracer_CFC_surface_flux_compute(activeTracers, &
+                                        tracerGroup, forcingPool,  &
+                                        nTracersGroup, nCellsOwned, &
+                                        indxTemp, indxSalt, tracerGroupSurfaceFlux, indxCFC11, indxCFC12, err)
+         endif ! CFC
+
+         !
+         ! ocean surface restoring
+         !
+         if (config_use_tracerGroup_surface_restoring) then
+!NV!        !!! EXECUTING !!!
+
+            call mpas_timer_start("surface_restoring_"//groupName//" gpu")
+            call mpas_pool_get_subpool(forcingPool, &
+                                   'tracersSurfaceRestoringFields', &
+                                    tracersSurfaceRestoringFieldsPool)
+
+            modifiedGroupName = groupName // "PistonVelocity"
+            call mpas_pool_get_array_gpu(tracersSurfaceRestoringFieldsPool,&
+                                     modifiedGroupName, &
+                                     tracerGroupPistonVelocity)
+
+            modifiedGroupName = groupName//"SurfaceRestoringValue"
+            call mpas_pool_get_array_gpu(tracersSurfaceRestoringFieldsPool,&
+                                     modifiedGroupName, &
+                                     tracerGroupSurfaceRestoringValue)
+
+            ! Note: monthly surface salinity restoring is a special
+            ! case for tracer restoring
+            call ocn_tracer_surface_restoring_compute_gpu(groupName, &
+                   nTracersGroup, nCellsAll, tracerGroup,  &
+                   tracerGroupPistonVelocity, &
+                   tracerGroupSurfaceRestoringValue, &
+                   tracerGroupSurfaceFlux, indxSalt, &
+                   config_use_surface_salinity_monthly_restoring, &
+                   config_salinity_restoring_constant_piston_velocity, &
+                   err)
+            call mpas_timer_stop("surface_restoring_"//groupName//" gpu")
+
+         endif ! sfc restoring
+
+         ! tracer fluxes at the land-ice / ocean interface
+         ! this is a flux at the top ocean surface -- so these
+         ! fluxes are added into tracerGroupSurfaceFlux
+!NV!     !!! NOT EXECUTING !!!
+         call ocn_surface_land_ice_fluxes_tracers_gpu(meshPool, groupName, &
+                             forcingPool, tracerGroupSurfaceFlux, err)
+
+         !
+         ! other additions to tracerGroupSurfaceFlux should be added here
+         !
+
+         !
+         ! now begin to accumulate the RHS tracer tendencies.
+         !
+
+         !
+         ! interior restoring forcing tendency
+         !
+         if (config_use_tracerGroup_interior_restoring) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_use_tracerGroup_interior_restoring NOT EXECUTING"
+
+            call mpas_timer_start("interior_restoring_"//groupName,&
+                                  .false.)
+            call mpas_pool_get_subpool(forcingPool, &
+                              'tracersInteriorRestoringFields', &
+                               tracersInteriorRestoringFieldsPool)
+
+            modifiedGroupName = groupName//"InteriorRestoringRate"
+            call mpas_pool_get_array(tracersInteriorRestoringFieldsPool,&
+                                     modifiedGroupName, &
+                                     tracerGroupInteriorRestoringRate)
+
+            modifiedGroupName = groupName//"InteriorRestoringValue"
+            call mpas_pool_get_array(tracersInteriorRestoringFieldsPool,&
+                                     modifiedGroupName, &
+                                     tracerGroupInteriorRestoringValue)
+
+            call ocn_tracer_interior_restoring_compute(nTracersGroup, &
+                        nCellsAll, minLevelCell, maxLevelCell, &
+                        layerThickness, tracerGroup, &
+                        tracerGroupInteriorRestoringRate, &
+                        tracerGroupInteriorRestoringValue, &
+                        tracerGroupTend, err)
+
+            call mpas_timer_stop("interior_restoring_"//groupName)
+
+         endif ! interior restoring
+
+         !
+         ! exponential decay tendency
+         !
+         if (config_use_tracerGroup_exponential_decay) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_use_tracerGroup_exponential_decay NOT EXECUTING"
+
+            call mpas_log_write( &
+                        "WARNING: exponential decay not fully tested", &
+                        MPAS_LOG_WARN)
+            call mpas_timer_start("exponential decay "//groupName)
+            call mpas_pool_get_subpool(forcingPool, &
+                               'tracersExponentialDecayFields', &
+                                tracersExponentialDecayFieldsPool)
+
+            modifiedGroupName = groupName // "ExponentialDecayRate"
+            call mpas_pool_get_array(tracersExponentialDecayFieldsPool,&
+                                     modifiedGroupName, &
+                                     tracerGroupExponentialDecayRate)
+
+            call ocn_tracer_exponential_decay_compute(nTracersGroup, &
+                        nCellsAll, minLevelCell, maxLevelCell, &
+                        layerThickness, tracerGroup, &
+                        tracerGroupExponentialDecayRate, &
+                        tracerGroupTend, err)
+
+            call mpas_timer_stop("exponential decay "//groupName)
+
+         endif ! exponential decay
+
+         !
+         ! ideal age forcing tendency
+         !   note: ocn_tracer_ideal_age_compute resets tracers in top
+         !   layer to zero
+         !
+         if (config_use_tracerGroup_idealAge_forcing) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_use_tracerGroup_idealAge_forcing NOT EXECUTING"
+
+            call mpas_timer_start("ideal age " // groupName)
+            if (trim(groupName) /= 'idealAgeTracers') call mpas_log_write( &
+                                                      "WARNING: ideal age not fully tested", &
+                                                      MPAS_LOG_WARN)
+
+            call mpas_pool_get_subpool(forcingPool, &
+                                       'tracersIdealAgeFields', &
+                                        tracersIdealAgeFieldsPool)
+
+            modifiedGroupName = groupName // "IdealAgeMask"
+            call mpas_pool_get_array_gpu(tracersIdealAgeFieldsPool, &
+                                     modifiedGroupName, &
+                                     tracerGroupIdealAgeMask)
+            call ocn_tracer_ideal_age_compute_gpu(nTracersGroup, nCellsAll,&
+                                      minLevelCell, maxLevelCell, &
+                                      layerThickness, &
+                                      tracerGroupIdealAgeMask, &
+                                      tracerGroup, tracerGroupTend, err)
+
+            call mpas_timer_stop("ideal age " // groupName)
+
+         endif ! ideal age
+
+         !
+         ! transit-time distribution (TTD) forcing tendency
+         !   note: no tendency is actually computed in ocn_tracer_TTD_compute
+         !   note: rather, tracerGroup is reset to tracerGroupTTDMask in
+         !   top-most layer
+         !
+         if (config_use_tracerGroup_ttd_forcing) then
+!NV!        !!! NOT EXECUTING !!!
+            write(*,*) "config_use_tracerGroup_tdd_forcing NOT EXECUTING"
+            call mpas_timer_start("TTD " // groupName)
+            call mpas_log_write("WARNING: TTD not fully tested", &
+                                MPAS_LOG_WARN)
+
+            call mpas_pool_get_subpool(forcingPool, &
+                                       'tracersTTDFields', &
+                                        tracersTTDFieldsPool)
+
+            modifiedGroupName = groupName // "TTDMask"
+            call mpas_pool_get_array(tracersTTDFieldsPool, &
+                                     modifiedGroupName, &
+                                     tracerGroupTTDMask)
+            call ocn_tracer_TTD_compute(nTracersGroup, nCellsAll, &
+                                        maxLevelCell, layerThickness, &
+                                        tracerGroupTTDMask, &
+                                        tracerGroup, err)
+
+            call mpas_timer_stop("TTD " // groupName)
+         endif ! TTD
+
+         !
+         ! Accumulate tendencies for all tracers
+         ! First is the horizontal advection term
+         !     -div( layerThickness \phi u)
+         ! Tracer budget is computed and stored within the tracer adv
+         ! routine
+         call ocn_tracer_advection_tend_gpu(tracerGroup, &
+                            normalThicknessFlux, vertAleTransportTop, &
+                            layerThickness, dt, tracerGroupTend, &
+                            computeBudgets)
+
+         !
+         ! Add horizontal tracer diffusion,
+         !    eg del2 form: div(h \kappa_2 \nabla \phi)
+         !
+
+         if (computeBudgets) then
+            ! compute budget contribution by taking the difference
+            ! of the total tendency before and after the call
+            ! here we store the before value for later subtraction
+            !$omp parallel
+            !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 4 - 2351
+!$acc parallel
+!$acc loop gang vector collapse(3)
+            do iCell = 1, nCellsAll
+            do k=1,nVertLevels
+            do n=1,nTracersGroup
+               activeTracerHorMixTendency(n,k,iCell) = &
+                          tracerGroupTend(n,k,iCell)
+            enddo
+            enddo
+            enddo
+!$acc end parallel
+            !$omp end do
+            !$omp end parallel
+         endif ! compute budgets
+
+         call ocn_tracer_hmix_tend_gpu(meshPool, layerThickEdgeMean, &
+                                   layerThickness, zMid, tracerGroup, &
+                                   RediKappa, slopeTriadUp, &
+                                   slopeTriadDown, dt, isActiveTracer, &
+                                   RediKappaScaling, rediLimiterCount, &
+                                   tracerGroupTend, err)
+
+         if (computeBudgets) then
+            ! Finish budget calculation by subtracting before, after
+            !$omp parallel
+            !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 5 - 2377
+!$acc parallel
+!$acc loop gang vector collapse(3)
+            do iCell = 1, nCellsAll
+            do k=1,nVertLevels
+            do n=1,nTracersGroup
+               activeTracerHorMixTendency(n,k,iCell) = &
+                          tracerGroupTend(n,k,iCell) - &! tendency after
+               activeTracerHorMixTendency(n,k,iCell)    ! tendency before
+            enddo
+            enddo
+            enddo
+!$acc end parallel
+            !$omp end do
+            !$omp end parallel
+         endif ! compute budgets
+
+         !
+         ! convert the surface tracer flux into a tracer tendency by
+         ! distributing the flux across some number of surface layers
+         !
+         if (computeBudgets) then
+            ! as in hmix above, the budget contribution is difference
+            ! between total tend before/after call - store before value
+            !$omp parallel
+            !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 6 - 2402
+!$acc parallel
+!$acc loop gang vector collapse(3)
+            do iCell = 1, nCellsAll
+            do k = 1, nVertLevels
+            do n = 1, nTracersGroup
+               activeTracerSurfaceFluxTendency(n,k,iCell) = &
+                               tracerGroupTend(n,k,iCell)
+            end do
+            end do
+            end do
+!$acc end parallel
+            !$omp end do
+            !$omp end parallel
+         endif ! compute budgets
+
+         call ocn_tracer_surface_flux_tend_gpu(meshPool, fractionAbsorbed, &
+                               fractionAbsorbedRunoff, layerThickness, &
+                               tracerGroupSurfaceFlux, &
+                               tracerGroupSurfaceFluxRunoff,  &
+                               tracerGroupTend, err)
+
+         !
+         ! Compute shortwave absorption
+         !
+         if (computeBudgets) then
+            ! finish previous budget difference and store
+            ! the before value for short wave
+            !$omp parallel
+            !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 7 - 2431
+!$acc parallel
+!$acc loop gang vector collapse(2)
+            do iCell = 1, nCellsAll
+            do k = 1, nVertLevels
+               do n = 1, nTracersGroup
+                  activeTracerSurfaceFluxTendency(n,k,iCell) = &
+                                  tracerGroupTend(n,k,iCell) - &
+                  activeTracerSurfaceFluxTendency(n,k,iCell)
+               end do
+
+               temperatureShortWaveTendency(k,iCell) = &
+                     tracerGroupTend(indxTemp,k,iCell)
+            end do
+            end do
+!$acc end parallel
+            !$omp end do
+            !$omp end parallel
+         endif ! compute budgets
+
+         ! only need sw flux for temperature
+         if (isActiveTracer) then
+            call ocn_tracer_short_wave_absorption_tend_gpu(meshPool, &
+                       swForcingPool, forcingPool, indxTemp, &
+                       layerThickness, penetrativeTemperatureFlux, &
+                       penetrativeTemperatureFluxOBL, tracerGroupTend, &
+                       bottomLayerShortwaveTemperatureFlux, err)
+         endif
+
+         if (computeBudgets) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+!NV! Kernel 8 - 2463
+!$acc parallel
+!$acc loop gang vector collapse(2)
+            do iCell = 1, nCellsAll
+            do k=1,nVertLevels
+               temperatureShortWaveTendency(k,iCell) = &
+                   tracerGroupTend(indxTemp,k,iCell) - &
+               temperatureShortWaveTendency(k,iCell)
+            end do
+            end do
+!$acc end parallel
+            !$omp end do
+            !$omp end parallel
+         endif ! compute budgets
+
+         !
+         ! Compute tracer tendency due to non-local flux computed in KPP
+         !
+         if (config_use_cvmix_kpp) then
+            call mpas_timer_start("non-local flux from KPP gpu")
+            if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
+               call ocn_compute_KPP_input_fields_gpu(statePool, forcingPool,&
+                                                 meshPool, timeLevel)
+
+               if (computeBudgets) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k,n)
+!NV! Kernel 9 - 2489
+!$acc parallel
+!$acc loop gang vector collapse(3)
+                  do iCell = 1, nCellsAll
+                  do k = 1, nVertLevels
+                  do n = 1, nTracersGroup
+                     activeTracerNonLocalTendency(n,k,iCell) = &
+                                  tracerGroupTend(n,k,iCell)
+                  end do
+                  end do
+                  end do
+!$acc end parallel
+                  !$omp end do
+                  !$omp end parallel
+               endif ! compute budgets
+
+               if (isActiveTracer) then
+                  call ocn_tracer_nonlocalflux_tend_gpu(meshPool, &
+                                          vertNonLocalFlux, &
+                                          nonLocalSurfaceTracerFlux, &
+                                          tracerGroupTend, err)
+               else ! not active
+                  call ocn_tracer_nonlocalflux_tend_gpu(meshPool, &
+                                          vertNonLocalFlux, &
+                                          tracerGroupSurfaceFlux, &
+                                          tracerGroupTend, err)
+               endif ! active tracer
+
+               if (computeBudgets) then
+                  !$omp parallel
+                  !$omp do schedule(runtime)
+!NV! Kernel 10 - 2519
+!$acc parallel
+!$acc loop gang vector collapse(3)
+                  do iCell = 1, nCellsAll
+                  do k = 1, nVertLevels
+                  do n = 1, nTracersGroup
+                     activeTracerNonLocalTendency(n,k,iCell) = &
+                                  tracerGroupTend(n,k,iCell) - &
+                     activeTracerNonLocalTendency(n,k,iCell)
+                  end do
+                  end do
+                  end do
+!$acc end parallel
+                  !$omp end do
+                  !$omp end parallel
+               endif ! compute budgets
+            end if ! not non-local with implicit mix
+            call mpas_timer_stop("non-local flux from KPP gpu")
+         end if ! KPP
+
+         ! Compute tracer tendency due to production/destruction of
+         ! frazil ice
+         call ocn_frazil_forcing_tracers_gpu(meshPool, tracersPool, &
+                     groupName, forcingPool, tracerGroupTend, err)
+
+      end if ! config use flag on
+      end if ! active only
+      end if ! member is field
+      end do ! loop over tracer groups
+
+!$acc end data
+
+      deallocate(normalThicknessFlux)
+
+      call mpas_timer_stop("ocn_tend_tracer gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tend_tracer_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_thick_ale.F
+++ b/src/shared/mpas_ocn_thick_ale.F
@@ -45,6 +45,7 @@ module ocn_thick_ale
    !--------------------------------------------------------------------
 
    public :: ocn_ALE_thickness, &
+             ocn_ALE_thickness_gpu, &
              ocn_thick_ale_init
 
    !--------------------------------------------------------------------
@@ -145,12 +146,6 @@ contains
 
       err = 0
 
-      !TEMP: acc directives temporarily disabled here for bit-for-bit
-      !      validation - will enable these on subsequent PR
-      !      must also update host since ssh data on device - this
-      !      will also be removed
-      !$acc update host (ssh)
-
       ! Retrieve or allocate needed variables
 
       call mpas_pool_get_array(verticalMeshPool, 'restingThickness', &
@@ -167,17 +162,9 @@ contains
       ! restingThickness_times_weights
       case (ALEthickProportionThickTimesWgts)
 
-#ifdef MPAS_OPENACC
-         !xacc parallel loop &
-         !xacc    present(ALE_thickness, SSH, restingThickness, &
-         !xacc            minLevelCell, maxLevelCell, &
-         !xacc            vertCoordMovementWeights) &
-         !xacc    private(k, kMin, kMax, thicknessSum)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, kMin, kMax, thicknessSum)
-#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
@@ -199,25 +186,15 @@ contains
                      restingThickness(k,iCell) )/thicknessSum
             end do
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
    
       ! weights_only
       case (ALEthickProportionWgtsOnly)
 
-#ifdef MPAS_OPENACC
-         !xacc parallel loop &
-         !xacc    present(ALE_thickness, restingThickness, ssh, &
-         !xacc            vertCoordMovementWeights, &
-         !xacc            minLevelCell, maxLevelCell) &
-         !xacc    private(k, kMin, kMax, weightSum)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, kMin, kMax, weightSum)
-#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
@@ -240,10 +217,8 @@ contains
                             vertCoordMovementWeights(k)/weightSum
             end do
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case default
          ! Checked on init
@@ -252,15 +227,8 @@ contains
       ! thickness filtering active
       if (present(newHighFreqThickness)) then
 
-#ifdef MPAS_OPENACC
-         !xacc parallel loop &
-         !xacc    present(ALE_thickness, newHighFreqThickness, &
-         !xacc            minLevelCell, maxLevelCell) &
-         !xacc    private(k, kMin, kMax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(k, kMin, kMax)
-#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
@@ -270,10 +238,8 @@ contains
                                       + newHighFreqThickness(k,iCell)
             enddo
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       endif
 
@@ -285,24 +251,12 @@ contains
          allocate(prelim_ALE_thickness  (nVertLevels), &
                   min_ALE_thickness_down(nVertLevels), &
                   min_ALE_thickness_up  (nVertLevels))
-         !xacc enter data create(prelim_ALE_thickness, &
-         !xacc                   min_ALE_thickness_down, &
-         !xacc                   min_ALE_thickness_up)
 
-#ifdef MPAS_OPENACC
-         !xacc parallel loop &
-         !xacc    present(ALE_thickness, restingThickness, &
-         !xacc            minLevelCell, maxLevelCell) &
-         !xacc    private(k, kMin, kMax, remainder, newThickness, &
-         !xacc            prelim_ALE_thickness, &
-         !xacc            min_ALE_thickness_down, min_ALE_thickness_up)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(k, kMin, kMax, remainder, newThickness, &
          !$omp            prelim_ALE_thickness, &
          !$omp            min_ALE_thickness_down, min_ALE_thickness_up)
-#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
@@ -346,29 +300,255 @@ contains
 
             enddo
          enddo
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
-         !xacc exit data delete(prelim_ALE_thickness, &
-         !xacc                  min_ALE_thickness_down, &
-         !xacc                  min_ALE_thickness_up)
          deallocate(prelim_ALE_thickness, &
                     min_ALE_thickness_down, &
                     min_ALE_thickness_up)
 
       endif ! useMinMaxThick
 
-      !xacc exit data delete(restingThickness) 
-
-      !TEMP: move result to device - this will be unnecessary once
-      !      acc directives enabled
-      !$acc update device(ALE_thickness)
-
    !--------------------------------------------------------------------
 
    end subroutine ocn_ALE_thickness!}}}
+
+   subroutine ocn_ALE_thickness_gpu(verticalMeshPool, SSH, ALE_thickness, &
+                                err, newHighFreqThickness)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         verticalMeshPool     !< [in] vertical mesh information
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         SSH                  !< [in] sea surface height
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         newHighFreqThickness !< [in] high freq thickness alters ALE thickness.
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         ALE_thickness            !< [out] desired thickness at new time
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k,    &! loop indices for cells, depth
+         kMax, kMin,  &! indices for min, max active levels
+         nCells        ! number of cells
+
+      real (kind=RKIND) :: &
+         weightSum,    &! sum of weights in vertical
+         thicknessSum, &! total thickness
+         remainder,    &! track remainder in mix/max alteration
+         newThickness   ! temp used during min/max adjustment
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         prelim_ALE_thickness,   & ! ALE thickness at new time
+         min_ALE_thickness_down, & ! thickness alteration in min/max adj
+         min_ALE_thickness_up      ! thickness alteration in min/max adj
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         restingThickness   ! Layer thickness when the ocean is at rest
+                            ! i.e. without SSH or internal perturbations.
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      err = 0
+
+      ! Retrieve or allocate needed variables
+
+      call mpas_pool_get_array_gpu(verticalMeshPool, 'restingThickness', &
+                                                  restingThickness)
+      !xacc enter data copyin(restingThickness) 
+
+      nCells = nCellsHalo(1)
+
+!$acc data present(maxLevelCell,minLevelCell,&
+!$acc              vertCoordMovementWeights,restingThickness,ALE_thickness,SSH)
+
+      !
+      ! ALE thickness alteration due to SSH (z-star)
+      !
+      select case(ALEthickProportionality)
+
+      ! restingThickness_times_weights
+      case (ALEthickProportionThickTimesWgts)
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMin, kMax, thicknessSum)
+!$acc parallel
+!$acc loop gang private(kMax,kMin,thicknessSum)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
+   
+            thicknessSum = 1e-14_RKIND
+!$acc loop seq
+            do k = kMin, kMax
+               thicknessSum = thicknessSum &
+                            + vertCoordMovementWeights(k) &
+                            * restingThickness(k,iCell)
+            end do
+   
+            ! Note that restingThickness is nonzero, and remaining
+            ! terms are perturbations about zero.
+            ! This is equation 4 and 6 in Petersen et al 2015,
+            ! but with eqn 6
+!$acc loop vector
+            do k = kMin, kMax
+               ALE_thickness(k,iCell) = restingThickness(k,iCell) &
+                  + (SSH(iCell)*vertCoordMovementWeights(k)* &
+                     restingThickness(k,iCell) )/thicknessSum
+            end do
+         enddo
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+   
+      ! weights_only
+      case (ALEthickProportionWgtsOnly)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_ALE_thickness_gpu ALEthickProportionWgtsOnly"
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMin, kMax, weightSum)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
+   
+            weightSum = 1e-14_RKIND
+            do k = kMin, kMax
+               weightSum = weightSum + vertCoordMovementWeights(k) 
+            end do
+   
+            do k = kMin, kMax
+               ! Using this, we must require that the
+               ! sum(restingThickness(k, iCell))
+               ! summed over k is equal to bottomDepth.
+               ! This is equation 4 and 6 in Petersen et al 2015,
+               ! but with eqn 6 altered so only the W_k weights
+               ! are used. The resting thickness shown in eqn 6 is
+               ! not included here.
+               ALE_thickness(k,iCell) = restingThickness(k,iCell) &
+                                      + ssh(iCell)* &
+                            vertCoordMovementWeights(k)/weightSum
+            end do
+         enddo
+         !$omp end do
+         !$omp end parallel
+
+      case default
+         ! Checked on init
+      end select ! ALE thickness proportionality
+
+      ! thickness filtering active
+      if (present(newHighFreqThickness)) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kMin, kMax)
+!$acc parallel
+!$acc loop gang private(kMax,kMin)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
+!$acc loop vector
+            do k=kMin,kMax
+               ALE_thickness(k,iCell) = ALE_thickness(k,iCell) &
+                                      + newHighFreqThickness(k,iCell)
+            enddo
+         enddo
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      endif
+
+      !
+      ! ALE thickness alteration due to minimum and maximum thickness
+      !
+      if (useMinMaxThick) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_ALE_thickness_gpu useMinMaxThick"
+
+         allocate(prelim_ALE_thickness  (nVertLevels), &
+                  min_ALE_thickness_down(nVertLevels), &
+                  min_ALE_thickness_up  (nVertLevels))
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMin, kMax, remainder, newThickness, &
+         !$omp            prelim_ALE_thickness, &
+         !$omp            min_ALE_thickness_down, min_ALE_thickness_up)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
+
+            ! go down the column:
+            do k = kMin, kMax
+               prelim_ALE_thickness(k) = ALE_thickness(k,iCell)
+            end do
+
+            remainder = 0.0_RKIND
+            do k = kMin, kMax
+               newThickness = max(minThick, &
+                            min(prelim_ALE_thickness(k) + remainder, &
+                                maxThickFact*restingThickness(k,iCell)))
+               min_ALE_thickness_down(k) = newThickness &
+                                         - prelim_ALE_thickness(k)
+               remainder = remainder - min_ALE_thickness_down(k)
+            end do
+
+            ! go back up the column:
+            min_ALE_thickness_up(kMax) = 0.0_RKIND
+            do k=kMin,kMax
+               prelim_ALE_thickness(k) = prelim_ALE_thickness(k) &
+                                       + min_ALE_thickness_down(k)
+            end do
+            do k = kMax-1, kMin, -1
+               newThickness = max(minThick, &
+                         min(prelim_ALE_thickness(k) + remainder, &
+                             maxThickFact * restingThickness(k,iCell)))
+               min_ALE_thickness_up(k) = newThickness &
+                                       - prelim_ALE_thickness(k)
+               remainder = remainder - min_ALE_thickness_up(k)
+            end do
+            min_ALE_thickness_up(kMin) = min_ALE_thickness_up(kMin) &
+                                       + remainder
+
+            do k=kMin,kMax
+               ALE_thickness(k,iCell) = ALE_thickness(k,iCell) &
+                                      + min_ALE_thickness_down(k) &
+                                      + min_ALE_thickness_up(k)
+
+            enddo
+         enddo
+         !$omp end do
+         !$omp end parallel
+
+         deallocate(prelim_ALE_thickness, &
+                    min_ALE_thickness_down, &
+                    min_ALE_thickness_up)
+
+      endif ! useMinMaxThick
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_ALE_thickness_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_thick_hadv.F
+++ b/src/shared/mpas_ocn_thick_hadv.F
@@ -44,6 +44,7 @@ module ocn_thick_hadv
    !--------------------------------------------------------------------
 
    public :: ocn_thick_hadv_tend, &
+             ocn_thick_hadv_tend_gpu, &
              ocn_thick_hadv_init
 
    !--------------------------------------------------------------------
@@ -126,16 +127,8 @@ contains
 
       call mpas_timer_start("thick hadv")
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc     present(tend, normalVelocity, dvEdge, &
-      !$acc             layerThickEdgeFlux, edgeSignOnCell, &
-      !$acc             minLevelEdgeBot, maxLevelEdgeBot) &
-      !$acc     private(i, k, invAreaCell, flux)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux)
-#endif
       do iCell = 1, nCellsOwned
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)
@@ -146,16 +139,100 @@ contains
           end do
         end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("thick hadv")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_thick_hadv_tend!}}}
+
+   subroutine ocn_thick_hadv_tend_gpu(normalVelocity, layerThickEdgeFlux, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity    !< Input: velocity
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeFlux     !< Input: flux-related thickness at edge
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k, i, iCell
+
+      real (kind=RKIND) :: flux, invAreaCell
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if(.not.thickHadvOn) return
+
+      call mpas_timer_start("thick hadv gpu")
+
+!$acc data present(areaCell,nEdgesOnCell,edgesOnCell,minLevelEdgeBot,maxLevelEdgeTop,dvEdge,edgeSignOnCell,&
+!$acc              normalVelocity,layerThickEdgeFlux,tend)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux)
+!$acc parallel
+!$acc loop gang private(invAreaCell,iEdge)
+      do iCell = 1, nCellsOwned
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+!$acc loop seq
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+!$acc loop vector private(flux)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThickEdgeFlux(k, iEdge)
+            tend(k, iCell) = tend(k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell
+          end do
+        end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("thick hadv gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_thick_hadv_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_thick_surface_flux.F
+++ b/src/shared/mpas_ocn_thick_surface_flux.F
@@ -46,6 +46,7 @@ module ocn_thick_surface_flux
    !--------------------------------------------------------------------
 
    public :: ocn_thick_surface_flux_tend, &
+             ocn_thick_surface_flux_tend_gpu, &
              ocn_thick_surface_flux_init
 
    !--------------------------------------------------------------------
@@ -123,17 +124,8 @@ contains
 
       call mpas_timer_start("thick surface flux")
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(transmissionCoefficients, transmissionCoefficientsRunoff)
-
-      !$acc parallel loop &
-      !$acc     present(tend, surfaceThicknessFlux, surfaceThicknessFluxRunoff, &
-      !$acc     transmissionCoefficients, transmissionCoefficientsRunoff, minLevelCell, maxLevelCell) &
-      !$acc     private(k, remainingFlux, remainingFluxRunoff)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(remainingFlux, remainingFluxRunoff, k)
-#endif
       do iCell = 1, nCellsOwned
         remainingFlux = 1.0_RKIND
         remainingFluxRunoff = 1.0_RKIND
@@ -154,20 +146,104 @@ contains
              + remainingFluxRunoff * surfaceThicknessFluxRunoff(iCell)
         end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(transmissionCoefficients, transmissionCoefficientsRunoff)
-#endif
 
       call mpas_timer_stop("thick surface flux")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_thick_surface_flux_tend!}}}
+
+   subroutine ocn_thick_surface_flux_tend_gpu(transmissionCoefficients, transmissionCoefficientsRunoff, &
+      surfaceThicknessFlux, surfaceThicknessFluxRunoff, tend, err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         transmissionCoefficients,     &!< Input: Coefficients for the transmission of surface fluxes
+         transmissionCoefficientsRunoff !< Input: Coefficients for the transmission of surface fluxes due to river runoff
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         surfaceThicknessFlux,       &!< Input: surface flux of thickness
+         surfaceThicknessFluxRunoff   !< Input: surface flux of thickness due to river runoff
+
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: thickness tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k
+
+      real (kind=RKIND) :: remainingFlux, remainingFluxRunoff
+
+      err = 0
+
+      if (.not. surfaceThicknessFluxOn) return
+
+      call mpas_timer_start("thick surface flux gpu")
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              transmissionCoefficients,transmissionCoefficientsRunoff,surfaceThicknessFlux,surfaceThicknessFluxRunoff,tend)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(remainingFlux, remainingFluxRunoff, k)
+!$acc parallel
+!$acc loop gang vector private(remainingFlux,remainingFluxRunoff)
+      do iCell = 1, nCellsOwned
+        remainingFlux = 1.0_RKIND
+        remainingFluxRunoff = 1.0_RKIND
+!$acc loop seq
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          remainingFlux = remainingFlux - transmissionCoefficients(k, iCell)
+          remainingFluxRunoff = remainingFluxRunoff - transmissionCoefficientsRunoff(k, iCell)
+
+          tend(k, iCell) = tend(k, iCell) + surfaceThicknessFlux(iCell) * transmissionCoefficients(k, iCell)  &
+                                          + surfaceThicknessFluxRunoff(iCell) * transmissionCoefficientsRunoff(k, iCell)
+        end do
+
+        if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+          tend(maxLevelCell(iCell), iCell) = tend(maxLevelCell(iCell), iCell) + remainingFlux * surfaceThicknessFlux(iCell)
+        end if
+
+        if(maxLevelCell(iCell) > 0 .and. remainingFluxRunoff > 0.0_RKIND) then
+          tend(maxLevelCell(iCell), iCell) = tend(maxLevelCell(iCell), iCell) &
+             + remainingFluxRunoff * surfaceThicknessFluxRunoff(iCell)
+        end if
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("thick surface flux gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_thick_surface_flux_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_thick_vadv.F
+++ b/src/shared/mpas_ocn_thick_vadv.F
@@ -44,6 +44,7 @@ module ocn_thick_vadv
    !--------------------------------------------------------------------
 
    public :: ocn_thick_vadv_tend, &
+             ocn_thick_vadv_tend_gpu, &
              ocn_thick_vadv_init
 
    !--------------------------------------------------------------------
@@ -121,29 +122,96 @@ contains
 
       call mpas_timer_start("thick vadv")
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc     present(tend, vertAleTransportTop, minLevelCell, maxLevelCell) &
-      !$acc     private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCellsOwned
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             tend(k,iCell) = tend(k,iCell) + vertAleTransportTop(k+1,iCell) - vertAleTransportTop(k,iCell)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("thick vadv")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_thick_vadv_tend!}}}
+
+   subroutine ocn_thick_vadv_tend_gpu(vertAleTransportTop, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertAleTransportTop     !< Input: vertical velocity on top layer
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if(.not.thickVadvOn) return
+
+      call mpas_timer_start("thick vadv gpu")
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              tend,vertAleTransportTop)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang
+      do iCell = 1, nCellsOwned
+!$acc loop vector
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
+            tend(k,iCell) = tend(k,iCell) + vertAleTransportTop(k+1,iCell) - vertAleTransportTop(k,iCell)
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("thick vadv gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_thick_vadv_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tidal_forcing.F
+++ b/src/shared/mpas_ocn_tidal_forcing.F
@@ -48,6 +48,7 @@ module ocn_tidal_forcing
 
    public :: ocn_tidal_forcing_build_array, &
              ocn_tidal_forcing_layer_thickness, &
+             ocn_tidal_forcing_layer_thickness_gpu, &
              ocn_tidal_forcing_init
 
    !--------------------------------------------------------------------
@@ -120,16 +121,8 @@ contains
       nCells = nCellsHalo( 1 )
 
       ! Build surface fluxes at cell centers
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(tidalLayerThicknessTendency)
-
-      !$acc parallel loop present(layerThicknessTend, maxLevelCell, minLevelCell, &
-      !$acc     tidalLayerThicknessTendency) &
-      !$acc     private(k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCells
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + &
@@ -137,18 +130,76 @@ contains
 
         end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(tidalLayerThicknessTendency)
-#endif
 
       call mpas_timer_stop("tidal thickness tendency")
 
    end subroutine ocn_tidal_forcing_layer_thickness !}}}
+
+   subroutine ocn_tidal_forcing_layer_thickness_gpu(forcingPool, layerThicknessTend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      real (kind=RKIND), intent(inout), dimension(:,:) :: layerThicknessTend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, nCells
+      real (kind=RKIND), dimension(:,:), pointer :: tidalLayerThicknessTendency
+
+      err = 0
+
+      if ( .not. tidalfluxOn ) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_tidal_forcing_layer_thickness_gpu NOT EXECUTING"
+
+      call mpas_timer_start("tidal thickness tendency gpu")
+
+      call mpas_pool_get_array(forcingPool, 'tidalLayerThicknessTendency', &
+                                             tidalLayerThicknessTendency)
+
+      ! frazil fields are needed only over 0 and 1 halos
+      nCells = nCellsHalo( 1 )
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCells
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + &
+                                        tidalLayerThicknessTendency(k,iCell)
+
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("tidal thickness tendency gpu")
+
+   end subroutine ocn_tidal_forcing_layer_thickness_gpu !}}}
 
 
 !***********************************************************************
@@ -220,6 +271,7 @@ contains
       character (len=StrKIND), pointer :: xtime
 
       if ( .not. tidalfluxOn ) return
+      write(*,*) "ocn_tidal_forcing_build_array NOT EXECUTING"
 
       call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)

--- a/src/shared/mpas_ocn_time_average_coupled.F
+++ b/src/shared/mpas_ocn_time_average_coupled.F
@@ -83,11 +83,11 @@ module ocn_time_average_coupled
 
         call mpas_pool_get_dimension(forcingPool, 'nCells', nCells)
 
-        call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
-        call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
-        call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-        call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
-        call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgSSHGradient', avgSSHGradient)
+        call mpas_pool_get_array_gpu(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
 
         !$omp parallel
         !$omp do schedule(runtime)
@@ -99,8 +99,10 @@ module ocn_time_average_coupled
         end do
         !$omp end do
         !$omp end parallel
+!$acc update device(avgSurfaceVelocity,avgTracersSurfaceValue,avgSSHGradient,avgTotalFreshWaterTemperatureFlux)
 
         if(trim(config_land_ice_flux_mode) == 'coupled') then
+           write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
            call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
            call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
            call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
@@ -118,6 +120,7 @@ module ocn_time_average_coupled
 
         !  set up BGC coupling fields if necessary
         if (config_use_ecosysTracers) then
+           write(*,*) "config_use_ecosysTracers NOT EXECUTING"
 
            call mpas_pool_get_subpool(forcingPool, 'ecosysAuxiliary', ecosysAuxiliary)
            call mpas_pool_get_array(ecosysAuxiliary, 'avgCO2_gas_flux', avgCO2_gas_flux)
@@ -155,6 +158,7 @@ module ocn_time_average_coupled
         end if
 
         if (config_use_DMSTracers) then
+           write(*,*) "config_use_DMSTracers NOT EXECUTING"
            call mpas_pool_get_subpool(forcingPool, 'DMSSeaIceCoupling', DMSSeaIceCoupling)
 
            call mpas_pool_get_array(DMSSeaIceCoupling, 'avgOceanSurfaceDMS', avgOceanSurfaceDMS)
@@ -170,6 +174,7 @@ module ocn_time_average_coupled
            !$omp end parallel
         endif
         if (config_use_MacroMoleculesTracers) then
+           write(*,*) "config_use_MacroMoleculesTracers NOT EXECUTING"
            call mpas_pool_get_subpool(forcingPool, 'MacroMoleculesSeaIceCoupling', MacroMoleculesSeaIceCoupling)
 
            call mpas_pool_get_array(MacroMoleculesSeaIceCoupling, 'avgOceanSurfaceDOC', avgOceanSurfaceDOC)
@@ -419,5 +424,246 @@ module ocn_time_average_coupled
         nAccumulatedCoupled = nAccumulatedCoupled + 1
 
     end subroutine ocn_time_average_coupled_accumulate!}}}
+
+    subroutine ocn_time_average_coupled_accumulate_gpu(statePool, forcingPool, timeLevel)!{{{
+        type (mpas_pool_type), intent(in) :: statePool
+        type (mpas_pool_type), intent(inout) :: forcingPool
+        integer, intent(in) :: timeLevel
+
+        real (kind=RKIND), dimension(:,:), pointer :: avgSurfaceVelocity
+        real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue
+        real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
+        integer :: iCell, k
+        integer, pointer :: index_temperaturePtr, index_SSHzonalPtr, &
+                 index_SSHmeridionalPtr, nAccumulatedCoupled, nCells
+        integer :: index_temperature, index_SSHzonal, index_SSHmeridional
+        real (kind=RKIND), dimension(:,:), pointer :: &
+                                                      avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
+        real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
+                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux
+
+        type (mpas_pool_type), pointer :: tracersPool
+
+        real (kind=RKIND), dimension(:,:,:), pointer :: &
+           ecosysTracers,  &
+           DMSTracers,     &
+           MacroMoleculesTracers
+
+        type (mpas_pool_type), pointer :: ecosysSeaIceCoupling, &
+                                          DMSSeaIceCoupling,    &
+                                          MacroMoleculesSeaIceCoupling
+
+        type (mpas_pool_type), pointer :: ecosysAuxiliary
+        real (kind=RKIND), dimension(:), pointer :: CO2_gas_flux, avgCO2_gas_flux
+
+        real (kind=RKIND), dimension(:), pointer :: avgOceanSurfaceDIC, &
+                                                    avgOceanSurfaceDON, &
+                                                    avgOceanSurfaceDOCSemiLabile, &
+                                                    avgOceanSurfaceNO3, &
+                                                    avgOceanSurfaceSiO3, &
+                                                    avgOceanSurfaceNH4, &
+                                                    avgOceanSurfaceDMS, &
+                                                    avgOceanSurfaceDMSP, &
+                                                    avgOceanSurfaceDOCr, &
+                                                    avgOceanSurfaceFeParticulate, &
+                                                    avgOceanSurfaceFeDissolved
+
+        real (kind=RKIND), dimension(:,:), pointer :: avgOceanSurfacePhytoC, &
+                                                      avgOceanSurfaceDOC
+
+        call mpas_pool_get_array_gpu(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgSSHGradient', avgSSHGradient)
+
+        call mpas_pool_get_array_gpu(forcingPool, 'totalFreshWaterTemperatureFlux', totalFreshWaterTemperatureFlux)
+        call mpas_pool_get_array_gpu(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
+
+        call mpas_pool_get_dimension(forcingPool, 'nCells', nCells)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgTemperatureSurfaceValue', &
+                                      index_temperaturePtr)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgSSHGradientZonal', &
+                                      index_SSHzonalPtr)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgSSHGradientMeridional', &
+                                      index_SSHmeridionalPtr)
+        index_temperature   = index_temperaturePtr
+        index_SSHzonal      = index_SSHzonalPtr
+        index_SSHmeridional = index_SSHmeridionalPtr
+
+        call mpas_pool_get_array_gpu(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
+
+!$acc data present(avgTracersSurfaceValue,tracersSurfaceValue,avgSSHGradient,gradSSHZonal,gradSSHMeridional,&
+!$acc               avgSurfaceVelocity,surfaceVelocity,avgTotalFreshWaterTemperatureFlux,totalFreshWaterTemperatureFlux)
+        !$omp parallel
+        !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang
+        do iCell = 1, nCells
+!$acc loop vector
+           do k = 1, size(avgTracersSurfaceValue,1)
+              avgTracersSurfaceValue(k, iCell) = avgTracersSurfaceValue(k, iCell) * nAccumulatedCoupled &
+                                               + tracersSurfaceValue(k, iCell)
+           enddo
+           avgTracersSurfaceValue(index_temperature, iCell) = avgTracersSurfaceValue(index_temperature, iCell) + T0_Kelvin
+!$acc loop vector
+           do k = 1, size(avgTracersSurfaceValue,1)
+              avgTracersSurfaceValue(k, iCell) = avgTracersSurfaceValue(k, iCell) / ( nAccumulatedCoupled + 1 )
+           enddo
+
+           avgSSHGradient(index_SSHzonal, iCell) = ( avgSSHGradient(index_SSHzonal, iCell) * nAccumulatedCoupled &
+                                                 + gradSSHZonal(iCell) ) / ( nAccumulatedCoupled + 1 )
+           avgSSHGradient(index_SSHmeridional, iCell) = ( avgSSHGradient(index_SSHmeridional, iCell) * nAccumulatedCoupled &
+                                                 + gradSSHMeridional(iCell) ) / ( nAccumulatedCoupled + 1 )
+!$acc loop vector
+           do k = 1, size(avgSurfaceVelocity,1)
+              avgSurfaceVelocity(k, iCell) = ( avgSurfaceVelocity(k, iCell) * nAccumulatedCoupled + surfaceVelocity(k, iCell) ) &
+                                           / ( nAccumulatedCoupled + 1 )
+           enddo
+           avgTotalFreshWaterTemperatureFlux(iCell) = ( avgTotalFreshWaterTemperatureFlux(iCell) * nAccumulatedCoupled &
+                                               + totalFreshWaterTemperatureFlux(iCell) ) / ( nAccumulatedCoupled + 1 )
+        end do
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+!$acc end data
+
+        if(trim(config_land_ice_flux_mode) == 'coupled') then
+!NV!       !!! NOT EXECUTING !!!
+           write(*,*) "config_land_ice_flux_mode NOT EXECUTING"
+           call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, timeLevel)
+
+           call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
+           call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceBoundaryLayerTracers(:, iCell) = ( avgLandIceBoundaryLayerTracers(:, iCell) * nAccumulatedCoupled &
+                 + landIceBoundaryLayerTracers(:, iCell) ) / ( nAccumulatedCoupled + 1 )
+              avgLandIceTracerTransferVelocities(:, iCell) = ( avgLandIceTracerTransferVelocities(:, iCell) * nAccumulatedCoupled &
+                 + landIceTracerTransferVelocities(:, iCell) ) / ( nAccumulatedCoupled + 1)
+              avgEffectiveDensityInLandIce(iCell) = ( avgEffectiveDensityInLandIce(iCell) * nAccumulatedCoupled &
+                 + effectiveDensityInLandIce(iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        !  accumulate BGC coupling fields if necessary
+        if (config_use_ecosysTracers) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "config_use_ecosysTracers NOT EXECUTING"
+         call mpas_pool_get_subpool(forcingPool, 'ecosysAuxiliary', ecosysAuxiliary)
+         call mpas_pool_get_array(ecosysAuxiliary, 'CO2_gas_flux', CO2_gas_flux)
+         call mpas_pool_get_array(ecosysAuxiliary, 'avgCO2_gas_flux', avgCO2_gas_flux)
+
+         call mpas_pool_get_subpool(forcingPool, 'ecosysSeaIceCoupling', ecosysSeaIceCoupling)
+
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfacePhytoC', avgOceanSurfacePhytoC)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDIC', avgOceanSurfaceDIC)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSemiLabile', avgOceanSurfaceDOCSemiLabile)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNO3', avgOceanSurfaceNO3)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCr', avgOceanSurfaceDOCr)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
+
+         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+         call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, 1)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+
+           avgCO2_gas_flux(iCell) = ( avgCO2_gas_flux(iCell) * nAccumulatedCoupled &
+              + CO2_gas_flux(iCell) ) / ( nAccumulatedCoupled + 1)
+
+           avgOceanSurfacePhytoC(1,iCell) = ( avgOceanSurfacePhytoC(1,iCell) * nAccumulatedCoupled &
+              + ecosysTracers(diatC_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfacePhytoC(2,iCell) = ( avgOceanSurfacePhytoC(2,iCell) * nAccumulatedCoupled &
+              + ecosysTracers(spC_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+! Currently no Phaeo in MARBL
+!          avgOceanSurfacePhytoC(3,iCell) = ( avgOceanSurfacePhytoC(3,iCell) * nAccumulatedCoupled &
+!             + ecosysTracers(phaeoC_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfacePhytoC(3,iCell) = 0.0_RKIND
+
+           avgOceanSurfaceDIC(iCell) = ( avgOceanSurfaceDIC(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(dic_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceDOCSemiLabile(iCell) = ( avgOceanSurfaceDOCSemiLabile(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(doc_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceSiO3(iCell) = ( avgOceanSurfaceSiO3(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(sio3_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceNO3(iCell) = ( avgOceanSurfaceNO3(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(no3_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceNH4(iCell) = ( avgOceanSurfaceNH4(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(nh4_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceFeDissolved(iCell) = ( avgOceanSurfaceFeDissolved(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(fe_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceDOCr(iCell) = ( avgOceanSurfaceDOCr(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(docr_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+
+           avgOceanSurfaceFeParticulate(iCell) = 0.0_RKIND
+
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        if (config_use_DMSTracers) then
+!NV!       !!! NOT EXECUTING !!!
+           write(*,*) "config_use_DMSTracers NOT EXECUTING"
+           call mpas_pool_get_subpool(forcingPool, 'DMSSeaIceCoupling', DMSSeaIceCoupling)
+
+           call mpas_pool_get_array(DMSSeaIceCoupling, 'avgOceanSurfaceDMS', avgOceanSurfaceDMS)
+           call mpas_pool_get_array(DMSSeaIceCoupling, 'avgOceanSurfaceDMSP', avgOceanSurfaceDMSP)
+
+           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+           call mpas_pool_get_array(tracersPool, 'DMSTracers', DMSTracers, 1)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+           avgOceanSurfaceDMS(iCell) = ( avgOceanSurfaceDMS(iCell) * nAccumulatedCoupled &
+              + DMSTracers(dmsIndices%dms_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceDMSP(iCell) = ( avgOceanSurfaceDMSP(iCell) * nAccumulatedCoupled &
+              + DMSTracers(dmsIndices%dmsp_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+        endif
+
+        if (config_use_MacroMoleculesTracers) then
+!NV!       !!! NOT EXECUTING !!!
+           write(*,*) "config_use_MacroMoleculesTracers NOT EXECUTING"
+           call mpas_pool_get_subpool(forcingPool, 'MacroMoleculesSeaIceCoupling', MacroMoleculesSeaIceCoupling)
+
+           call mpas_pool_get_array(MacroMoleculesSeaIceCoupling, 'avgOceanSurfaceDOC', avgOceanSurfaceDOC)
+           call mpas_pool_get_array(MacroMoleculesSeaIceCoupling, 'avgOceanSurfaceDON', avgOceanSurfaceDON)
+
+           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+           call mpas_pool_get_array(tracersPool, 'MacroMoleculesTracers', MacroMoleculesTracers, 1)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+           avgOceanSurfaceDOC(1,iCell) = ( avgOceanSurfaceDOC(1,iCell) * nAccumulatedCoupled &
+              + MacroMoleculesTracers(macrosIndices%poly_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceDOC(2,iCell) = ( avgOceanSurfaceDOC(2,iCell) * nAccumulatedCoupled &
+              + MacroMoleculesTracers(macrosIndices%lip_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
+!maltrud need to renormalize
+           avgOceanSurfaceDON(iCell) = ( avgOceanSurfaceDON(iCell) * nAccumulatedCoupled &
+              + MacroMoleculesTracers(macrosIndices%prot_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+        endif
+
+        nAccumulatedCoupled = nAccumulatedCoupled + 1
+
+    end subroutine ocn_time_average_coupled_accumulate_gpu!}}}
 
 end module ocn_time_average_coupled

--- a/src/shared/mpas_ocn_tracer_DMS.F
+++ b/src/shared/mpas_ocn_tracer_DMS.F
@@ -471,7 +471,8 @@ contains
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_array(tracersPool, 'DMSTracers', DMSTracers, 1)
+      call mpas_pool_get_array_gpu(tracersPool, 'DMSTracers', DMSTracers, 1)
+!$acc update host(DMSTracers)
 
       ! make sure DMS is turned on
 

--- a/src/shared/mpas_ocn_tracer_advection.F
+++ b/src/shared/mpas_ocn_tracer_advection.F
@@ -39,7 +39,8 @@ module ocn_tracer_advection
 
    ! public module method interfaces
    public :: ocn_tracer_advection_init,         &
-             ocn_tracer_advection_tend
+             ocn_tracer_advection_tend,         &
+             ocn_tracer_advection_tend_gpu
 
    ! privat module variables
    logical :: tracerAdvOff  !< flag to turn off tracer advection
@@ -111,6 +112,55 @@ module ocn_tracer_advection
       call mpas_timer_stop("tracer adv")
 
    end subroutine ocn_tracer_advection_tend!}}}
+
+   subroutine ocn_tracer_advection_tend_gpu(tracers, normalThicknessFlux, &
+                                        w, layerThickness, dt, tend,  &
+                                        computeBudgets)!{{{
+
+      !*** Input/Output parameters
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend            !< [in,out] Tracer tendency to which advection added
+
+      !*** Input parameters
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] Current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux, &!< [in] Thickness weighted horiz velocity
+         w,                   &!< [in] Vertical velocity
+         layerThickness        !< [in] Thickness field
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Time step
+
+      logical, intent(in) :: &
+         computeBudgets      ! flag to compute active tracer budget
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      ! immediate return if tracer advection not selected
+      if (tracerAdvOff) return
+
+      call mpas_timer_start("tracer adv gpu")
+
+      ! call specific advection routine based on choice of monotonicity
+      if (monotonicOn) then
+         call ocn_tracer_advection_mono_tend_gpu(tend, tracers, layerThickness,    &
+                                             normalThicknessFlux, w, dt,       &
+                                             computeBudgets)
+
+      else
+         call ocn_tracer_advection_std_tend_gpu(tracers, normalThicknessFlux, &
+                                            w, layerThickness, dt, tend)
+      endif
+
+      call mpas_timer_stop("tracer adv gpu")
+
+   end subroutine ocn_tracer_advection_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -44,6 +44,7 @@ module ocn_tracer_advection_mono
 
    ! public method interfaces
    public :: ocn_tracer_advection_mono_tend, &
+             ocn_tracer_advection_mono_tend_gpu, &
              ocn_tracer_advection_mono_init
 
 !**********************************************************************
@@ -163,11 +164,6 @@ module ocn_tracer_advection_mono
                lowOrderFlx (nVertLevels+1,max(nCellsAll,nEdgesAll)+1), &
                highOrderFlx(nVertLevels+1,max(nCellsAll,nEdgesAll)+1))
 
-      !$acc enter data create(wgtTmp, flxTmp, sgnTmp, &
-      !$acc                   tracerCur, tracerMin, tracerMax, &
-      !$acc                   hNewInv, hProv, hProvInv, flxIn, flxOut, &
-      !$acc                   workTend, lowOrderFlx, highOrderFlx)
-
 #ifdef _ADV_TIMERS
       call mpas_timer_stop('allocates')
       call mpas_timer_start('prov thickness')
@@ -179,18 +175,9 @@ module ocn_tracer_advection_mono
       ! we dont flip order and horizontal is always first.
       ! See notes in commit 2cd4a89d.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(areaCell, dvEdge, minLevelCell, maxLevelCell, &
-      !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
-      !$acc            layerThickness, normalThicknessFlux, w, &
-      !$acc            hProv, hProvInv, hNewInv) &
-      !$acc    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
-#endif
       do iCell = 1, nCellsAll
          invAreaCell1 = dt/areaCell(iCell)
          kmin = minLevelCell(iCell)
@@ -217,10 +204,8 @@ module ocn_tracer_advection_mono
                                 dt*w(k,iCell) + dt*w(k+1, iCell))
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
       call mpas_timer_stop('prov thickness')
@@ -234,13 +219,8 @@ module ocn_tracer_advection_mono
 #endif
 
         ! Extract current tracer and change index order to improve locality
-#ifdef MPAS_OPENACC
-        !$acc parallel loop collapse(2) &
-        !$acc    present(tracerCur, tracers)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
-#endif
         do iCell = 1, nCellsAll+1
         do k=1, nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
@@ -263,16 +243,9 @@ module ocn_tracer_advection_mono
         ! Determine bounds on tracer (tracerMin and tracerMax) from
         ! surrounding cells for later limiting.
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, nEdgesOnCell, &
-        !$acc            cellsOnCell, tracerCur, tracerMin, tracerMax) &
-        !$acc    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
-#else
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
-#endif
         do iCell = 1, nCells
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
@@ -292,10 +265,8 @@ module ocn_tracer_advection_mono
               end do ! k loop
            end do ! i loop over nEdgesOnCell
         end do ! cell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('tracer bounds')
@@ -306,22 +277,10 @@ module ocn_tracer_advection_mono
 
         ! Compute the high order horizontal flux
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, minLevelEdgeBot, &
-        !$acc            maxLevelEdgeTop, nAdvCellsForEdge, & 
-        !$acc            advCellsForEdge, cellsOnEdge, dvEdge, &
-        !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
-        !$acc            tracerCur, normalThicknessFlux, &
-        !$acc            highOrderFlx, lowOrderFlx) &
-        !$acc    private(i, k, icell, cell1, cell2, coef1, coef3, &
-        !$acc            wgtTmp, sgnTmp, flxTmp, tracerWeight)
-#else
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp    private(i, k, icell, cell1, cell2, coef1, coef3, &
         !$omp            wgtTmp, sgnTmp, flxTmp, tracerWeight)
-#endif
         do iEdge = 1, nEdges
            cell1 = cellsOnEdge(1, iEdge)
            cell2 = cellsOnEdge(2, iEdge)
@@ -372,10 +331,8 @@ module ocn_tracer_advection_mono
                                     -  lowOrderFlx(k,iEdge)
            end do ! k loop
         end do ! iEdge loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('horiz flux')
@@ -384,13 +341,8 @@ module ocn_tracer_advection_mono
 
         ! Initialize flux arrays for all cells
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present (workTend, flxIn, flxOut)
-#else
         !$omp parallel
         !$omp do schedule(runtime)
-#endif
         do iCell = 1, nCellsAll+1
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
@@ -398,32 +350,17 @@ module ocn_tracer_advection_mono
            flxOut  (k, iCell) = 0.0_RKIND
         end do ! k loop
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
         ! Need one halo of cells around owned cells
         nCells = nCellsHalo(1)
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
-        !$acc            minLevelCell, maxLevelCell, areaCell, &
-        !$acc            nEdgesOnCell, edgesOnCell, cellsOnEdge, &
-        !$acc            edgeSignOnCell, layerThickness, hProvInv, &
-        !$acc            tracerCur, tracerMax, tracerMin, workTend, &
-        !$acc            flxOut, flxIn, lowOrderFlx, highOrderFlx) &
-        !$acc    private(i, k, iEdge, cell1, cell2, &
-        !$acc            invAreaCell1, signedFactor, scaleFactor, &
-        !$acc            tracerUpwindNew, tracerMinNew, tracerMaxNew)
-#else
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp    private(i, k, iEdge, cell1, cell2, &
         !$omp            invAreaCell1, signedFactor, scaleFactor, &
         !$omp            tracerUpwindNew, tracerMinNew, tracerMaxNew)
-#endif
         do iCell = 1, nCells
            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -474,10 +411,8 @@ module ocn_tracer_advection_mono
                                 max(0.0_RKIND, scaleFactor))
            end do ! k loop
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
@@ -487,15 +422,8 @@ module ocn_tracer_advection_mono
         nEdges = nEdgesHalo(1)
         !  rescale the high order horizontal fluxes
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
-        !$acc            cellsOnEdge, highOrderFlx, flxIn, flxOut) &
-        !$acc    private(k, cell1, cell2)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k, cell1, cell2)
-#endif
         do iEdge = 1, nEdges
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
@@ -506,10 +434,8 @@ module ocn_tracer_advection_mono
                                       min(flxIn (k,cell1), flxOut(k,cell2))
            end do ! k loop
         end do ! iEdge loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
@@ -518,19 +444,9 @@ module ocn_tracer_advection_mono
 
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
-        !$acc            minLevelCell, maxLevelCell, areaCell, &
-        !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
-        !$acc            workTend, highOrderFlx, layerThickness, &
-        !$acc            tracerCur, hProvInv, tend) &
-        !$acc    private(i, k, iEdge, invAreaCell1, signedFactor) 
-#else
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
-#endif
         do iCell = 1, nCellsOwned
            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -559,10 +475,8 @@ module ocn_tracer_advection_mono
            end do
 
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
@@ -572,15 +486,8 @@ module ocn_tracer_advection_mono
         if (computeBudgets) then
 
            nEdges = nEdgesHalo(2)
-#ifdef MPAS_OPENACC
-           !$acc parallel loop private(k) &
-           !$acc    present(activeTracerHorizontalAdvectionEdgeFlux, &
-           !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-           !$acc            lowOrderFlx, highOrderFlx, dvEdge)
-#else
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-#endif
            do iEdge = 1,nEdges
            do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
@@ -589,27 +496,17 @@ module ocn_tracer_advection_mono
                  (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
            enddo
            enddo
-#ifndef MPAS_OPENACC
            !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-           !$acc parallel loop private(k) &
-           !$acc    present(activeTracerHorizontalAdvectionTendency, &
-           !$acc            minLevelCell, maxLevelCell, workTend)
-#else
            !$omp do schedule(runtime) private(k)
-#endif
            do iCell = 1, nCellsOwned
            do k = minLevelCell(iCell), maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
                                                      workTend(k,iCell)
            end do
            end do ! iCell loop
-#ifndef MPAS_OPENACC
            !$omp end do
            !$omp end parallel
-#endif
 
         end if ! computeBudgets
 
@@ -618,7 +515,6 @@ module ocn_tracer_advection_mono
            ! non-monotone values and write warning if found
 
            ! Perform check on host since print involved
-           !$acc update host(tracerCur, tracerMin, tracerMax)
 
            !$omp parallel
            !$omp do schedule(runtime) private(k)
@@ -658,21 +554,15 @@ module ocn_tracer_advection_mono
 #endif
         ! Initialize variables for use in this iTracer iteration
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop collapse(2) present(workTend)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
-#endif
         do iCell = 1, nCellsAll
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
         end do ! k loop
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('cell init vert')
@@ -683,15 +573,8 @@ module ocn_tracer_advection_mono
         nCells = nCellsHalo(1)
 
         ! Determine bounds on tracerCur from neighbor values for limiting
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(tracerCur, tracerMin, tracerMax, &
-        !$acc            minLevelCell, maxLevelCell) &
-        !$acc    private(k, kmin, kmax)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
         do iCell = 1, nCells
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
@@ -715,10 +598,8 @@ module ocn_tracer_advection_mono
            tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
                                        tracerCur(kmax-1,iCell))
         end do ! cell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('vertical bounds')
@@ -739,16 +620,8 @@ module ocn_tracer_advection_mono
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, w, tracerCur, &
-        !$acc            lowOrderFlx, highOrderFlx, workTend, &
-        !$acc            flxIn, flxOut) &
-        !$acc    private(k, kmin, kmax)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
         do iCell = 1, nCells
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
@@ -777,10 +650,8 @@ module ocn_tracer_advection_mono
                               - max(0.0_RKIND, highOrderFlx(k  ,iCell))
            end do ! k Loop
         end do ! iCell Loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('vertical flux')
@@ -794,19 +665,10 @@ module ocn_tracer_advection_mono
 
         nCells = nCellsHalo(1) ! Need one halo around owned cells
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, hProv, hNewInv, &
-        !$acc            tracerCur, tracerMax, tracerMin, &
-        !$acc            workTend, flxIn, flxOut) &
-        !$acc    private(k, tracerMinNew, tracerMaxNew, &
-        !$acc            tracerUpwindNew, scaleFactor) 
-#else
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp    private(k, tracerMinNew, tracerMaxNew, &
         !$omp            tracerUpwindNew, scaleFactor)
-#endif
         do iCell = 1, nCells
 
            do k = minLevelCell(iCell), maxLevelCell(iCell)
@@ -831,10 +693,8 @@ module ocn_tracer_advection_mono
                                 max(0.0_RKIND, scaleFactor))
            end do ! k loop
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
@@ -844,15 +704,8 @@ module ocn_tracer_advection_mono
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, highOrderFlx, &
-        !$acc            flxIn, flxOut, workTend, tend) &
-        !$acc    private(k, kmin, kmax, flux)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k, kmin, kmax, flux)
-#endif
         do iCell = 1, nCellsOwned
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
@@ -878,10 +731,8 @@ module ocn_tracer_advection_mono
            end do ! k loop
 
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
 
         ! Compute advection diagnostics and monotonicity checks if requested
 #ifdef _ADV_TIMERS
@@ -890,17 +741,8 @@ module ocn_tracer_advection_mono
 #endif
         if (computeBudgets) then
 
-#ifdef MPAS_OPENACC
-           !$acc parallel loop &
-           !$acc    present(lowOrderFlx, highOrderFlx, workTend, &
-           !$acc            activeTracerVerticalAdvectionTopFlux, &
-           !$acc            activeTracerVerticalAdvectionTendency, &
-           !$acc            minLevelCell, maxLevelCell) &
-           !$acc    private(k, kmin, kmax)
-#else
            !$omp parallel
            !$omp do schedule(runtime) private(k,kmin,kmax)
-#endif
            do iCell = 1, nCellsOwned
               kmin = minLevelCell(iCell)
               kmax = maxLevelCell(iCell)
@@ -913,10 +755,8 @@ module ocn_tracer_advection_mono
                     workTend(k,iCell)
               end do
            end do ! iCell loop
-#ifndef MPAS_OPENACC
            !$omp end do
            !$omp end parallel
-#endif
         end if ! computeBudgets
 
         if (monotonicityCheck) then
@@ -924,14 +764,8 @@ module ocn_tracer_advection_mono
            ! Check for monotonicity of new tracer value
            ! Use flxIn as a temp for new tracer value
 
-#ifdef MPAS_OPENACC
-           !$acc parallel loop collapse(2) &
-           !$acc    present(flxIn, tracerCur, hProv, hNewInv, &
-           !$acc            workTend, cellMask)
-#else
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-#endif
            do iCell = 1,nCellsOwned
            do k = 1,nVertLevels
               ! workTend on the RHS is total vertical advection tendency
@@ -940,13 +774,10 @@ module ocn_tracer_advection_mono
                              * hNewInv(k,iCell)*cellMask(k,iCell)
            end do ! vert
            end do ! cell loop
-#ifndef MPAS_OPENACC
            !$omp end do
            !$omp end parallel
-#endif
 
            ! Transfer new tracer values to host for diagnostic check
-           !$acc update host(flxIn)
 
            ! Print out info for cells that are out of bounds
            ! flxIn holds new tracer values
@@ -976,10 +807,6 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif
-      !$acc exit data delete(wgtTmp, flxTmp, sgnTmp, &
-      !$acc                  tracerCur, tracerMin, tracerMax, &
-      !$acc                  hNewInv, hProv, hProvInv, flxIn, flxOut, &
-      !$acc                  workTend, lowOrderFlx, highOrderFlx)
 
       deallocate(wgtTmp,       &
                  flxTmp,       &
@@ -1001,6 +828,876 @@ module ocn_tracer_advection_mono
 #endif
 
    end subroutine ocn_tracer_advection_mono_tend!}}}
+
+   subroutine ocn_tracer_advection_mono_tend_gpu( &
+                                        tend, tracers, layerThickness, &
+                                        normalThicknessFlux, w, dt,    &
+                                        computeBudgets)!{{{
+
+      !-----------------------------------------------------------------
+      ! Input/Output parameters
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend    !< [inout] Tracer tendency to which advection added
+
+      !-----------------------------------------------------------------
+      ! Input parameters
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] Current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness,      &!< [in] Thickness
+         normalThicknessFlux, &!< [in] Thichness weighted velocitiy
+         w                     !< [in] Vertical velocity
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Timestep
+
+      logical, intent(in) :: &
+         computeBudgets        !< [in] Flag to compute active tracer budgets
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         i, iCell, iEdge, &! horz indices
+         cell1, cell2,    &! neighbor cell indices
+         nCells, nEdges,  &! numbers of cells or edges
+         k,kmin, kmax, &! vert index variants
+         kmin1, kmax1,    &! vert index variants
+         iTracer,         &! tracer index
+         numTracers        ! total number of tracers
+
+      real (kind=RKIND) ::  &
+         signedFactor,      &! temp factor including flux sign
+         tracerMinNew,      &! updated tracer minimum
+         tracerMaxNew,      &! updated tracer maximum
+         tracerUpwindNew,   &! tracer updated with upwind flx
+         scaleFactor,       &! factor for normalizing fluxes
+         flux,              &! flux temporary
+         tracerWeight,      &! tracer weighting temporary
+         invAreaCell1,      &! inverse cell area
+         coef1, coef3        ! temporary coefficients
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         wgtTmp,            &! vertical temporaries for
+         flxTmp, sgnTmp      !   high-order flux computation
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerCur,     &! reordered current tracer
+         tracerMax,     &! max tracer in neighbors for limiting
+         tracerMin,     &! min tracer in neighbors for limiting
+         hNewInv,       &! inverse of new layer thickness
+         hProv,         &! provisional layer thickness
+         hProvInv,      &! inverse of provisional layer thickness
+         flxIn,         &! flux coming into each cell
+         flxOut,        &! flux going out of each cell
+         workTend,      &! temp for holding some tendency values
+         lowOrderFlx,   &! low order flux for FCT
+         highOrderFlx    ! high order flux for FCT
+!$acc declare create(tracerCur,tracerMin,tracerMax,hNewInv,hProv,hProvInv,flxIn,flxOut,workTend,lowOrderFlx,highOrderFlx)
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('allocates')
+#endif
+      ! Get dimensions
+      numTracers  = size(tracers,dim=1)
+
+      ! allocate temporary arrays
+      allocate(wgtTmp      (nVertLevels), &
+               flxTmp      (nVertLevels), &
+               sgnTmp      (nVertLevels), &
+               tracerCur   (nVertLevels  ,nCellsAll+1), &
+               tracerMin   (nVertLevels  ,nCellsAll), &
+               tracerMax   (nVertLevels  ,nCellsAll), &
+               hNewInv     (nVertLevels  ,nCellsAll), &
+               hProv       (nVertLevels  ,nCellsAll), &
+               hProvInv    (nVertLevels  ,nCellsAll), &
+               flxIn       (nVertLevels  ,nCellsAll+1), &
+               flxOut      (nVertLevels  ,nCellsAll+1), &
+               workTend    (nVertLevels  ,nCellsAll+1), &
+               lowOrderFlx (nVertLevels+1,max(nCellsAll,nEdgesAll)+1), &
+               highOrderFlx(nVertLevels+1,max(nCellsAll,nEdgesAll)+1))
+
+!$acc data present(areaCell,minLevelCell,maxLevelCell,nEdgesOnCell,edgesOnCell,dvEdge,edgeSignOnCell,&
+!$acc              cellsOnCell,cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,&
+!$acc              tracerCur,tracerMin,tracerMax,hNewInv,hProv,hProvInv,flxIn,flxOut,workTend,lowOrderFlx,highOrderFlx,&
+!$acc              layerThickness,normalThicknessFlux,w,tracers,tend,&
+!$acc              advMaskHighOrder,nAdvCellsForEdge,advCellsForEdge,advCoefs,advCoefs3rd,&
+!$acc              activeTracerHorizontalAdvectionEdgeFlux,activeTracerHorizontalAdvectionTendency,&
+!$acc              activeTracerVerticalAdvectionTopFlux,activeTracerVerticalAdvectionTendency)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('allocates')
+      call mpas_timer_start('prov thickness')
+#endif
+
+      ! Compute some provisional layer thicknesses
+      ! Note: This assumes we are in the first part of the horizontal/
+      ! vertical operator splitting, which is true because currently
+      ! we dont flip order and horizontal is always first.
+      ! See notes in commit 2cd4a89d.
+
+!NV!  Causing differences
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+!NV! Kernel 1 - 956
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,kmin,kmax,iEdge,signedFactor)
+      do iCell = 1, nCellsAll
+         invAreaCell1 = dt/areaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+!$acc loop vector
+         do k = kmin, kmax
+            hProv(k, iCell) = layerThickness(k, iCell)
+         end do
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i,iCell)
+            signedFactor = invAreaCell1*dvEdge(iEdge)* &
+                           edgeSignOnCell(i,iCell)
+            ! Provisional layer thickness is after horizontal
+            ! thickness flux only
+!$acc loop vector
+            do k = kmin, kmax
+               hProv(k,iCell) = hProv(k,iCell) &
+                              + signedFactor*normalThicknessFlux(k,iEdge)
+            end do
+         end do
+         ! New layer thickness is after horizontal and vertical
+         ! thickness flux
+!$acc loop vector
+         do k = kmin, kmax
+            hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+            hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                dt*w(k,iCell) + dt*w(k+1, iCell))
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('prov thickness')
+#endif
+
+      ! Loop over tracers. One tracer is advected at a time.
+      do iTracer = 1, numTracers
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init')
+#endif
+
+        ! Extract current tracer and change index order to improve locality
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+!NV! Kernel 2 - 1006
+!$acc parallel
+!$acc loop gang vector collapse(2)
+        do iCell = 1, nCellsAll+1
+        do k=1, nVertLevels
+           tracerCur(k,iCell) = tracers(iTracer,k,iCell)
+        end do ! k loop
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute the high and low order horizontal fluxes.
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init')
+        call mpas_timer_start('tracer bounds')
+#endif
+
+        ! set nCells to first halo level
+        nCells = nCellsHalo(1)
+
+        ! Determine bounds on tracer (tracerMin and tracerMax) from
+        ! surrounding cells for later limiting.
+
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
+!NV! Kernel 3 - 1032
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,cell2,kmin1,kmax1)
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+!$acc loop vector
+           do k=kmin,kmax
+              tracerMin(k,iCell) = tracerCur(k,iCell)
+              tracerMax(k,iCell) = tracerCur(k,iCell)
+           end do
+!$acc loop seq
+           do i = 1, nEdgesOnCell(iCell)
+              cell2 = cellsOnCell(i,iCell)
+              kmin1 = max(kmin, minLevelCell(cell2))
+              kmax1 = min(kmax, maxLevelCell(cell2))
+!$acc loop vector
+              do k=kmin1,kmax1
+                 tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+                                          tracerCur(k,cell2))
+                 tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+                                          tracerCur(k,cell2))
+              end do ! k loop
+           end do ! i loop over nEdgesOnCell
+        end do ! cell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('tracer bounds')
+        call mpas_timer_start('horiz flux')
+#endif
+        ! Need all the edges around the 1 halo cells and owned cells
+        nEdges = nEdgesHalo(2)
+
+        ! Compute the high order horizontal flux
+
+
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, icell, cell1, cell2, coef1, coef3, &
+        !$omp            wgtTmp, sgnTmp, flxTmp, tracerWeight)
+!NV! Kernel 4 - 1074
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,wgtTmp,sgnTmp,flxTmp,iCell,coef1,coef3)
+        do iEdge = 1, nEdges
+           cell1 = cellsOnEdge(1, iEdge)
+           cell2 = cellsOnEdge(2, iEdge)
+
+           ! compute some common intermediate factors
+!$acc loop vector
+           do k = 1, nVertLevels
+              wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
+                          advMaskHighOrder(k,iEdge)
+              !print*, 'normalThicknessFlux(k,iEdge) ', normalThicknessFlux(k,iEdge)
+              sgnTmp(k) = sign(1.0_RKIND, &
+                               normalThicknessFlux(k,iEdge))
+              flxTmp(k) = 0.0_RKIND
+           end do
+
+           ! Compute 3rd or 4th fluxes where requested.
+!$acc loop seq
+           do i = 1, nAdvCellsForEdge(iEdge)
+              iCell = advCellsForEdge(i,iEdge)
+              coef1 = advCoefs       (i,iEdge)
+              coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
+!$acc loop vector
+              do k = minLevelCell(iCell), maxLevelCell(iCell)
+                 flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
+                             wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
+              end do ! k loop
+           end do ! i loop over nAdvCellsForEdge
+
+!$acc loop vector
+           do k=1,nVertLevels
+              highOrderFlx(k,iEdge) = flxTmp(k)
+           end do
+
+           ! Compute 2nd order fluxes where needed.
+           ! Also compute low order upwind horizontal flux (monotonic)
+           ! Remove low order flux from the high order flux
+           ! Store left over high order flux in highOrderFlx array
+!$acc loop vector private(tracerWeight)
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
+                           * (dvEdge(iEdge) * 0.5_RKIND)             &
+                           * normalThicknessFlux(k, iEdge)
+
+              lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+               (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell1) &
+              + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell2))
+
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iedge) &
+                                    + tracerWeight*(tracerCur(k,cell1) &
+                                                  + tracerCur(k,cell2))
+
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                    -  lowOrderFlx(k,iEdge)
+           end do ! k loop
+        end do ! iEdge loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('horiz flux')
+        call mpas_timer_start('scale factor build')
+#endif
+
+        ! Initialize flux arrays for all cells
+
+        !$omp parallel
+        !$omp do schedule(runtime)
+!NV! Kernel 5 - 1144
+!$acc parallel
+!$acc loop gang vector collapse(2)
+        do iCell = 1, nCellsAll+1
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+           flxIn   (k, iCell) = 0.0_RKIND
+           flxOut  (k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo(1)
+
+!NV!    Causing differences
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, iEdge, cell1, cell2, &
+        !$omp            invAreaCell1, signedFactor, scaleFactor, &
+        !$omp            tracerUpwindNew, tracerMinNew, tracerMaxNew)
+!NV! Kernel 6 - 1166
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,iEdge,cell1,cell2,signedFactor)
+        do iCell = 1, nCells
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+           ! Finish computing the low order horizontal fluxes
+           ! Upwind fluxes are accumulated in workTend
+!$acc loop seq
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
+
+!$acc loop vector
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+
+                 ! Here workTend is the advection tendency due to the
+                 ! upwind (low order) fluxes.
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*lowOrderFlx(k,iEdge)
+
+                 ! Accumulate remaining high order fluxes
+                 flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
+                 flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
+
+              end do
+           end do
+
+           ! Build the factors for the FCT
+           ! Computed using the bounds that were computed previously,
+           ! and the bounds on the newly updated value
+           ! Factors are placed in the flxIn and flxOut arrays
+!$acc loop vector private(tracerUpwindNew,tracerMinNew,tracerMaxNew,scaleFactor)
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! Here workTend is the upwind tendency
+              tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
+                              + dt*workTend(k,iCell))*hProvInv(k,iCell)
+              tracerMinNew = tracerUpwindNew &
+                           + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+              tracerMaxNew = tracerUpwindNew &
+                           + dt*flxIn (k,iCell)*hProvInv(k,iCell)
+
+              scaleFactor = (tracerMax(k,iCell) - tracerUpwindNew)/ &
+                            (tracerMaxNew - tracerUpwindNew + eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+              scaleFactor = (tracerUpwindNew - tracerMin(k,iCell))/ &
+                            (tracerUpwindNew - tracerMinNew + eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('rescale horiz fluxes')
+#endif
+        ! Need all of the edges around owned cells
+        nEdges = nEdgesHalo(1)
+        !  rescale the high order horizontal fluxes
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, cell1, cell2)
+!NV! Kernel 7 - 1235
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2)
+        do iEdge = 1, nEdges
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+!$acc loop vector
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                    + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxIn (k,cell1), flxOut(k,cell2))
+           end do ! k loop
+        end do ! iEdge loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('rescale horiz fluxes')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
+!NV! Kernel 8 - 1262
+!$acc parallel
+!$acc loop gang worker private(invAreaCell1,iEdge,signedFactor)
+        do iCell = 1, nCellsOwned
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+           ! Accumulate the scaled high order horizontal tendencies
+!$acc loop seq
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              signedFactor = invAreaCell1*edgeSignOnCell(i,iCell)
+!$acc loop vector
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                 ! workTend on RHS is upwind tendency
+                 ! workTend on LHS is total horiz advect tendency
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*highOrderFlx(k,iEdge)
+              end do
+           end do
+
+!$acc loop vector
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend  on RHS is total horiz advection tendency
+              ! tracerCur on LHS is provisional tracer after
+              !                     horizontal fluxes only.
+              tracerCur(k,iCell) = (tracerCur(k,iCell)* &
+                                    layerThickness(k,iCell) &
+                                    + dt*workTend(k,iCell)) &
+                                 * hProvInv(k,iCell)
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do
+
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags horiz')
+#endif
+        ! Compute budget and monotonicity diagnostics if needed
+        if (computeBudgets) then
+
+           nEdges = nEdgesHalo(2)
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+!NV! Kernel 9 - 1308
+!$acc parallel
+!$acc loop gang worker
+           do iEdge = 1,nEdges
+!$acc loop vector
+           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+              ! Save u*h*T flux on edge for analysis. This variable will be
+              ! divided by h at the end of the time step.
+              activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                 (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+           enddo
+           enddo
+!$acc end parallel
+           !$omp end do
+
+           !$omp do schedule(runtime) private(k)
+!NV! Kernel 10 - 1323
+!$acc parallel
+!$acc loop gang worker
+           do iCell = 1, nCellsOwned
+!$acc loop vector
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                                                     workTend(k,iCell)
+           end do
+           end do ! iCell loop
+!$acc end parallel
+           !$omp end do
+           !$omp end parallel
+
+        end if ! computeBudgets
+
+        if (monotonicityCheck) then
+!NV!       !!! NOT EXECUTING !!!
+           write(*,*) "ocn_tracer_advection_mono_tend_gpu monotonicityCheck 1 NOT EXECUTING"
+           ! Check tracer values against local min,max to detect
+           ! non-monotone values and write warning if found
+
+           ! Perform check on host since print involved
+
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                    'Horizontal minimum out of bounds on tracer: $i $r $r ', &
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMin(k, iCell), tracerCur(k,iCell) /) )
+              end if
+
+              if(tracerCur(k,iCell) > tracerMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                    'Horizontal maximum out of bounds on tracer: $i $r $r ', &
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMax(k, iCell), tracerCur(k,iCell) /) )
+              end if
+           end do
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags horiz')
+#endif
+
+        !-----------------------------------------------------------------------
+        !
+        !  Horizontal advection complete
+        !  Begin vertical advection
+        !
+        !-----------------------------------------------------------------------
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init vert')
+#endif
+        ! Initialize variables for use in this iTracer iteration
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+!NV! Kernel 11 - 1386
+!$acc parallel
+!$acc loop gang vector collapse(2)
+        do iCell = 1, nCellsAll
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init vert')
+        call mpas_timer_start('vertical bounds')
+#endif
+
+        ! Need all owned and 1 halo cells
+        nCells = nCellsHalo(1)
+
+        ! Determine bounds on tracerCur from neighbor values for limiting
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+!NV! Kernel 12 - 1408
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax)
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           ! take care of top cell
+           tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+           tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+!$acc loop vector
+           do k=kmin+1,kmax-1
+              tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+              tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+           end do
+           ! finish with bottom cell
+           tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
+           tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
+        end do ! cell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical bounds')
+        call mpas_timer_start('vertical flux high')
+#endif
+
+        ! Compute the high order vertical fluxes based on order selected.
+        call ocn_tracer_advection_vert_flx_gpu(tracerCur, w, hProv, &
+                                           highOrderFlx)
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux high')
+        call mpas_timer_start('vertical flux')
+#endif
+
+        ! Compute low order upwind vertical flux (monotonic)
+        ! Remove low order flux from the high order flux.
+        ! Store left over high order flux in highOrderFlx array.
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+!NV! Kernel 13 - 1457
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax)
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           lowOrderFlx(kmin,iCell) = 0.0_RKIND
+!$acc loop vector
+           do k = kmin+1, kmax
+              lowOrderFlx(k,iCell) = &
+                    min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
+                    max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
+              highOrderFlx(k,iCell) = highOrderFlx(k,iCell) &
+                                    -  lowOrderFlx(k,iCell)
+           end do ! k loop
+           lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+
+           ! Upwind fluxes are accumulated in workTend
+           ! flxIn  contains total remaining high order flux into iCell
+           !          it is positive.
+           ! flxOut contains total remaining high order flux out of iCell
+           !          it is negative
+!$acc loop vector
+           do k = kmin,kmax
+              workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                                - lowOrderFlx(k  ,iCell)
+              flxIn (k,iCell) = max(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - min(0.0_RKIND, highOrderFlx(k  ,iCell))
+              flxOut(k,iCell) = min(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - max(0.0_RKIND, highOrderFlx(k  ,iCell))
+           end do ! k Loop
+        end do ! iCell Loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux')
+        call mpas_timer_start('scale factor build')
+#endif
+
+        ! Build the scale factors to limit flux for FCT
+        ! Computed using the bounds that were computed previously,
+        ! and the bounds on the newly updated value
+        ! Factors are placed in the flxIn and flxOut arrays
+
+        nCells = nCellsHalo(1) ! Need one halo around owned cells
+
+!NV!     Causing differences
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(k, tracerMinNew, tracerMaxNew, &
+        !$omp            tracerUpwindNew, scaleFactor)
+!NV! Kernel 14 - 1510
+!$acc parallel
+!$acc loop gang worker 
+        do iCell = 1, nCells
+!$acc loop vector private(tracerMinNew,tracerMaxNew,tracerUpwindNew,scaleFactor)
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend on the RHS is the upwind tendency
+              tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                              + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+
+              scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
+                            (tracerMaxNew-tracerUpwindNew+eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+
+              scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
+                            (tracerUpwindNew-tracerMinNew+eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax, flux)
+!NV! Kernel 15 - 1550
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax)
+        do iCell = 1, nCellsOwned
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+           ! rescale the high order vertical flux
+!$acc loop vector private(flux)
+           do k = kmin+1, kmax
+              flux =  highOrderFlx(k,iCell)
+              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                      min(flxOut(k  ,iCell), &
+                                          flxIn (k-1,iCell)) &
+                                    + min(0.0_RKIND,flux)*   &
+                                      min(flxOut(k-1,iCell), &
+                                          flxIn (k  ,iCell))
+           end do ! k loop
+!$acc loop vector
+           do k = kmin,kmax
+              ! workTend on the RHS is upwind tendency
+              ! workTend on the LHS is total vertical advection tendency
+              workTend(k, iCell) = workTend(k, iCell)       &
+                                 + (highOrderFlx(k+1,iCell) &
+                                  - highOrderFlx(k  ,iCell))
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do ! k loop
+
+        end do ! iCell loop
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute advection diagnostics and monotonicity checks if requested
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags vert')
+#endif
+        if (computeBudgets) then
+           !$omp parallel
+           !$omp do schedule(runtime) private(k,kmin,kmax)
+!NV! Kernel 16 - 1590
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax)
+           do iCell = 1, nCellsOwned
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+!$acc loop vector
+              do k = kmin+1,kmax
+                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
+                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
+              end do
+!$acc loop vector
+              do k = kmin,kmax
+                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                    workTend(k,iCell)
+              end do
+           end do ! iCell loop
+!$acc end parallel
+           !$omp end do
+           !$omp end parallel
+        end if ! computeBudgets
+
+        if (monotonicityCheck) then
+!NV!       !!! NOT EXECUTING !!!
+           write(*,*) "ocn_tracer_advection_mono_tend_gpu monotonicityCheck 2 NOT EXECUTING"
+           ! Check for monotonicity of new tracer value
+           ! Use flxIn as a temp for new tracer value
+
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1,nCellsOwned
+           do k = 1,nVertLevels
+              ! workTend on the RHS is total vertical advection tendency
+              flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
+                             + dt*workTend(k, iCell)) &
+                             * hNewInv(k,iCell)*cellMask(k,iCell)
+           end do ! vert
+           end do ! cell loop
+           !$omp end do
+           !$omp end parallel
+
+           ! Transfer new tracer values to host for diagnostic check
+
+           ! Print out info for cells that are out of bounds
+           ! flxIn holds new tracer values
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                   'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
+                   MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                   realArgs=(/ tracerMin(k,iCell), flxIn(k,iCell) /) )
+              end if
+              if (flxIn(k,iCell) > tracerMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                   'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
+                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                    realArgs=(/ tracerMax(k,iCell), flxIn(k,iCell) /) )
+              end if
+           end do
+           end do
+
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags vert')
+#endif
+      end do ! iTracer loop
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('deallocates')
+#endif
+
+!$acc end data
+
+!!!$acc update host(tend)
+
+      deallocate(wgtTmp,       &
+                 flxTmp,       &
+                 sgnTmp,       &
+                 tracerCur,    &
+                 tracerMin,    &
+                 tracerMax,    &
+                 hNewInv,      &
+                 hProv,        &
+                 hProvInv,     &
+                 flxIn,        &
+                 flxOut,       &
+                 workTend,     &
+                 lowOrderFlx,  &
+                 highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('deallocates')
+#endif
+
+   end subroutine ocn_tracer_advection_mono_tend_gpu!}}}
 
 !**********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -51,6 +51,7 @@ module ocn_tracer_advection_shared
       advCoefs,       &! common advection coefficients
       advCoefs3rd,    &! common advection coeffs for high order
       advMaskHighOrder ! mask for high order advection terms
+!$acc declare create(nAdvCellsForEdge,advCellsForEdge,advCoefs,advCoefs3rd,advMaskHighOrder)
 
    !--------------------------------------------------------------------
    ! Public member functions 
@@ -310,10 +311,7 @@ module ocn_tracer_advection_shared
       if (config_horiz_tracer_adv_order == 2) &
          advMaskHighOrder(:,:) = 0.0_RKIND
 
-      ! Copy module variables to device
-      !$acc enter data copyin(nAdvCellsForEdge, advCellsForEdge, &
-      !$acc                   advCoefs, advCoefs3rd, advMaskHighOrder)
-
+!$acc update device(nAdvCellsForEdge,advCellsForEdge,advCoefs,advCoefs3rd,advMaskHighOrder)
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_advection_shared_init !}}}

--- a/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/shared/mpas_ocn_tracer_advection_std.F
@@ -39,6 +39,7 @@ module ocn_tracer_advection_std
 
    ! public method interfaces
    public :: ocn_tracer_advection_std_tend, &
+             ocn_tracer_advection_std_tend_gpu, &
              ocn_tracer_advection_std_init
 
 !***********************************************************************
@@ -120,44 +121,27 @@ module ocn_tracer_advection_std
                highOrderFlxHorz(nVertLevels  , nEdgesAll), &
                highOrderFlxVert(nVertLevels+1, nCellsAll))
 
-      !$acc enter data &
-      !$acc    create(tracerCur, highOrderFlxHorz, highOrderFlxVert)
-
       ! Loop over tracers. One tracer is advected at a time. It is
       ! copied into a temporary array in order to improve locality
       do iTracer = 1, numTracers
 
         ! Initialize variables for use in this iTracer iteration
-#ifdef MPAS_OPENACC
-        !$acc parallel loop collapse(2) &
-        !$acc    present(tracerCur, tracers)
-#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
-#endif
         do iCell = 1, nCellsAll
         do k=1,nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do
         end do
-#ifndef MPAS_OPENACC
         !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop collapse(2) &
-        !$acc    present(highOrderFlxHorz)
-#else
         !$omp do schedule(runtime) private(k)
-#endif
         do iEdge = 1, nEdgesAll
         do k=1,nVertLevels
            highOrderFlxHorz(k, iEdge) = 0.0_RKIND
         end do
         end do
-#ifndef MPAS_OPENACC
         !$omp end do
-#endif
 
         ! Compute the high order vertical flux.
 
@@ -165,20 +149,8 @@ module ocn_tracer_advection_std
                            layerThickness, highOrderFlxVert)
 
         ! Compute the high order horizontal flux
-
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
-        !$acc            minLevelCell, maxLevelCell, cellsOnEdge, &
-        !$acc            nAdvCellsForEdge, advCellsForEdge, dvEdge, &
-        !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
-        !$acc            normalThicknessFlux, highOrderFlxHorz, &
-        !$acc            tracerCur) &
-        !$acc    private(i,iCell,cell1,cell2, k, kmin, kmax, tracerWgt) 
-#else
         !$omp do schedule(runtime) &
         !$omp    private(i,iCell,cell1,cell2, k, kmin, kmax, tracerWgt) 
-#endif
         do iEdge = 1, nEdgesAll
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
@@ -214,21 +186,11 @@ module ocn_tracer_advection_std
             end do ! k loop
           end do ! i loop over nAdvCellsForEdge
         end do ! iEdge loop
-#ifndef MPAS_OPENACC
         !$omp end do
-#endif
 
         ! Accumulate the scaled high order horizontal tendencies
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
-        !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
-        !$acc            areaCell, tend, highOrderFlxHorz) &
-        !$acc    private(i, iEdge, k, kmin, kmax, invAreaCell1)
-#else
         !$omp do schedule(runtime) &
         !$omp    private(i, iEdge, k, kmin, kmax, invAreaCell1)
-#endif
         do iCell = 1, nCellsAll
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
           do i = 1, nEdgesOnCell(iCell)
@@ -244,21 +206,12 @@ module ocn_tracer_advection_std
             end do
           end do
         end do
-#ifndef MPAS_OPENACC
         !$omp end do
-#endif
 
         ! Accumulate the scaled high order vertical tendencies.
         vertDivFactor = 1.0_RKIND
 
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, tend, &
-        !$acc            highOrderFlxVert) &
-        !$acc    private(k, kmin, kmax)
-#else
         !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
         do iCell = 1, nCellsOwned
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
@@ -269,18 +222,185 @@ module ocn_tracer_advection_std
                                       - highOrderFlxVert(k, iCell))
            end do ! k loop
         end do ! iCell loop
-#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#endif
       end do ! iTracer loop
-
-      !$acc exit data &
-      !$acc    delete(tracerCur, highOrderFlxHorz, highOrderFlxVert)
 
       deallocate(tracerCur, highOrderFlxHorz, highOrderFlxVert)
 
    end subroutine ocn_tracer_advection_std_tend!}}}
+
+   subroutine ocn_tracer_advection_std_tend_gpu(tracers, normalThicknessFlux, &
+                                            w, layerThickness, dt, tend)
+
+      !-----------------------------------------------------------------
+      ! Input/Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend            !< [inout] Accumulated tracer tendency
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux, &!< [in] Thickness weighted velocitiy
+         w,                   &!< [in] Vertical velocity
+         layerThickness        !< [in] Thickness
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Timestep
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, k,         &! loop indices for neighbors, vertical
+         kmin, kmax,   &! min, max active vertical layers
+         iCell, iEdge, &! loop indices for cells, edges
+         iTracer,      &! tracer index
+         cell1, cell2, &! neighbor cell indices across edge
+         numTracers
+
+      real (kind=RKIND) :: &
+         tracerWgt,        &! local temporary
+         invAreaCell1,     &! inverse cell area
+         vertDivFactor      ! vertical divergence factor
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerCur,        &! reordered tracer at current time
+         highOrderFlxHorz, &! high-order flux in horizontal
+         highOrderFlxVert   ! high-order flux in vertical
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small value to avoid div by zero
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Get dimensions
+      numTracers = size(tracers,dim=1)
+
+      ! Allocate some arrays
+      allocate(tracerCur       (nVertLevels  , nCellsAll), &
+               highOrderFlxHorz(nVertLevels  , nEdgesAll), &
+               highOrderFlxVert(nVertLevels+1, nCellsAll))
+
+      write(*,*) "ocn_tracer_advection_std_tend_gpu NOT EXECUTING"
+      ! Loop over tracers. One tracer is advected at a time. It is
+      ! copied into a temporary array in order to improve locality
+      do iTracer = 1, numTracers
+
+        ! Initialize variables for use in this iTracer iteration
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1, nCellsAll
+        do k=1,nVertLevels
+           tracerCur(k,iCell) = tracers(iTracer,k,iCell)
+        end do
+        end do
+        !$omp end do
+
+        !$omp do schedule(runtime) private(k)
+        do iEdge = 1, nEdgesAll
+        do k=1,nVertLevels
+           highOrderFlxHorz(k, iEdge) = 0.0_RKIND
+        end do
+        end do
+        !$omp end do
+
+        ! Compute the high order vertical flux.
+
+        call ocn_tracer_advection_vert_flx_gpu(tracerCur, w, &
+                           layerThickness, highOrderFlxVert)
+
+        ! Compute the high order horizontal flux
+        !$omp do schedule(runtime) &
+        !$omp    private(i,iCell,cell1,cell2, k, kmin, kmax, tracerWgt) 
+        do iEdge = 1, nEdgesAll
+          cell1 = cellsOnEdge(1, iEdge)
+          cell2 = cellsOnEdge(2, iEdge)
+          kmin = minLevelEdgeBot(iEdge)
+          kmax = maxLevelEdgeTop(iEdge)
+
+          ! Compute 2nd order fluxes where needed.
+          do k = kmin, kmax
+            tracerWgt = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
+                      * (dvEdge(iEdge) * 0.5_RKIND) &
+                      * normalThicknessFlux(k, iEdge)
+
+            highOrderFlxHorz(k, iEdge) = highOrderFlxHorz(k, iedge) &
+                                       + tracerWgt*(tracerCur(k,cell1) &
+                                                  + tracerCur(k,cell2))
+          end do ! k loop
+
+          ! Compute 3rd or 4th fluxes where requested.
+          do i = 1, nAdvCellsForEdge(iEdge)
+            iCell = advCellsForEdge(i,iEdge)
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+
+            do k = kmin,kmax
+              tracerWgt = advMaskHighOrder(k,iEdge) &
+                        * (advCoefs(i,iEdge) + coef3rdOrder &
+                        * sign(1.0_RKIND,normalThicknessFlux(k,iEdge)) &
+                        * advCoefs3rd(i,iEdge))
+
+              tracerWgt = normalThicknessFlux(k,iEdge)*tracerWgt
+              highOrderFlxHorz(k,iEdge) = highOrderFlxHorz(k,iEdge) &
+                                        + tracerWgt*tracerCur(k,iCell)
+            end do ! k loop
+          end do ! i loop over nAdvCellsForEdge
+        end do ! iEdge loop
+        !$omp end do
+
+        ! Accumulate the scaled high order horizontal tendencies
+        !$omp do schedule(runtime) &
+        !$omp    private(i, iEdge, k, kmin, kmax, invAreaCell1)
+        do iCell = 1, nCellsAll
+          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+          do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+
+            do k = kmin,kmax
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) &
+                                      + edgeSignOnCell(i, iCell) &
+                                      * highOrderFlxHorz(k, iEdge) &
+                                      * invAreaCell1
+            end do
+          end do
+        end do
+        !$omp end do
+
+        ! Accumulate the scaled high order vertical tendencies.
+        vertDivFactor = 1.0_RKIND
+
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+        do iCell = 1, nCellsOwned
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           do k = kmin,kmax
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + &
+                         vertDivFactor*(highOrderFlxVert(k+1, iCell) &
+                                      - highOrderFlxVert(k, iCell))
+           end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+      end do ! iTracer loop
+
+      deallocate(tracerCur, highOrderFlxHorz, highOrderFlxVert)
+
+   end subroutine ocn_tracer_advection_std_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_advection_vert.F
+++ b/src/shared/mpas_ocn_tracer_advection_vert.F
@@ -44,6 +44,7 @@ module ocn_tracer_advection_vert
 
    ! public method interfaces
    public :: ocn_tracer_advection_vert_flx, &
+             ocn_tracer_advection_vert_flx_gpu, &
              ocn_tracer_advection_vert_init
 
 !***********************************************************************
@@ -105,20 +106,14 @@ module ocn_tracer_advection_vert
       ! Initialize return flux to zero
       ! Also ensures that top and bottom fluxes are zero
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) present(vertFlx)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCellsAll
       do k=1,nVertLevels+1
          vertFlx(k,iCell) = 0.0_RKIND
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! Compute flux for interior layers at high order based on
       ! user-requested order
@@ -126,15 +121,8 @@ module ocn_tracer_advection_vert
       select case (vertOrder)
       case (vertOrder4)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(minLevelCell, maxLevelCell, w, &
-         !$acc            vertFlx, tracer) &
-         !$acc    private(k, kmin, kmax)
-#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax)
-#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -147,21 +135,12 @@ module ocn_tracer_advection_vert
                                                 12.0_RKIND
             end do ! vertical loop
          end do ! iCell Loop
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
 
       case (vertOrder3)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(minLevelCell, maxLevelCell, w, &
-         !$acc            vertFlx, tracer) &
-         !$acc    private(k, kmin, kmax)
-#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax)
-#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -179,23 +158,13 @@ module ocn_tracer_advection_vert
                                                  12.0_RKIND
             end do ! vertical loop
          end do ! iCell Loop
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
 
       case (vertOrder2)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(minLevelCell, maxLevelCell, w, &
-         !$acc            layerThick, vertFlx, tracer) &
-         !$acc    private(k, kmin, kmax, &
-         !$acc            verticalWeightK, verticalWeightKm1)
-#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax, &
          !$omp            verticalWeightK, verticalWeightKm1)
-#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -211,9 +180,7 @@ module ocn_tracer_advection_vert
                             verticalWeightKm1*tracer(k-1,iCell))
             end do ! vertical loop
          end do ! iCell Loop
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
 
       end select ! vertOrder
 
@@ -221,17 +188,9 @@ module ocn_tracer_advection_vert
       ! layers near the top and bottom where high-order forms
       ! can not be computed.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(minLevelCell, maxLevelCell, w, &
-      !$acc            layerThick, vertFlx, tracer) &
-      !$acc    private(k, kmin, kmax, &
-      !$acc            verticalWeightK, verticalWeightKm1)
-#else
       !$omp do schedule(runtime) &
       !$omp    private(k, kmin, kmax, &
       !$omp            verticalWeightK, verticalWeightKm1)
-#endif
       do iCell = 1, nCellsAll
          kmin = minLevelCell(iCell)
          kmax = maxLevelCell(iCell)
@@ -262,14 +221,199 @@ module ocn_tracer_advection_vert
                            verticalWeightKm1*tracer(k-1,iCell))
          end if ! kmax > kmin
       end do ! iCell Loop
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_advection_vert_flx !}}}
+
+   subroutine ocn_tracer_advection_vert_flx_gpu(tracer, w, layerThick, &
+                                            vertFlx)
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertFlx         !< [out] high-order vertical advection flux
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracer          !< [in] current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w,             &!< [in] Vertical velocity
+         layerThick      !< [in] Layer thickness to use for advection
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell,            &! cell address
+         k, kmin, kmax      ! current, min, max vertical layer indices
+
+      real (kind=RKIND) :: &
+         verticalWeightK,  &! weights for vertical advection
+         verticalWeightKm1  ! weights for vertical advection
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Compute the high order vertical flux.
+
+      ! Initialize return flux to zero
+      ! Also ensures that top and bottom fluxes are zero
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              vertFlx,tracer,w,layerThick)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iCell = 1, nCellsAll
+      do k=1,nVertLevels+1
+         vertFlx(k,iCell) = 0.0_RKIND
+      end do
+      end do
+!$acc end parallel
+      !$omp end do
+
+      ! Compute flux for interior layers at high order based on
+      ! user-requested order
+
+      select case (vertOrder)
+      case (vertOrder4)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax)
+!$acc parallel
+!$acc loop gang private(kmin,kmax)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+!$acc loop vector
+            do k=kmin+2,kmax-1
+               vertFlx(k, iCell) = w(k,iCell)* &
+                                   ( 7.0_RKIND*(tracer(k  ,iCell)+ &
+                                                tracer(k-1,iCell)) &
+                                             - (tracer(k+1,iCell)+ &
+                                                tracer(k-2,iCell)))/&
+                                                12.0_RKIND
+            end do ! vertical loop
+         end do ! iCell Loop
+!$acc end parallel
+         !$omp end do
+
+      case (vertOrder3)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax)
+!$acc parallel
+!$acc loop gang private(kmin,kmax)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+!$acc loop vector
+            do k=kmin+2,kmax-1
+               vertFlx(k, iCell) = (w(k,iCell)* &
+                                   (7.0_RKIND * (tracer(k  ,iCell)+ &
+                                                 tracer(k-1,iCell)) - &
+                                                (tracer(k+1,iCell)+ &
+                                                 tracer(k-2,iCell))) - &
+                                coef3rdOrder*abs(w(k,iCell))* &
+                                               ((tracer(k+1,iCell)- &
+                                                 tracer(k-2,iCell)) - &
+                                      3.0_RKIND*(tracer(k  ,iCell)- &
+                                                 tracer(k-1,iCell))))/ &
+                                                 12.0_RKIND
+            end do ! vertical loop
+         end do ! iCell Loop
+!$acc end parallel
+         !$omp end do
+
+      case (vertOrder2)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax, &
+         !$omp            verticalWeightK, verticalWeightKm1)
+!$acc parallel
+!$acc loop gang private(kmin,kmax)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+!$acc loop vector private(verticalWeightK,verticalWeightKm1)
+            do k=kmin+2,kmax-1
+               verticalWeightK   = layerThick(k-1,iCell) / &
+                                  (layerThick(k  ,iCell) + &
+                                   layerThick(k-1,iCell))
+               verticalWeightKm1 = layerThick(k  ,iCell) / &
+                                  (layerThick(k  ,iCell) + &
+                                   layerThick(k-1,iCell))
+               vertFlx(k,iCell) = w(k, iCell) * &
+                           (verticalWeightK  *tracer(k  ,iCell) + &
+                            verticalWeightKm1*tracer(k-1,iCell))
+            end do ! vertical loop
+         end do ! iCell Loop
+!$acc end parallel
+         !$omp end do
+
+      end select ! vertOrder
+
+      ! Now take care of the edge cases, reducing order for
+      ! layers near the top and bottom where high-order forms
+      ! can not be computed.
+
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kmin, kmax, &
+      !$omp            verticalWeightK, verticalWeightKm1)
+!$acc parallel
+!$acc loop gang vector private(kmin,kmax,k)
+      do iCell = 1, nCellsAll
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         ! at top, flux is zero (already initialized)
+         ! at next-to-top (kmin+1), reduce to 2nd order
+         !   but avoid case where 0 or 1 active layer (kmax <= kmin)
+         if (kmax > kmin) then
+            k = kmin+1
+            verticalWeightK   = layerThick(k-1,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            verticalWeightKm1 = layerThick(k  ,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            vertFlx(k,iCell) = w(k,iCell)&
+                          *(verticalWeightK  *tracer(k  ,iCell) + &
+                            verticalWeightKm1*tracer(k-1,iCell))
+            ! Deepest active level also at 2nd order
+            k = kmax
+            verticalWeightK   = layerThick(k-1,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            verticalWeightKm1 = layerThick(k  ,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            vertFlx(k,iCell) = w(k,iCell)* &
+                          (verticalWeightK  *tracer(k  ,iCell) + &
+                           verticalWeightKm1*tracer(k-1,iCell))
+         end if ! kmax > kmin
+      end do ! iCell Loop
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_advection_vert_flx_gpu !}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_hmix.F
+++ b/src/shared/mpas_ocn_tracer_hmix.F
@@ -48,6 +48,7 @@ module ocn_tracer_hmix
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_hmix_tend, &
+             ocn_tracer_hmix_tend_gpu, &
              ocn_tracer_hmix_init
 
    !--------------------------------------------------------------------
@@ -162,6 +163,91 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_hmix_tend!}}}
+
+   subroutine ocn_tracer_hmix_tend_gpu(meshPool, layerThickEdgeMean, layerThickness, zMid, tracers, &
+                                   RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
+                                   RediKappaScaling, rediLimiterCount, tend, err)!{{{
+
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+
+      real (kind=RKIND), dimension(:), intent(in), optional :: &
+         RediKappa
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeMean, &!< Input: mean thickness at edge
+         layerThickness,     &!< Input: thickness at centers
+         zMid                 !< Input: Z coordinate at the center of a cell
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         RediKappaScaling        !< Input: vertical structure of GM/Redi limiter
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        slopeTriadUp, slopeTriadDown, &
+        tracers !< Input: tracer quantities
+
+      real (kind=RKIND), intent(in) :: dt
+
+      integer, dimension(:,:), intent(inout), optional :: rediLimiterCount
+
+      logical,intent(in) :: isActiveTracer
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: err1, err2
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      if(.not.tracerHmixOn) return
+
+      call mpas_timer_start("tracer hmix gpu")
+
+      call ocn_tracer_hmix_del2_tend_gpu(meshPool, layerThickEdgeMean, tracers, tend, err1)
+      call ocn_tracer_hmix_del4_tend_gpu(meshPool, layerThickEdgeMean, tracers, tend, err2)
+      if (config_use_Redi) then
+!NV!    !!! EXECUTING !!!
+        call ocn_tracer_hmix_Redi_tend_gpu(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
+                                     RediKappa, dt, isActiveTracer,        &
+                                     slopeTriadUp, slopeTriadDown, &
+                                     RediKappaScaling, rediLimiterCount, tend, err1)
+      endif
+      err = ior(err1, err2)
+      call mpas_timer_stop("tracer hmix gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -49,6 +49,7 @@ module ocn_tracer_hmix_del2
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_hmix_del2_tend, &
+             ocn_tracer_hmix_del2_tend_gpu, &
              ocn_tracer_hmix_del2_init
 
    !--------------------------------------------------------------------
@@ -189,6 +190,121 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_hmix_del2_tend!}}}
+
+   subroutine ocn_tracer_hmix_del2_tend_gpu(meshPool, layerThickEdgeMean, tracers, tend, err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeMean !< Input: mean thickness at edges
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        tracers !< Input: tracer quantities
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: i, k, iTracer, num_tracers, nCells
+      integer, dimension(:), pointer :: nCellsArray
+
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
+
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: tracer_turb_flux, flux, r_tmp
+
+      real (kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
+      real (kind=RKIND), dimension(:), pointer :: meshScalingDel2
+
+      err = 0
+
+      if (.not.del2On) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_tracer_hmix_del2_tend_gpu NOT EXECUTING"
+
+      call mpas_timer_start("tracer del2 gpu")
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      num_tracers = size(tracers, dim=1)
+
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
+
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+
+      nCells = nCellsArray( 1 )
+
+      !
+      ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, iTracer, &
+      !$omp         tracer_turb_flux, flux)
+      do iCell = 1, nCells
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+
+          r_tmp = meshScalingDel2(iEdge) * eddyDiff2 * dvEdge(iEdge) / dcEdge(iEdge)
+
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            do iTracer = 1, num_tracers
+              ! \kappa_2 \nabla \phi on edge
+              tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)
+
+              ! div(h \kappa_2 \nabla \phi) at cell center
+              flux = layerThickEdgeMean(k, iEdge) * tracer_turb_flux * r_tmp
+
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+            end do
+          end do
+
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("tracer del2 gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_del2_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -46,6 +46,7 @@ module ocn_tracer_hmix_del4
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_hmix_del4_tend, &
+             ocn_tracer_hmix_del4_tend_gpu, &
              ocn_tracer_hmix_del4_init
 
    !--------------------------------------------------------------------
@@ -234,6 +235,168 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_hmix_del4_tend!}}}
+
+   subroutine ocn_tracer_hmix_del4_tend_gpu(meshPool, layerThickEdgeMean, tracers, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeMean    !< Input: mean thickness at edge
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        tracers !< Input: tracer quantities
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, num_tracers, nCells
+      integer :: iTracer, k, iCell, cell1, cell2, i
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
+
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell, nEdgesOnCell
+      integer, dimension(:,:), pointer :: edgeMask, cellsOnEdge, edgesOnCell, edgeSignOnCell
+
+      real (kind=RKIND) :: invAreaCell1, tracer_turb_flux, flux, invdcEdge, r_tmp1, r_tmp2
+
+      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, meshScalingDel4
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:,:), allocatable :: delsq_tracer
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if ( .not. del4On ) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_tracer_hmix_del4_tend_gpu NOT EXECUTING"
+
+      call mpas_timer_start("tracer del4 gpu")
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      num_tracers = size(tracers, dim=1)
+
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
+
+      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+
+      ! Need 1 halo around owned cells
+      nCells = nCellsArray( 2 )
+
+      allocate(delsq_tracer(num_tracers, nVertLevels, nCells))
+
+      ! first del2: div(h \nabla \phi) at cell center
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, invdcEdge, cell1, cell2, k, iTracer, r_tmp1, r_tmp2)
+      do iCell = 1, nCells
+        delsq_tracer(:, :, iCell) = 0.0_RKIND
+        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          invdcEdge = dvEdge(iEdge) / dcEdge(iEdge)
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            do iTracer = 1, num_tracers * edgeMask(k, iEdge)
+
+              r_tmp1 = invdcEdge * layerThickEdgeMean(k, iEdge) * tracers(iTracer, k, cell1)
+              r_tmp2 = invdcEdge * layerThickEdgeMean(k, iEdge) * tracers(iTracer, k, cell2)
+
+              delsq_tracer(iTracer, k, iCell) = delsq_tracer(iTracer, k, iCell) - edgeSignOnCell(i, iCell) &
+                                              * (r_tmp2 - r_tmp1) * invAreaCell1
+            end do
+          end do
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! Only need tendency on owned cells
+      nCells = nCellsArray( 1 )
+
+      ! second del2: div(h \nabla [delsq_tracer]) at cell center
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, cell1, cell2, invdcEdge, k, iTracer, tracer_turb_flux, flux)
+      do iCell = 1, nCells
+        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          cell1 = cellsOnEdge(1, iEdge)
+          cell2 = cellsOnedge(2, iEdge)
+
+          invdcEdge = meshScalingDel4(iEdge) * dvEdge(iEdge) * eddyDiff4 / dcEdge(iEdge)
+
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            do iTracer = 1, num_tracers * edgeMask(k, iEdge)
+              tracer_turb_flux = (delsq_tracer(iTracer, k, cell2) - delsq_tracer(iTracer, k, cell1))
+
+              flux = tracer_turb_flux * invdcEdge
+
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell1
+            end do
+          end do
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(delsq_tracer)
+
+      call mpas_timer_stop("tracer del4 gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_del4_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -45,6 +45,7 @@ module ocn_tracer_hmix_Redi
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_hmix_Redi_tend, &
+             ocn_tracer_hmix_Redi_tend_gpu, &
              ocn_tracer_hmix_Redi_init
 
    !--------------------------------------------------------------------
@@ -57,6 +58,7 @@ module ocn_tracer_hmix_Redi
    real(kind=RKIND), dimension(:), allocatable :: rediKappaCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term2_edge, redi_term3_topOfCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term1, redi_term2, redi_term3
+!$acc declare create(rediKappaCell,redi_term2_edge,redi_term3_topOfCell,redi_term1,redi_term2,redi_term3)
 
 !***********************************************************************
 
@@ -470,6 +472,485 @@ contains
 
    end subroutine ocn_tracer_hmix_Redi_tend!}}}
 
+   subroutine ocn_tracer_hmix_Redi_tend_gpu(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
+                                        RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
+                                        RediKappaScaling, rediLimiterCount, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type(mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+
+      real(kind=RKIND), dimension(:), intent(in) :: &
+         RediKappa
+
+      real(kind=RKIND), dimension(:, :), intent(in) :: &
+         layerThickEdgeMean, &!< Input: mean thickness at edge
+         zMid, &!< Input: Z coordinate at the center of a cell
+         RediKappaScaling, &
+         layerThickness
+
+      real(kind=RKIND), dimension(:, :, :), intent(in) :: &
+         slopeTriadUp, slopeTriadDown, &
+         tracers !< Input: tracer quantities
+
+      real(kind=RKIND), intent(in) :: dt
+
+      integer, dimension(:, :), intent(inout) :: rediLimiterCount
+
+      logical, intent(in) :: isActiveTracer
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real(kind=RKIND), dimension(:, :, :), intent(inout) :: &
+         tend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2, iCellSelf
+      integer :: i, k, iTr, nTracers, nCells, nEdges, nCellsP1
+      logical :: use_Redi_diag_terms
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
+
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell, minLevelCell, maxLevelCell
+      integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell, cellsOnCell
+
+      real(kind=RKIND) :: tempTracer, invAreaCell
+      real(kind=RKIND) :: flux, flux_term2, flux_term3, dTracerDx, coef
+      real(kind=RKIND) :: r_tmp, tracer_turb_flux, kappaRediEdgeVal
+      real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
+      real(kind=RKIND), dimension(:), allocatable :: minimumVal
+      real(kind=RKIND), dimension(:, :), allocatable :: fluxRediZTop
+      err = 0
+
+      call mpas_timer_start("tracer redi gpu")
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      nTracers = size(tracers, dim=1)
+
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array_gpu(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+
+      nCells = nCellsArray(size(nCellsArray))
+      nEdges = nEdgesArray(size(nEdgesArray))
+
+      allocate (minimumVal(nTracers))
+      allocate (fluxRediZTop(nTracers, nVertLevels + 1))
+      allocate (rediKappaCell(nCells))
+      allocate (redi_term1(nTracers, nVertLevels, nCells))
+      allocate (redi_term2(nTracers, nVertLevels, nCells))
+      allocate (redi_term3(nTracers, nVertLevels, nCells))
+      allocate (redi_term2_edge(nTracers, nVertLevels, nEdges))
+      allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
+
+!$acc data present(minLevelEdgeBot,minLevelCell,maxLevelEdgeTop,maxLevelCell,cellsOnEdge,&
+!$acc              areaCell,dvEdge,dcEdge,nEdgesOnCell,edgesOnCell,cellsOnCell,edgeSignOnCell,&
+!$acc              RediKappa,RediKappaScaling,tracers,layerThickEdgeMean,slopeTriadDown,zMid,slopeTriadUp,&
+!$acc              rediLimiterCount,layerThickness,tend)&
+!$acc      create(minimumVal)
+
+      ! RediKappa changes every time step if either:
+      !   config_Redi_horizontal_taper == 'RossbyRadius'  
+      !   config_Redi_closure == 'equalGM'
+      ! in that case, RediKappa is updated every time step in mpas_ocn_gm.F
+      ! For static RediKappa, it is set on init and remains unchanged.
+
+      nCells = nCellsArray(2)
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, iEdge)
+!$acc parallel
+!$acc loop gang vector private(iEdge)
+      do iCell = 1,nCells
+        rediKappaCell(iCell) = 0.0_RKIND
+!$acc loop seq
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          rediKappaCell(iCell) = rediKappaCell(iCell) + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
+        enddo
+        rediKappaCell(iCell) = rediKappaCell(iCell) / areaCell(iCell)
+      enddo
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsArray(2)
+      nCellsP1 = nCellsArray(size(nCellsArray)) + 1
+
+      ! Term 1: this is the "standard" horizontal del2 term, but with RediKappa coefficient.
+      ! \kappa_2 \nabla \phi on edge
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(fluxRediZTop, invAreaCell, i, iEdge, cell1, cell2, iCellSelf, r_tmp, coef, k, &
+      !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
+      !$omp         dTracerDx, use_Redi_diag_terms)
+!$acc parallel
+!$acc loop gang worker private(fluxRediZTop,invAreaCell,i,iEdge,cell1,cell2,iCellSelf,r_tmp,coef,k,&
+!$acc                   iTr,flux_term3,use_Redi_diag_terms)
+      do iCell = 1, nCells
+         if (maxLevelCell(iCell) .ge. config_Redi_min_layers_diag_terms) then
+            use_Redi_diag_terms = .true.
+         else
+            use_Redi_diag_terms = .false.
+         endif
+!$acc loop vector collapse(2)
+         do k = 1, nVertLevels
+         do iTr = 1, nTracers
+         redi_term1(iTr, k, iCell) = 0.0_RKIND
+         redi_term2(iTr, k, iCell) = 0.0_RKIND
+         redi_term3(iTr, k, iCell) = 0.0_RKIND
+         fluxRediZTop(iTr, k) = 0.0_RKIND
+         if(k==nVertLevels) fluxRediZTop(iTr, k+1) = 0.0_RKIND
+         enddo
+         enddo
+        !rediKappaCell(iCell) = 0.0_RKIND
+         invAreaCell = 1.0_RKIND/areaCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            ! Check if neighboring cell exists
+!NV!            if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
+            if (cellsOnCell(i, iCell) .ne. nCellsP1) then
+            iEdge = edgesOnCell(i, iCell)
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (cell1 == iCell) then
+               iCellSelf = 1
+            else  ! cell2 == iCell
+               iCellSelf = 2
+            endif
+
+            r_tmp = dvEdge(iEdge)/dcEdge(iEdge)
+            coef = dvEdge(iEdge)
+
+            k = 1
+            if (minLevelEdgeBot(iEdge) .ne. 1) k = minLevelEdgeBot(iEdge)
+!$acc loop vector private(kappaRediEdgeVal,tracer_turb_flux,flux,flux_term2)
+            do iTr = 1, nTracers
+               kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+
+               tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
+                                           (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+
+!NV!               if (.not.use_Redi_diag_terms) cycle
+               if (use_Redi_diag_terms) then
+
+               ! Term 2: div( h S dphi/dz)
+               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+                            0.25_RKIND* &
+                            (slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
+                             /(zMid(k, cell1) - zMid(k + 1, cell1)) &
+                             + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
+                             /(zMid(k, cell2) - zMid(k + 1, cell2)))
+               if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 1, iEdge)* &
+                               (tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1))/(zMid(k - 1, cell1) - zMid(k, cell1))
+               endif
+               if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 2, iEdge)* &
+                               (tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2))/(zMid(k - 1, cell2) - zMid(k, cell2))
+               endif
+
+               redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
+               redi_term2_edge(iTr, k, iEdge) = -flux_term2
+
+               endif
+            end do
+
+!$acc loop vector collapse(2) private(kappaRediEdgeVal,tracer_turb_flux,flux,flux_term2,dTracerDx)
+            do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
+               do iTr = 1, nTracers
+                  kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+
+                  ! \kappa_2 \nabla \phi on edge
+                  tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
+
+                  ! div(h \kappa_2 \nabla \phi) at cell center
+                  flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+
+                  redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
+                                              (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+
+!NV!                  if (.not.use_Redi_diag_terms) cycle
+                  if (use_Redi_diag_terms) then
+
+                  flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThickEdgeMean(k, iEdge)* &
+                               0.25_RKIND* &
+                               (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
+                                /(zMid(k - 1, cell1) - zMid(k, cell1)) &
+                                + slopeTriadUp(k, 2, iEdge)*(tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2)) &
+                                /(zMid(k - 1, cell2) - zMid(k, cell2)) &
+                                + slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
+                                /(zMid(k, cell1) - zMid(k + 1, cell1)) &
+                                + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
+                                /(zMid(k, cell2) - zMid(k + 1, cell2)))
+                  redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2* &
+                                invAreaCell
+                  redi_term2_edge(iTr, k, iEdge) = -flux_term2
+
+                  dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
+                  fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
+                                         0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
+                                         *dTracerDx
+                  endif
+               end do
+            end do
+
+            k = maxLevelEdgeTop(iEdge)
+!$acc loop vector private(kappaRediEdgeVal,tracer_turb_flux,flux,flux_term2,dTracerDx)
+            do iTr = 1, nTracers
+               kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+
+               tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
+                                           (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+
+!NV!               if (.not.use_Redi_diag_terms) cycle
+               if (use_Redi_diag_terms) then
+
+               ! For bottom layer, only use triads pointing up:
+               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+                            0.25_RKIND* &
+                            (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
+                             /(zMid(k - 1, cell1) - zMid(k, cell1)) &
+                             + slopeTriadUp(k, 2, iEdge)*(tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2)) &
+                             /(zMid(k - 1, cell2) - zMid(k, cell2)))
+
+               if (maxLevelCell(cell1) > maxLevelEdgeTop(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 1, iEdge)* &
+                               (tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1))/(zMid(k, cell1) - zMid(k + 1, cell1))
+               endif
+               if (maxLevelCell(cell2) > maxLevelEdgeTop(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
+                               (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
+               endif
+               redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
+                                *invAreaCell
+               redi_term2_edge(iTr, k, iEdge) = -flux_term2
+
+               dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
+               fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
+                                      0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
+                                      *dTracerDx
+               endif
+            end do
+
+            endif
+         end do ! nEdgesOnCell(iCell)
+
+         if ( use_Redi_diag_terms) then
+            ! impose no-flux boundary conditions at top and bottom of column
+!$acc loop gang vector collapse(2)
+            do k = 1, minLevelCell(iCell)
+            do iTr = 1, nTracers
+               fluxRediZTop(iTr, k) = 0.0_RKIND
+               redi_term3_topOfCell(iTr, k, iCell) = 0.0_RKIND
+            enddo
+            enddo
+!NV!            fluxRediZTop(:, 1:minLevelCell(iCell)) = 0.0_RKIND
+!NV!            fluxRediZTop(:, maxLevelCell(iCell) + 1) = 0.0_RKIND
+!NV!            redi_term3_topOfCell(:, 1:minLevelCell(iCell), iCell) = 0.0_RKIND
+!$acc loop gang vector
+            do iTr = 1, nTracers
+               fluxRediZTop(iTr, maxLevelCell(iCell) + 1) = 0.0_RKIND
+               redi_term3_topOfCell(iTr, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+            enddo
+!$acc loop gang vector collapse(2)
+            do k = minLevelCell(iCell) + 1, maxLevelCell(iCell)
+            do iTr = 1, nTracers
+               redi_term3_topOfCell(iTr, k, iCell) = fluxRediZTop(iTr, k) * invAreaCell
+            enddo
+            end do
+!NV!            redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+
+!$acc loop gang vector collapse(2) private(flux_term3)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               do iTr = 1, nTracers
+                  ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
+                  ! 2.0 in next line is because a dot product on a C-grid
+                  ! requires a factor of 1/2 to average to the cell center.
+                  flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
+                               (RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
+                               * invAreaCell - RediKappaScaling(k + 1, iCell) &
+                               *fluxRediZTop(iTr, k + 1) * invAreaCell)
+
+                  redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
+               end do
+            end do
+         end if
+
+      end do ! iCell
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !loop over cells and check for out of bounds
+      if (isActiveTracer) then
+!$acc parallel
+!$acc loop gang vector
+         do iTr = 1, nTracers
+         if(iTr==1) then
+            minimumVal(iTr) = -2.0_RKIND
+         else
+            minimumVal(iTr) = 0.0_RKIND
+         endif
+         enddo
+!$acc end parallel
+         !$omp parallel
+         !$omp do schedule(runtime)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+         do iCell = 1, nCells
+         do k = 1, nVertLevels
+            rediLimiterCount(k, iCell) = 0
+         enddo
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+      else
+!$acc parallel
+!$acc loop gang vector
+         do iTr = 1, nTracers
+         minimumVal(iTr) = 0.0_RKIND
+         enddo
+!$acc end parallel
+      endif
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, iTr, tempTracer, iEdge)
+!$acc parallel
+!$acc loop gang
+      do iCell = 1, nCells
+!$acc loop vector private(tempTracer,iEdge)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
+!$acc loop seq
+            do iTr = 1, ntracers
+               tempTracer = tracers(iTr, k, iCell) + dt*(redi_term1(iTr, k, iCell) + redi_term2(iTr, k, iCell) + &
+                                                         redi_term3(iTr, k, iCell))/layerThickness(k, iCell)
+
+               if (tempTracer < minimumVal(iTr)) then
+!$acc loop seq
+                  do i = 1, nEdgesOnCell(iCell)
+                     iEdge = edgesOnCell(i, iCell)
+                     redi_term2_edge(iTr, k, iEdge) = 0.0_RKIND
+                  end do
+
+                  redi_term3_topOfCell(iTr, k, iCell) = 0.0_RKIND
+                  redi_term3_topOfCell(iTr, k + 1, iCell) = 0.0_RKIND
+                  if (isActiveTracer) then
+                     rediLimiterCount(k, iCell) = rediLimiterCount(k, iCell) + 1
+                  endif
+               endif
+            end do
+         end do
+      end do ! iCell
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      !now go back and reapply all tendencies
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
+!$acc parallel
+!$acc loop gang worker private(invAreaCell,iEdge)
+      do iCell = 1, nCells
+         invAreaCell = 1.0_RKIND/areaCell(iCell)
+!$acc loop vector
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
+            do iTr = 1, ntracers
+               tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
+            end do
+         end do
+
+         if (maxLevelCell(iCell) .ge. config_Redi_min_layers_diag_terms) then
+!$acc loop vector
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               do iTr = 1, ntracers
+                  tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
+                                        (RediKappaScaling(k, iCell)* &
+                                         redi_term3_topOfCell(iTr, k, iCell) - &
+                                         RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+               end do
+            end do
+
+!$acc loop seq
+            do i = 1, nEdgesOnCell(iCell)
+!NV!               if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
+               if (cellsOnCell(i, iCell) .ne. nCellsP1) then
+               iEdge = edgesOnCell(i, iCell)
+!$acc loop vector
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                  do iTr = 1, ntracers
+                     tend(iTr, k, iCell) = tend(iTr, k, iCell) + edgeSignOnCell(i, iCell)*invAreaCell*redi_term2_edge(iTr, k, iEdge)
+                  end do
+               end do
+               endif
+            end do
+         end if
+      end do ! iCell
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate (fluxRediZTop)
+      deallocate (minimumVal)
+      deallocate (rediKappaCell)
+      deallocate (redi_term1)
+      deallocate (redi_term2)
+      deallocate (redi_term3)
+      deallocate (redi_term2_edge)
+      deallocate (redi_term3_topOfCell)
+
+      call mpas_timer_stop("tracer redi gpu")
+
+      !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_Redi_tend_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_tracer_hmix_Redi_init
@@ -517,12 +998,12 @@ contains
          call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-         call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
-         call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', RediHorizontalTaper)
-         call mpas_pool_get_array(forcingPool, 'RediKappaData', RediKappaData)
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediKappa', RediKappa)
+         call mpas_pool_get_array_gpu(diagnosticsPool, 'RediHorizontalTaper', RediHorizontalTaper)
+         call mpas_pool_get_array_gpu(forcingPool, 'RediKappaData', RediKappaData)
+         call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+         call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+!$acc update host(RediKappa,RediHorizontalTaper,RediKappaData,cellsOnEdge,dcEdge)
 
          ! initialize Redi kappa array
          if (config_Redi_closure == 'constant'.or. &
@@ -589,6 +1070,7 @@ contains
          block => block%next
       end do
 
+!$acc update device(RediKappa,RediHorizontalTaper)
       !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_hmix_Redi_init!}}}

--- a/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -42,6 +42,7 @@ module ocn_tracer_ideal_age
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_ideal_age_compute, &
+             ocn_tracer_ideal_age_compute_gpu, &
              ocn_tracer_ideal_age_init
 
    !--------------------------------------------------------------------
@@ -146,6 +147,86 @@ contains
 
    end subroutine ocn_tracer_ideal_age_compute!}}}
 
+   subroutine ocn_tracer_ideal_age_compute_gpu(nTracers, nCellsSolve, minLevelCell, maxLevelCell, layerThickness, &
+                  idealAgeMask, tracers, tracer_tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      ! one dimensional arrays
+      integer, dimension(:), intent(in) :: &
+         minLevelCell, maxLevelCell
+
+      ! two dimensional arrays
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness, &
+         idealAgeMask
+
+      integer, intent(in) :: nTracers, nCellsSolve
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      ! three dimensional arrays
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+        tracers, &
+        tracer_tend
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iLevel, iTracer
+
+      err = 0
+
+      ! add a tendency increment equivalent to "dt" to entire domain below top level
+      !$omp parallel
+      !$omp do schedule(runtime) private(iLevel, iTracer)
+      do iCell=1,nCellsSolve
+        do iLevel=minLevelCell(iCell) + 1, maxLevelCell(iCell)
+          do iTracer=1,nTracers
+             tracer_tend(iTracer, iLevel, iCell) = tracer_tend(iTracer, iLevel, iCell) +  &
+                layerThickness(iLevel,iCell)
+          enddo
+        enddo
+      enddo
+      !$omp end do
+      !$omp end parallel
+
+      ! zero surface tendency where mask == 0
+      !$omp parallel
+      !$omp do schedule(runtime) private(iLevel, iTracer)
+      do iCell=1,nCellsSolve
+        iLevel = minLevelCell(iCell)
+        do iTracer=1,nTracers
+           tracer_tend(iTracer, iLevel, iCell) = tracer_tend(iTracer, iLevel, iCell) +  &
+              idealAgeMask(iTracer, iCell)*layerThickness(iLevel,iCell)
+        enddo
+      enddo
+      !$omp end do
+      !$omp end parallel
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_ideal_age_compute_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_tracer_ideal_age_init
@@ -181,11 +262,12 @@ contains
       call mpas_pool_get_subpool(forcingPool, &
                                  'tracersIdealAgeFields', &
                                   tracersIdealAgeFieldsPool)
-      call mpas_pool_get_array(tracersIdealAgeFieldsPool, &
+      call mpas_pool_get_array_gpu(tracersIdealAgeFieldsPool, &
                                'idealAgeTracersIdealAgeMask', &
                                 idealAgeMask)
 
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array_gpu(forcingPool, 'landIceMask', landIceMask)
+!$acc update host(idealAgeMask,landIceMask)
 
       if (config_use_idealAgeTracers_idealAge_forcing) then
          ! set mask = 0 for open ocean
@@ -195,6 +277,7 @@ contains
             where (landIceMask /= 0) idealAgeMask(1,:) = 1.0_RKIND
          end if
       end if
+!$acc update device(idealAgeMask)
 
    end subroutine ocn_tracer_ideal_age_init!}}}
 

--- a/src/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/src/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -44,6 +44,7 @@ module ocn_tracer_nonlocalflux
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_nonlocalflux_tend, &
+             ocn_tracer_nonlocalflux_tend_gpu, &
              ocn_tracer_nonlocalflux_init
 
    !--------------------------------------------------------------------
@@ -168,6 +169,115 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_nonlocalflux_tend!}}}
+
+   subroutine ocn_tracer_nonlocalflux_tend_gpu(meshPool, vertNonLocalFlux, surfaceTracerFlux, tend, err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        surfaceTracerFlux !< Input: surface tracer fluxes
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        vertNonLocalFlux !< Input: non-local flux of tracers defined at layer interfaces
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, iTracer, nTracers, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
+      real (kind=RKIND) :: fluxTopOfCell, fluxBottomOfCell
+
+      err = 0
+
+      if (.not. nonLocalFluxOn) return
+
+      call mpas_timer_start('non-local flux gpu')
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      nTracers = size(tend, dim=1)
+
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+
+      nCells = nCellsArray( 1 )
+
+!$acc data present(minLevelCell,maxLevelCell,surfaceTracerFlux,vertNonLocalFlux,tend)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, iTracer, fluxTopOfCell, fluxBottomOfCell)
+!$acc parallel
+!$acc loop gang private(k)
+      do iCell = 1, nCells
+!$acc loop vector collapse(2) private(fluxTopOfCell,fluxBottomOfCell)
+        do k = minLevelCell(iCell)+1, maxLevelCell(iCell)-1
+
+          ! NOTE: at the moment, all tracers are based on the flux-profile used for temperature, i.e. vertNonLocalFlux(1,:,:)
+          do iTracer = 1, nTracers
+            fluxTopOfCell = surfaceTracerFlux(iTracer, iCell) * vertNonLocalFlux(1, k, iCell)
+            fluxBottomOfCell = surfaceTracerFlux(iTracer, iCell) * vertNonLocalFlux(1, k+1, iCell)
+            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + (fluxTopOfCell-fluxBottomOfCell)
+          end do
+        end do
+
+        ! enforce boundary conditions at bottom of column
+        k = maxLevelCell(iCell)
+!$acc loop vector private(fluxTopOfCell,fluxBottomOfCell)
+        do iTracer = 1, nTracers
+          fluxTopOfCell = surfaceTracerFlux(iTracer, iCell) * vertNonLocalFlux(1, k, iCell)
+          fluxBottomOfCell = 0.0_RKIND
+          tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + (fluxTopOfCell-fluxBottomOfCell)
+        end do
+
+        ! enforce boundary conditions at top of column
+        k = minLevelCell(iCell)
+!$acc loop vector private(fluxTopOfCell,fluxBottomOfCell)
+        do iTracer = 1, nTracers
+          fluxTopOfCell = 0.0_RKIND
+          fluxBottomOfCell = surfaceTracerFlux(iTracer, iCell) * vertNonLocalFlux(1, k+1, iCell)
+          tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + (fluxTopOfCell-fluxBottomOfCell)
+        end do
+
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop('non-local flux gpu')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_nonlocalflux_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -38,6 +38,7 @@ module ocn_tracer_short_wave_absorption
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_short_wave_absorption_tend, &
+             ocn_tracer_short_wave_absorption_tend_gpu, &
              ocn_tracer_short_wave_absorption_init
 
    !--------------------------------------------------------------------
@@ -132,6 +133,78 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_short_wave_absorption_tend!}}}
+
+   subroutine ocn_tracer_short_wave_absorption_tend_gpu(meshPool, swForcingPool, forcingPool, index_temperature, & !{{{
+                    layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                    bottomLayerShortwaveTemperatureFlux, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool, swForcingPool, forcingPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         penetrativeTemperatureFlux !< Input: short wave heat flux
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         bottomLayerShortwaveTemperatureFlux
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
+
+      integer, intent(in) :: index_temperature
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      if (trim(config_sw_absorption_type)=='none')  return
+
+      call mpas_timer_start("short wave gpu")
+
+      err = 0
+      if(useJerlov) then
+!NV!     !!! WORKING !!!
+         call ocn_tracer_short_wave_absorption_jerlov_tend_gpu(meshPool, forcingPool, index_temperature, layerThickness, &
+                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                        bottomLayerShortwaveTemperatureFLux, err)
+      else
+!NV!     !!NOT EXECUTING !!!
+         write(*,*) "ocn_tracer_short_wave_absorption_tend_gpu NOT EXECUTING"
+         call ocn_tracer_short_wave_absorption_variable_tend_gpu(meshPool,swForcingPool, forcingPool, index_temperature, &
+                                        layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL,tend, &
+                                        bottomLayerShortwaveTemperatureFlux, err)
+      endif
+
+      call mpas_timer_stop("short wave gpu")
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_short_wave_absorption_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -35,7 +35,9 @@ module ocn_tracer_short_wave_absorption_jerlov
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_short_wave_absorption_jerlov_tend, &
-             ocn_get_jerlov_fraction
+             ocn_tracer_short_wave_absorption_jerlov_tend_gpu, &
+             ocn_get_jerlov_fraction, &
+             ocn_get_jerlov_fraction_gpu
 
    !--------------------------------------------------------------------
    !
@@ -58,6 +60,7 @@ module ocn_tracer_short_wave_absorption_jerlov
       rfac   = (/ 0.58_RKIND, 0.62_RKIND, 0.67_RKIND, 0.77_RKIND, 0.78_RKIND /), &
       depth1 = (/ 0.35_RKIND, 0.60_RKIND, 1.00_RKIND, 1.50_RKIND, 1.40_RKIND /), &
       depth2 = (/ 23.0_RKIND, 20.0_RKIND, 17.0_RKIND, 14.0_RKIND, 7.90_RKIND /)
+!$acc declare create(rfac,depth1,depth2)
 
 !***********************************************************************
 
@@ -215,6 +218,161 @@ contains
 
    end subroutine ocn_tracer_short_wave_absorption_jerlov_tend!}}}
 
+   subroutine ocn_tracer_short_wave_absorption_jerlov_tend_gpu(meshPool, forcingPool, index_temperature, layerThickness, &
+                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                        bottomLayerShortwaveTemperatureFlux, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool, forcingPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+        penetrativeTemperatureFlux !< Input: penetrative temperature flux through the surface
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        bottomLayerShortwaveTemperatureFlux
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
+
+      integer, intent(in) :: index_temperature
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, depLev, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
+
+      real (kind=RKIND) :: depth, fluxRemaining
+      real (kind=RKIND), dimension(:), pointer :: refBottomDepth
+      real (kind=RKIND), dimension(:), allocatable :: weights
+
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'refBottomDepth', refBottomDepth)
+
+      allocate(weights(nVertLevels+1))
+      weights = 0.0_RKIND
+      weights(1) = 1.0_RKIND
+
+!$acc update device(rfac,depth1,depth2)
+
+!$acc data present(minLevelCell,maxLevelCell,layerThickness,tend,penetrativeTemperatureFlux,&
+!$acc               bottomLayerShortwaveTemperatureFlux,penetrativeTemperatureFluxOBL)
+
+      nCells = nCellsArray( 3 )
+
+#ifndef CPRPGI
+      !$omp parallel
+      !$omp do schedule(runtime) private(fluxRemaining, depth, k, depLev) &
+      !$omp firstprivate(weights)
+#endif
+!$acc parallel
+!$acc loop gang vector private(depth,fluxRemaining,weights,k,depLev)
+      do iCell = 1, nCells
+         depth = 0.0_RKIND ! depth relative to minLevelCell(iCell)
+         fluxRemaining = 1.0_RKIND
+!$acc loop seq
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
+            depth = depth + layerThickness(k, iCell)
+
+            call ocn_get_jerlov_fraction_gpu(depth, weights(k+1))
+            tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell) &
+                                              * (weights(k) - weights(k+1))
+            fluxRemaining = fluxRemaining - (weights(k) - weights(k+1))
+         end do
+
+         ! based on coupled testing we only track the solar induced warming incident on the bottom ocean
+         k = maxLevelCell(iCell)
+         if(k > 0 .and. fluxRemaining > 0.0_RKIND) then
+            bottomLayerShortwaveTemperatureFlux(iCell) = penetrativeTemperatureFlux(iCell) * fluxRemaining
+         else
+            bottomLayerShortwaveTemperatureFlux(iCell) = 0.0_RKIND
+         end if
+
+         depth = 0.0_RKIND
+!$acc loop seq
+         do k=minLevelCell(iCell),maxLevelCell(iCell)
+           depth = depth + layerThickness(k,iCell)
+           if(depth > abs(config_surface_buoyancy_depth)) exit
+         enddo
+
+         if(k == maxLevelCell(iCell) .or. k == minLevelCell(iCell)) then
+           depLev=minLevelCell(iCell)+1
+         else
+           depLev=k
+         endif
+         penetrativeTemperatureFluxOBL(iCell)=penetrativeTemperatureFlux(iCell)*weights(depLev)
+
+      end do
+!$acc end parallel
+#ifndef CPRPGI
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      if(config_enable_shortwave_energy_fixer) then
+#ifndef CPRPGI
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+#endif
+!$acc parallel
+!$acc loop gang vector private(k)
+         do iCell = 1, nCells
+            k = maxLevelCell(iCell)
+            tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + &
+                      bottomLayerShortwaveTemperatureFlux(iCell)
+         end do
+!$acc end parallel
+#ifndef CPRPGI
+         !$omp end do
+         !$omp end parallel
+#endif
+      end if
+
+!$acc end data
+
+      deallocate(weights)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_short_wave_absorption_jerlov_tend_gpu!}}}
+
 !***********************************************************************
 !
 !  routine ocn_init_jerlov_fractions
@@ -263,6 +421,42 @@ contains
                   + (1.0_RKIND - rfac(config_jerlov_water_type)) * exp(-depth/depth2(config_jerlov_water_type))
       endif
    end subroutine ocn_get_jerlov_fraction!}}}
+
+   subroutine ocn_get_jerlov_fraction_gpu(depth, weight)!{{{
+!$acc routine seq
+!  Note: below 200m the solar penetration gets set to zero,
+!     otherwise the limit for the exponent ($+/- 5678$) needs to be
+!     taken care of.
+
+      real (kind=RKIND), intent(in) :: depth !< Input: Depth of bottom of cell
+      real (kind=RKIND), intent(out) :: weight !< Output: Weight for Jerlov absorption
+
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+!
+      integer,  parameter :: num_water_types = 5  ! max number of different water types
+
+      ! I don't understand what the previous two lines are for.  They appear unnecessary
+
+      real (kind=RKIND), parameter :: depth_cutoff = -200.0_RKIND
+
+!-----------------------------------------------------------------------
+!
+!  compute absorption fraction
+!
+!-----------------------------------------------------------------------
+
+      if (-depth < depth_cutoff) then
+         weight = 0.0_RKIND
+      else
+         weight = rfac(mod_jerlov_water_type) * exp(-depth/depth1(mod_jerlov_water_type)) &
+                  + (1.0_RKIND - rfac(mod_jerlov_water_type)) * exp(-depth/depth2(mod_jerlov_water_type))
+      endif
+   end subroutine ocn_get_jerlov_fraction_gpu!}}}
 
 end module ocn_tracer_short_wave_absorption_jerlov
 

--- a/src/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -40,6 +40,7 @@ module ocn_tracer_short_wave_absorption_variable
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_short_wave_absorption_variable_tend, &
+             ocn_tracer_short_wave_absorption_variable_tend_gpu, &
              ocn_tracer_short_wave_absorption_variable_init, &
              ocn_get_variable_sw_fraction,                   &
              ocn_get_os00_coeffs,                            &
@@ -224,6 +225,160 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_short_wave_absorption_variable_tend!}}}
+
+   subroutine ocn_tracer_short_wave_absorption_variable_tend_gpu(meshPool, swForcingPool, forcingPool, index_temperature, & !{{{
+                                  layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                  bottomLayerShortwaveTemperatureFlux, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool,                         &          !< Input: mesh information
+         swForcingPool,                    &          !< Input: chlorophyll, cloud, zenith data
+         forcingPool
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+        penetrativeTemperatureFlux !< Input: penetrative temperature flux through the surface
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        bottomLayerShortwaveTemperatureFlux
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
+
+      integer, intent(in) :: index_temperature
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, depLev, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
+
+      real (kind=RKIND) :: depth
+      real (kind=RKIND), dimension(:), pointer :: refBottomDepth
+      real (kind=RKIND), dimension(:), allocatable :: weights
+      real (kind=RKIND), dimension(:), pointer :: chlorophyllA, zenithAngle, clearSkyRadiation
+      real (kind=RKIND), dimension(4) :: Avals, Kvals
+      real (kind=RKIND) :: cloudRatio ! cloud Ratio = 1 - incident_sfc_sw_radiation/clearSkyRadiation
+      real (kind=RKIND) :: fluxRemaining ! amount of incident solar left to be distributed
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+
+      allocate(weights(nVertLevels+1))
+      weights = 0.0_RKIND
+      weights(minLevelCell(iCell)) = 1.0_RKIND
+      Avals(:)=0.0_RKIND
+      Kvals(:)=0.0_RKIND
+
+      call mpas_pool_get_array(swForcingPool,'chlorophyllData',chlorophyllA)
+
+      call mpas_pool_get_array(swForcingPool,'zenithAngle',zenithAngle)
+      call mpas_pool_get_array(swForcingPool,'clearSkyRadiation',clearSkyRadiation)
+
+      nCells = nCellsArray( 3 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(fluxRemaining, depth, cloudRatio, k, depLev, Avals, Kvals, weights)
+      do iCell = 1, nCells
+        depth = 0.0_RKIND
+        fluxRemaining = 1.0_RKIND
+        cloudRatio = min(1.0_RKIND, 1.0_RKIND - penetrativeTemperatureFlux(iCell)/(hflux_factor*(1.0E-15_RKIND + &
+                                                     clearSkyRadiation(iCell))))
+        cloudRatio = max(0.0_RKIND, cloudRatio)
+
+        call ocn_get_os00_coeffs(chlorophyllA(iCell),zenithAngle(iCell),cloudRatio,Avals, Kvals)
+
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          depth = depth + layerThickness(k, iCell)
+
+          call ocn_get_variable_sw_fraction(depth, weights(k+1), Avals, Kvals)
+          tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell) &
+                                            * (weights(k) - weights(k+1) )
+          fluxRemaining = fluxRemaining - (weights(k) - weights(k+1))
+        end do
+
+        ! based on coupled testing we simply log the shortwave temperature flux incident on the bottom of the ocean
+        k = maxLevelCell(iCell)
+        if(k > 0 .and. fluxRemaining > 0.0_RKIND) then
+           bottomLayerShortwaveTemperatureFlux(iCell) = penetrativeTemperatureFlux(iCell) * fluxRemaining
+        else
+           bottomLayerShortwaveTemperatureFlux(iCell) = 0.0_RKIND
+        end if
+
+        depth = 0.0_RKIND
+        do k=minLevelCell(iCell),maxLevelCell(iCell)
+           depth = depth + layerThickness(k,iCell)
+           if(depth > abs(config_surface_buoyancy_depth)) exit
+        enddo
+
+        if(k == maxLevelCell(iCell) .or. k == minLevelCell(iCell)) then
+           depLev=minLevelCell(iCell)+1
+        else
+           depLev=k
+        endif
+        penetrativeTemperatureFluxOBL(iCell)=penetrativeTemperatureFlux(iCell)*weights(depLev)
+
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      if(config_enable_shortwave_energy_fixer) then
+#ifndef CPRPGI
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+#endif
+         do iCell = 1, nCells
+            k = maxLevelCell(iCell)
+            tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + &
+                bottomLayerShortwaveTemperatureFlux(iCell)
+         end do
+#ifndef CPRPGI
+         !$omp end do
+         !$omp end parallel
+#endif
+      end if
+
+      deallocate(weights)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_short_wave_absorption_variable_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -45,6 +45,7 @@ module ocn_tracer_surface_flux_to_tend
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_surface_flux_tend, &
+             ocn_tracer_surface_flux_tend_gpu, &
              ocn_tracer_surface_flux_init
 
    !--------------------------------------------------------------------
@@ -201,6 +202,151 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_surface_flux_tend!}}}
+
+   subroutine ocn_tracer_surface_flux_tend_gpu(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness,  &
+      surfaceTracerFlux, surfaceTracerFluxRunoff, tend, err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThickness !< Input: Layer thickness
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        surfaceTracerFlux !< Input: surface tracer fluxes
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        fractionAbsorbed !< Input: Coefficients for the application of surface fluxes
+
+      real (kind=RKIND), dimension(:,:), intent(in), pointer :: &
+        surfaceTracerFluxRunoff !< Input: surface tracer fluxes from river runoff
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        fractionAbsorbedRunoff !< Input: Coefficients for the application of surface fluxes due to river runoff
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, iTracer, nTracers, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
+
+      real (kind=RKIND) :: remainingFlux
+
+      err = 0
+
+      if (.not. surfaceTracerFluxOn) return
+
+      call mpas_timer_start("surface_tracer_flux gpu")
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      nTracers = size(tend, dim=1)
+
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+
+      nCells = nCellsArray( 1 )
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              fractionAbsorbed,tend,surfaceTracerFlux,fractionAbsorbedRunoff,surfaceTracerFluxRunoff)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
+!$acc parallel
+!$acc loop gang worker private(remainingFlux)
+      do iCell = 1, nCells
+        remainingFlux = 1.0_RKIND
+!$acc loop seq
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
+          remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
+!$acc loop vector
+          do iTracer = 1, nTracers
+            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + surfaceTracerFlux(iTracer, iCell) * fractionAbsorbed(k, iCell)
+          end do
+        end do
+
+        if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+!$acc loop vector
+          do iTracer = 1, nTracers
+            tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
+                                                      + surfaceTracerFlux(iTracer, iCell) * remainingFlux
+          end do
+        end if
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("surface_tracer_flux gpu")
+
+      ! now do runoff component
+
+      if (associated(surfaceTracerFluxRunoff)) then
+        call mpas_timer_start("surface_tracer_runoff_flux gpu")
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
+!$acc parallel
+!$acc loop gang worker private(remainingFlux)
+        do iCell = 1, nCells
+          remainingFlux = 1.0_RKIND
+!$acc loop seq
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
+            remainingFlux = remainingFlux - fractionAbsorbedRunoff(k, iCell)
+!$acc loop vector
+            do iTracer = 1, nTracers
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) +  &
+                 surfaceTracerFluxRunoff(iTracer, iCell) * fractionAbsorbedRunoff(k, iCell)
+            end do
+          end do
+
+          if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+!$acc loop vector
+            do iTracer = 1, nTracers
+              tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
+                                                        + surfaceTracerFluxRunoff(iTracer, iCell) * remainingFlux
+            end do
+          end if
+        end do
+!$acc end parallel
+        !$omp end do
+        !$omp end parallel
+
+        call mpas_timer_stop("surface_tracer_runoff_flux gpu")
+      end if
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_surface_flux_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/src/shared/mpas_ocn_tracer_surface_restoring.F
@@ -50,6 +50,7 @@ module ocn_tracer_surface_restoring
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_surface_restoring_compute,          &
+             ocn_tracer_surface_restoring_compute_gpu,      &
              ocn_get_surfaceSalinityData,                   &
              ocn_salinity_restoring_forcing_write_restart,  &
              ocn_tracer_surface_restoring_init
@@ -163,6 +164,105 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_surface_restoring_compute!}}}
+
+   subroutine ocn_tracer_surface_restoring_compute_gpu(groupName, nTracers, nCells, tracers, pistonVelocity, &
+                 tracersSurfaceRestoringValue, tracersSurfaceFlux, indexSalinity,  &
+                 use_surface_salinity_monthly_restoring, salinity_restoring_constant_piston_velocity, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      character (len=*), intent(in) :: groupName !< Input: Name of tracer group
+
+      ! scalars
+      integer, intent(in) ::  &
+          nTracers,           &
+          indexSalinity,      &
+          nCells
+
+      real (kind=RKIND), intent(in) :: salinity_restoring_constant_piston_velocity
+
+      ! logicals
+      logical, intent(in) ::  &
+          use_surface_salinity_monthly_restoring
+
+      ! three dimensional arrays
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers
+
+      ! two dimensional ararys
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         pistonVelocity,     &
+         tracersSurfaceRestoringValue
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+        tracersSurfaceFlux
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iLevel, iTracer
+      character (len=13) :: trimGroupName
+
+      err = 0
+      trimGroupName = trim(groupName)
+
+!$acc data present(minLevelCell,&
+!$acc              tracersSurfaceFlux,tracersSurfaceRestoringValue,pistonVelocity,tracers)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(iTracer, iLevel)
+!$acc parallel
+!$acc loop gang private(iLevel)
+      do iCell=1,nCells
+        iLevel = minLevelCell(iCell)  ! base surface flux restoring on tracer fields in the top layer
+
+!$acc loop vector
+        do iTracer=1,nTracers
+
+          ! For monthly salinity restoring, tracersSurfaceRestoringValue contains the zero-mean deltaS
+          if (trimGroupName == 'activeTracers' &
+                .and. iTracer == indexSalinity   &
+                .and. use_surface_salinity_monthly_restoring) then
+          tracersSurfaceFlux(iTracer, iCell) =   tracersSurfaceFlux(iTracer, iCell) + &
+                                                 salinity_restoring_constant_piston_velocity * &
+                                                 tracersSurfaceRestoringValue(iTracer,iCell)
+          else
+          tracersSurfaceFlux(iTracer, iCell) =  tracersSurfaceFlux(iTracer, iCell) - &
+                                                pistonVelocity(iTracer,iCell) *      &
+                                                 (tracers(iTracer, iLevel, iCell) - tracersSurfaceRestoringValue(iTracer,iCell))
+          endif
+        enddo
+      enddo
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_surface_restoring_compute_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_forcing.F
+++ b/src/shared/mpas_ocn_vel_forcing.F
@@ -45,6 +45,7 @@ module ocn_vel_forcing
    !--------------------------------------------------------------------
 
    public :: ocn_vel_forcing_tend, &
+             ocn_vel_forcing_tend_gpu, &
              ocn_vel_forcing_init
 
    !--------------------------------------------------------------------
@@ -134,6 +135,66 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_tend!}}}
+
+   subroutine ocn_vel_forcing_tend_gpu(normalVelocity, sfcFlxAttCoeff, &
+                                   surfaceStress, kineticEnergyCell, &
+                                   layerThickEdgeMean, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity,    &!< [in] Normal velocity at edges
+         kineticEnergyCell, &!< [in] kinetic energy at cell
+         layerThickEdgeMean  !< [in] mean thickness at edge
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         sfcFlxAttCoeff, &!< [in] attenuation coefficient for sfc fluxes
+         surfaceStress    !< [in] surface stress at edges
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: err1 ! local error flag
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** initialize error flag, then call individual forcing routines
+
+      err = 0
+
+      call ocn_vel_forcing_surface_stress_tend_gpu(sfcFlxAttCoeff, &
+                   surfaceStress, layerThickEdgeMean, tend, err1)
+      err = ior(err, err1)
+
+      call ocn_vel_forcing_explicit_bottom_drag_tend_gpu(normalVelocity, &
+                   kineticEnergyCell, layerThickEdgeMean, tend, err1)
+      err = ior(err, err1)
+
+      call ocn_vel_forcing_topographic_wave_drag_tend_gpu(normalVelocity, &
+                   tend, err1)
+
+      err = ior(err, err1)
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -44,6 +44,7 @@ module ocn_vel_forcing_explicit_bottom_drag
    !--------------------------------------------------------------------
 
    public :: ocn_vel_forcing_explicit_bottom_drag_tend, &
+             ocn_vel_forcing_explicit_bottom_drag_tend_gpu, &
              ocn_vel_forcing_explicit_bottom_drag_init
 
    !--------------------------------------------------------------------
@@ -127,15 +128,8 @@ contains
       ! momentum mixing, and is explicit if both |u| and u are chosen to be at
       ! time level n.
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, KECell, &
-      !$acc            tend, normVelocity, layerThickEdgeMean) &
-      !$acc    private(k, cell1, cell2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, cell1, cell2)
-#endif
       do iEdge = 1, nEdgesOwned
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)
@@ -148,16 +142,91 @@ contains
         end if
 
       enddo
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop('vel explicit bottom drag')
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_explicit_bottom_drag_tend!}}}
+
+   subroutine ocn_vel_forcing_explicit_bottom_drag_tend_gpu(normVelocity, &
+                                 KECell, layerThickEdgeMean, tend, err) !{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normVelocity,      &!< [in] normal velocity
+         KECell,            &!< [in] kinetic energy at cell
+         layerThickEdgeMean  !< [in] mean layer thickness at edge
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge,      &! loop index for edge loop
+         k,          &! vertical index of lowest active layer at edge
+         cell1, cell2 ! neighbor cell addresses across edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Initialize error code and return if not turned on
+      !*** Otherwise start timer
+
+      err = 0
+      if (explicitBottomDragOff) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_vel_forcing_explicit_bottom_drag_tend_gpu NOT EXECUTING"
+      call mpas_timer_start('vel explicit bottom drag gpu')
+
+      ! Explicit bottom drag term:
+      ! du/dt = ... - c |u| u / h
+      ! appied to bottom layer only.
+      ! This term comes from the bottom boundary condition in the vertical
+      ! momentum mixing, and is explicit if both |u| and u are chosen to be at
+      ! time level n.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, cell1, cell2)
+      do iEdge = 1, nEdgesOwned
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+        k =  maxLevelEdgeTop(iEdge)
+
+        if (k > 0) then
+           tend(k,iEdge) = tend(k,iEdge) - dragCoeff* &
+                           sqrt(KECell(k,cell1) + KECell(k,cell2))* &
+                           normVelocity(k,iEdge)/layerThickEdgeMean(k,iEdge)
+        end if
+
+      enddo
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop('vel explicit bottom drag gpu')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_explicit_bottom_drag_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -44,6 +44,7 @@ module ocn_vel_forcing_surface_stress
    !--------------------------------------------------------------------
 
    public :: ocn_vel_forcing_surface_stress_tend, &
+             ocn_vel_forcing_surface_stress_tend_gpu, &
              ocn_vel_forcing_surface_stress_init
 
    !--------------------------------------------------------------------
@@ -132,21 +133,11 @@ contains
       if (surfaceStressOff) return
       call mpas_timer_start('vel surface stress')
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
-      !$acc            sfcFlxAttCoeff, sfcStress, layerThickEdgeMean, &
-      !$acc            tend) &
-      !$acc    private(k, kmax, cell1, cell2, zBot, zTop, &
-      !$acc            attCoeff, attDepth, remainingStress, &
-      !$acc            transCoeffTop, transCoeffBot, absorb)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, kmax, cell1, cell2, zBot, zTop, &
       !$omp            attCoeff, attDepth, remainingStress, &
       !$omp            transCoeffTop, transCoeffBot, absorb)
-#endif
       do iEdge = 1, nEdgesOwned
         zTop     = 0.0_RKIND
         cell1 = cellsOnEdge(1,iEdge)
@@ -184,16 +175,131 @@ contains
                               layerThickEdgeMean(kmax,iEdge)
         end if
       enddo
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop('vel surface stress')
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_surface_stress_tend!}}}
+
+   subroutine ocn_vel_forcing_surface_stress_tend_gpu(sfcFlxAttCoeff, &
+                               sfcStress, layerThickEdgeMean, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         sfcStress,    & !< [in] Wind stress at surface
+         sfcFlxAttCoeff  !< [in] attenuation coefficient for sfc fluxes
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeMean  !< [in] mean thickness at edge
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::      &
+         iEdge, k,    &! loop indices for edge, vertical loops
+         kmax,        &! index of deepest active edge
+         cell1, cell2  ! neighbor cell addresses across edge
+
+      real (kind=RKIND) :: &
+         transCoeffTop,    &! transmission coefficent at top of edge
+         transCoeffBot,    &! transmission coefficent at bottom of edge
+         zTop, zBot,       &! depths at top and bottom of edge
+         remainingStress,  &! stress remaining at bottom of edge
+         absorb,           &! absorption fraction within layer
+         attDepth,         &! depth scaled by attenuation length
+         attCoeff           ! attenuation coefficient on edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Initialize error code and return if not on
+      !*** If turned on, start timer.
+
+      err = 0
+      if (surfaceStressOff) return
+      call mpas_timer_start('vel surface stress gpu')
+
+!$acc data present(cellsOnEdge,maxLevelEdgeTop,minLevelEdgeBot,edgeMask,&
+!$acc              sfcFlxAttCoeff,layerThickEdgeMean,tend,sfcStress)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kmax, cell1, cell2, zBot, zTop, &
+      !$omp            attCoeff, attDepth, remainingStress, &
+      !$omp            transCoeffTop, transCoeffBot, absorb)
+!$acc parallel
+!$acc loop gang vector private(zTop,cell1,cell2,attCoeff,attDepth,transCoeffTop,&
+!$acc                          remainingStress,kmax,zBot,absorb,transCoeffBot)
+      do iEdge = 1, nEdgesOwned
+        zTop     = 0.0_RKIND
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+        attCoeff = 0.5_RKIND*(sfcFlxAttCoeff(cell1) &
+                            + sfcFlxAttCoeff(cell2))
+        attDepth = 0.0_RKIND
+        transCoeffTop = 1.0_RKIND
+        remainingStress = 1.0_RKIND
+        kmax = maxLevelEdgeTop(iEdge)
+!$acc loop seq
+        do k = minLevelEdgeBot(iEdge), kmax
+           zBot = zTop - layerThickEdgeMean(k,iEdge)
+           attDepth = max(zBot/attCoeff, maxAttDepth)
+
+           transCoeffBot = exp(attDepth)
+
+           absorb = transCoeffTop - transCoeffBot
+           remainingStress = remainingStress - absorb
+
+           tend(k,iEdge) =  tend(k,iEdge) + &
+                            edgeMask(k,iEdge)*sfcStress(iEdge) * &
+                            absorb/rho_sw/layerThickEdgeMean(k,iEdge)
+
+           zTop = zBot
+           transCoeffTop = transCoeffBot
+        enddo
+
+        !*** if there is any remaining stress at the bottom, add it
+        !*** to the bottom layer
+
+        if ( kmax > 0 .and. remainingStress > 0.0_RKIND) then
+           tend(kmax,iEdge) = tend(kmax,iEdge) &
+                            + edgeMask(kmax,iEdge)*sfcStress(iEdge)* &
+                              remainingStress/rho_sw/ &
+                              layerThickEdgeMean(kmax,iEdge)
+        end if
+      enddo
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop('vel surface stress gpu')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_surface_stress_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -46,6 +46,7 @@ module ocn_vel_forcing_topographic_wave_drag
    !--------------------------------------------------------------------
 
    public :: ocn_vel_forcing_topographic_wave_drag_tend, &
+             ocn_vel_forcing_topographic_wave_drag_tend_gpu, &
              ocn_vel_forcing_topographic_wave_drag_init
 
    !--------------------------------------------------------------------
@@ -135,6 +136,70 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_topographic_wave_drag_tend!}}}
+
+   subroutine ocn_vel_forcing_topographic_wave_drag_tend_gpu(normalVelocity, & !{{{
+                     tend, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity   !< Input: velocity
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k
+
+      err = 0
+      if ( .not. topographicWaveDragOn ) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_vel_forcing_topographic_wave_drag_tend_gpu NOT EXECUTING"
+
+      call mpas_timer_start('vel topographic wave drag gpu')
+
+      !$omp do schedule(runtime) private(k)
+      do iEdge = 1, nEdgesOwned
+        k =  maxLevelEdgeTop(iEdge)
+        ! topographic wave drag term:
+        ! du/dt = ... 1/rinv * u
+        ! rinv is the e-folding time use in HyCOM. Here
+        ! topographic_wave_drag = 1/rinv
+        if (k>0) then
+          tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff &
+             * topographic_wave_drag(iEdge) * normalVelocity(k,iEdge)
+        endif
+      enddo
+      !$omp end do
+
+      call mpas_timer_stop('vel topographic wave drag gpu')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_topographic_wave_drag_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -43,6 +43,7 @@ module ocn_vel_hadv_coriolis
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hadv_coriolis_tend, &
+             ocn_vel_hadv_coriolis_tend_gpu, &
              ocn_vel_hadv_coriolis_init
 
    !--------------------------------------------------------------------
@@ -139,63 +140,33 @@ contains
 
       allocate(tmpVorticity(nVertLevels,nEdgesAll), &
                        qArr(nVertLevels,nEdgesAll))
-      !$acc enter data create(tmpVorticity, qArr)
 
-#ifndef MPAS_OPENACC
       !$omp parallel
-#endif
       if (usePlanetVorticity) then
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(tmpVorticity, normRelVortEdge, &
-         !$acc            normPlanetVortEdge) &
-         !$acc    private(k)
-#else
          !$omp do schedule(runtime) &
          !$omp    private(k)
-#endif
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             tmpVorticity(k,iEdge) = normRelVortEdge(k,iEdge) + &
                                  normPlanetVortEdge(k,iEdge)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
       else
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(tmpVorticity, normRelVortEdge) &
-         !$acc    private(k)
-#else
          !$omp do schedule(runtime) &
          !$omp    private(k)
-#endif
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             tmpVorticity(k,iEdge) = normRelVortEdge(k,iEdge)
          end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
-#endif
       endif
-#ifndef MPAS_OPENACC
          !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop, qArr, tmpVorticity, &
-      !$acc            normalVelocity, layerThickEdgeFlux) &
-      !$acc    private(k, j, eoe, edgeWeight, avgVorticity, kmin, kmax)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, j, eoe, edgeWeight, avgVorticity, kmin, kmax)
-#endif
       do iEdge = 1, nEdgesOwned
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
@@ -219,19 +190,10 @@ contains
 
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
-      !$acc            dcEdge, tend, qArr, kineticEnergyCell) &
-      !$acc    private(cell1, cell2, invLength, k, kmin, kmax)
-#else
       !$omp do schedule(runtime) &
       !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
-#endif
       do iEdge = 1, nEdgesOwned
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
@@ -247,12 +209,9 @@ contains
                           - kineticEnergyCell(k,cell1))*invLength)
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(tmpVorticity, qArr)
       deallocate(qArr,tmpVorticity)
 
       call mpas_timer_stop("coriolis")
@@ -260,6 +219,169 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_hadv_coriolis_tend!}}}
+
+   subroutine ocn_vel_hadv_coriolis_tend_gpu(normRelVortEdge, &
+                                      normPlanetVortEdge, &
+                                      layerThickEdgeFlux, normalVelocity, &
+                                      kineticEnergyCell, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normRelVortEdge,    &!< [in] relative vorticity/thickness at edge
+         normPlanetVortEdge, &!< [in] planetary vorticity/thickness at edge
+         layerThickEdgeFlux,     &!< [in] layer thickness on edge
+         normalVelocity,     &!< [in] Horizontal velocity
+         kineticEnergyCell    !< [in] Kinetic Energy
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend                 !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::       &
+         iEdge, j, k,  &! loop indices for edges, vertical
+         cell1, cell2, &! neighbor cell indices
+         eoe,          &! edge on edge index
+         kmin, kmax     ! min and max indices for vertical
+
+      real (kind=RKIND) :: &
+         avgVorticity, &! vorticity averaged across edge
+         invLength,    &! temp variable for 1/dcedge
+         edgeWeight     ! weight for summing over edges
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         qArr,         &! temporary vorticity array
+         tmpVorticity   ! vorticity on edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set error code and exit early if disabled
+      !*** Otherwise, start timer
+
+      err = 0
+      if (hadvCoriolisDisabled) return
+      call mpas_timer_start("coriolis gpu")
+
+      !*** allocate and transfer temporary arrays
+
+      allocate(tmpVorticity(nVertLevels,nEdgesAll), &
+                       qArr(nVertLevels,nEdgesAll))
+
+!$acc data present(minLevelEdgeBot,maxLevelEdgeTop,nEdgesOnEdge,edgesOnEdge,weightsOnEdge,&
+!$acc              cellsOnEdge,dcEdge,edgeMask,&
+!$acc              normRelVortEdge,normPlanetVortEdge,normalVelocity,layerThickEdgeFlux,tend,kineticEnergyCell) &
+!$acc      create(tmpVorticity,qArr)
+
+      !$omp parallel
+      if (usePlanetVorticity) then
+         !$omp do schedule(runtime) &
+         !$omp    private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+         do iEdge = 1, nEdgesAll
+         do k=1,nVertLevels
+            tmpVorticity(k,iEdge) = normRelVortEdge(k,iEdge) + &
+                                 normPlanetVortEdge(k,iEdge)
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+      else
+         !$omp do schedule(runtime) &
+         !$omp    private(k)
+!$acc parallel
+!$acc loop gang vector collapse(2)
+         do iEdge = 1, nEdgesAll
+         do k=1,nVertLevels
+            tmpVorticity(k,iEdge) = normRelVortEdge(k,iEdge)
+         end do
+         end do
+!$acc end parallel
+         !$omp end do
+      endif
+         !$omp end parallel
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, j, eoe, edgeWeight, avgVorticity, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,eoe,edgeWeight)
+      do iEdge = 1, nEdgesOwned
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+!$acc loop vector
+         do k = 1, nVertLevels
+            qArr(k,iEdge) = 0.0_RKIND
+         end do
+!$acc loop vector private(avgVorticity)
+            do k = kmin, kmax
+
+!$acc loop seq
+         do j = 1, nEdgesOnEdge(iEdge)
+            eoe = edgesOnEdge(j, iEdge)
+            edgeWeight = weightsOnEdge(j, iEdge)
+
+               avgVorticity = 0.5_RKIND* &
+                              (tmpVorticity(k,iEdge) + &
+                               tmpVorticity(k,eoe))
+               qArr(k,iEdge) = qArr(k,iEdge) + &
+                               edgeWeight*normalVelocity(k,eoe)* &
+                               avgVorticity*layerThickEdgeFlux(k,eoe)
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,cell1,cell2,invLength)
+      do iEdge = 1, nEdgesOwned
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         invLength = 1.0_RKIND / dcEdge(iEdge)
+!$acc loop vector
+         do k = kmin, kmax
+            tend(k,iEdge) = tend(k,iEdge) + &
+                        edgeMask(k,iEdge)* (qArr(k,iEdge) - &
+                           (kineticEnergyCell(k,cell2) &
+                          - kineticEnergyCell(k,cell1))*invLength)
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(qArr,tmpVorticity)
+
+      call mpas_timer_stop("coriolis gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_hadv_coriolis_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_hmix.F
+++ b/src/shared/mpas_ocn_vel_hmix.F
@@ -48,6 +48,7 @@ module ocn_vel_hmix
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_tend, &
+             ocn_vel_hmix_tend_gpu, &
              ocn_vel_hmix_init
 
    !--------------------------------------------------------------------
@@ -139,6 +140,66 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_hmix_tend!}}}
+
+   subroutine ocn_vel_hmix_tend_gpu(div, relVort, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         err1     ! local error flag
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Initialize return error code and viscosity
+      !*** exit early if not turned on, otherwise start relevant timer
+
+      err = 0
+      if (hmixOff) return
+      call mpas_timer_start("vel hmix gpu")
+
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+
+      call ocn_vel_hmix_del2_tend_gpu(div, relVort, tend, err1)
+      err = ior(err1, err)
+
+      call ocn_vel_hmix_leith_tend_gpu(div, relVort, tend, err1)
+      err = ior(err1, err)
+
+      call ocn_vel_hmix_del4_tend_gpu(div, relVort, tend, err1)
+      err = ior(err1, err)
+
+      call mpas_timer_stop("vel hmix gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_hmix_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_hmix_del2.F
+++ b/src/shared/mpas_ocn_vel_hmix_del2.F
@@ -43,6 +43,7 @@ module ocn_vel_hmix_del2
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_del2_tend, &
+             ocn_vel_hmix_del2_tend_gpu, &
              ocn_vel_hmix_del2_init
 
    !-------------------------------------------------------------------
@@ -128,19 +129,10 @@ contains
 
       call mpas_timer_start("vel del2")
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, minLevelEdgeBot, &
-      !$acc            verticesOnEdge, edgeMask, dcEdge, dvEdge, &
-      !$acc            meshScalingDel2, div, relVort, tend) &
-      !$acc    private(k, cell1, cell2, uDiff, vertex1, vertex2, &
-      !$acc            dcEdgeInv, dvEdgeInv, visc2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, cell1, cell2, uDiff, vertex1, vertex2, &
       !$omp            dcEdgeInv, dvEdgeInv, visc2)
-#endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -169,16 +161,115 @@ contains
 
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("vel del2")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_hmix_del2_tend!}}}
+
+   subroutine ocn_vel_hmix_del2_tend_gpu(div, relVort, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
+
+      !-----------------------------------------------------------------
+      ! input /output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::           &
+         iEdge, k,         &! loop indices for edge, vertical loops
+         cell1, cell2,     &! neighbor cell addresses across edge
+         vertex1, vertex2   ! neighbor vertex addresses along edge
+
+      real (kind=RKIND) :: &
+         uDiff,            &! velocity diffusion
+         dcEdgeInv,        &! 1/dcEdge
+         dvEdgeInv,        &! 1/dvEdge
+         visc2              ! scaled viscosity coefficient
+
+      !-----------------------------------------------------------------
+      !
+      ! exit if this mixing is not selected
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if (hmixDel2Off) return
+
+      call mpas_timer_start("vel del2 gpu")
+
+!$acc data present(cellsOnEdge,verticesOnEdge,dcEdge,dvEdge,meshScalingDel2,&
+!$acc              minLevelEdgeBot,maxLevelEdgeTop,edgeMask,&
+!$acc              div,relVort,tend)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, uDiff, vertex1, vertex2, &
+      !$omp            dcEdgeInv, dvEdgeInv, visc2)
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,vertex1,vertex2,dcEdgeInv,dvEdgeInv,visc2)
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
+
+         visc2 =  viscDel2*meshScalingDel2(iEdge)
+
+!$acc loop vector private(uDiff)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+
+            ! Here -( relativeVorticity(k,vertex2) - 
+            !         relativeVorticity(k,vertex1) ) / dvEdge(iEdge)
+            ! is - \nabla relativeVorticity pointing from vertex 2 
+            ! to vertex 1, or equivalently
+            ! + k \times \nabla relativeVorticity pointing from cell1 
+            ! to cell2.
+
+            uDiff = (div(k,cell2) - div(k,cell1))*dcEdgeInv &
+                   -(relVort(k,vertex2)-relVort(k,vertex1))*dvEdgeInv
+
+            tend(k,iEdge) = tend(k,iEdge) + &
+                            edgeMask(k,iEdge)*visc2*uDiff
+
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop("vel del2 gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_hmix_del2_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/shared/mpas_ocn_vel_hmix_del4.F
@@ -43,6 +43,7 @@ module ocn_vel_hmix_del4
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_del4_tend, &
+             ocn_vel_hmix_del4_tend_gpu, &
              ocn_vel_hmix_del4_init
 
    !--------------------------------------------------------------------
@@ -145,23 +146,14 @@ contains
       allocate(del2u(nVertLevels, nEdgesAll + 1), &
                del2div(nVertLevels, nCellsAll + 1), &
                del2relVort(nVertLevels, nVerticesAll + 1))
-      !$acc enter data create(del2u, del2div, del2relVort)
 
       nEdges = nEdgesHalo(2)
 
       !Compute Laplacian of velocity
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
-      !$acc            dvEdge, dcEdge, del2u, div, relVort) &
-      !$acc    private(k, cell1, cell2, vertex1, vertex2, &
-      !$acc            dcEdgeInv, dvEdgeInv, kmin, kmax)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, cell1, cell2, vertex1, vertex2, &
       !$omp            dcEdgeInv, dvEdgeInv, kmin, kmax)
-#endif
       do iEdge = 1, nEdges
          del2u(:, iEdge) = 0.0_RKIND
          cell1 = cellsOnEdge(1,iEdge)
@@ -183,24 +175,14 @@ contains
                                                            dvEdgeInv
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nVertices = nVerticesHalo(1)
 
       ! Compute del2 of relative vorticity
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(edgesOnVertex, minLevelVertexBot, maxLevelVertexTop, dcEdge, &
-      !$acc            areaTriangle, edgeSignOnVertex, del2u, &
-      !$acc            del2relVort) &
-      !$acc    private(i, k, iEdge, areaTriInv, kmin, kmax)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(i, k, iEdge, areaTriInv, kmin, kmax)
-#endif
       do iVertex = 1, nVertices
          kmin = minLevelVertexBot(iVertex)
          kmax = maxLevelVertexTop(iVertex)
@@ -215,23 +197,14 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsHalo(1)
 
       ! Compute del2 of divergence
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(nEdgesOnCell, edgesOnCell, minLevelCell, maxLevelCell, dvEdge,&
-      !$acc            edgeSignOnCell, areaCell, del2u, del2div) &
-      !$acc    private(i, k, iEdge, areaCellInv, kmin, kmax)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(i, k, iEdge, areaCellInv, kmin, kmax)
-#endif
       do iCell = 1, nCells
          kmin = minLevelCell(iCell)
          kmax = maxLevelCell(iCell)
@@ -246,28 +219,17 @@ contains
             end do
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       ! Compute final tendency \kappa \nabla^4 u
       ! as  \nabla div(\nabla^2 u) + k \times 
       !     \nabla ( k \cross curl(\nabla^2 u) )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
-      !$acc            dcEdge, dvEdge, meshScalingDel4, edgeMask, &
-      !$acc            del2div, del2relVort, tend) &
-      !$acc private(k, cell1, cell2, vertex1, vertex2, &
-      !$acc         dcEdgeInv, dvEdgeInv, visc4, uDiff, kmin, kmax)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, cell1, cell2, vertex1, vertex2, &
       !$omp         dcEdgeInv, dvEdgeInv, visc4, uDiff, kmin, kmax)
-#endif
       do iEdge = 1, nEdgesOwned
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
@@ -291,12 +253,9 @@ contains
                             edgeMask(k,iEdge)*uDiff*visc4
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(del2u, del2div, del2relVort)
       deallocate(del2u, &
                  del2div, &
                  del2relVort)
@@ -306,6 +265,216 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_hmix_del4_tend!}}}
+
+   subroutine ocn_vel_hmix_del4_tend_gpu(div, relVort, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::                      &
+         iEdge, iCell, iVertex, k, i, &! loop counters 
+         cell1, cell2,     &! neighbor cell addresses across edge
+         vertex1, vertex2, &! neighbor vertex addresses along edge
+         nEdges, nCells, nVertices ! num edges,cells,vertices incl halos
+
+      real (kind=RKIND) :: &
+         uDiff,            &! diffusion operator temporary
+         areaCellInv,      &! 1/area of cell
+         areaTriInv,       &! 1/area of triangle
+         dcEdgeInv,        &! 1/dcEdge
+         dvEdgeInv,        &! 1/dvEdge
+         visc4              ! scaled biharmonic viscosity coeff
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         del2div,     &!
+         del2relVort, &!
+         del2u
+
+      integer :: kmin, kmax
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** initialize error code and return if not selected
+      !*** otherwise start timer
+
+      err = 0
+      if (hmixDel4Off) return
+      call mpas_timer_start("vel del4 gpu")
+
+      !*** allocate temporaries
+
+      allocate(del2u(nVertLevels, nEdgesAll + 1), &
+               del2div(nVertLevels, nCellsAll + 1), &
+               del2relVort(nVertLevels, nVerticesAll + 1))
+
+      nEdges = nEdgesHalo(2)
+
+!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,verticesOnEdge,dcEdge,dvEdge,&
+!$acc              minLevelVertexBot,maxLevelVertexTop,areaTriangle,edgesOnVertex,edgeSignOnVertex,&
+!$acc              minLevelCell,maxLevelCell,areaCell,nEdgesOnCell,edgesOnCell,edgeSignOnCell,&
+!$acc              meshScalingDel4,edgeMask,&
+!$acc              div,relVort,tend) &
+!$acc      create(del2u,del2div,del2relVort)
+
+      !Compute Laplacian of velocity
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, vertex1, vertex2, &
+      !$omp            dcEdgeInv, dvEdgeInv, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,kmin,kmax,vertex1,vertex2,dcEdgeInv,dvEdgeInv)
+      do iEdge = 1, nEdges
+         del2u(:, iEdge) = 0.0_RKIND
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / max(dvEdge(iEdge), 0.25_RKIND*dcEdge(iEdge))
+!$acc loop vector
+         do k=kmin, kmax
+            ! Compute \nabla^2 u = \nabla divergence + k \times \nabla relativeVorticity
+            del2u(k,iEdge) = (div(k,cell2) - div(k,cell1))*dcEdgeInv &
+                            -(relVort(k,vertex2) - relVort(k,vertex1))*&
+                                                           dvEdgeInv
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nVertices = nVerticesHalo(1)
+
+      ! Compute del2 of relative vorticity
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, k, iEdge, areaTriInv, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,areaTriInv,iEdge)
+      do iVertex = 1, nVertices
+         kmin = minLevelVertexBot(iVertex)
+         kmax = maxLevelVertexTop(iVertex)
+         del2relVort(:, iVertex) = 0.0_RKIND
+         areaTriInv = 1.0_RKIND/areaTriangle(iVertex)
+!$acc loop seq
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+!$acc loop vector
+            do k = kmin, kmax
+               del2relVort(k,iVertex) = del2relVort(k,iVertex) &
+                                      + edgeSignOnVertex(i,iVertex) &
+                                       *dcEdge(iEdge)*del2u(k,iEdge)*areaTriInv
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsHalo(1)
+
+      ! Compute del2 of divergence
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, k, iEdge, areaCellInv, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,areaCellInv,iEdge)
+      do iCell = 1, nCells
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         del2div(:, iCell) = 0.0_RKIND
+         areaCellInv = 1.0_RKIND / areaCell(iCell)
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+!$acc loop vector
+            do k = kmin, kmax
+               del2div(k,iCell) = del2div(k,iCell) - &
+                                  edgeSignOnCell(i,iCell)*dvEdge(iEdge) &
+                                 *del2u(k,iEdge)*areaCellInv
+            end do
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+      ! Compute final tendency \kappa \nabla^4 u
+      ! as  \nabla div(\nabla^2 u) + k \times 
+      !     \nabla ( k \cross curl(\nabla^2 u) )
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, cell1, cell2, vertex1, vertex2, &
+      !$omp         dcEdgeInv, dvEdgeInv, visc4, uDiff, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax,cell1,cell2,vertex1,vertex2,dcEdgeInv,dvEdgeInv,visc4)
+      do iEdge = 1, nEdgesOwned
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
+         visc4 = viscDel4*meshScalingDel4(iEdge)
+!$acc loop vector private(uDiff)
+         do k = kmin, kmax
+            uDiff = divFactor*(del2div(k,cell2) - del2div(k,cell1))* &
+                                                          dcEdgeInv  &
+                  - (del2relVort(k,vertex2) - del2relVort(k,vertex1))* &
+                                                          dvEdgeInv
+
+            tend(k,iEdge) = tend(k,iEdge) - &
+                            edgeMask(k,iEdge)*uDiff*visc4
+         end do
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(del2u, &
+                 del2div, &
+                 del2relVort)
+
+      call mpas_timer_stop("vel del4 gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_hmix_del4_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -43,6 +43,7 @@ module ocn_vel_hmix_leith
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_leith_tend, &
+             ocn_vel_hmix_leith_tend_gpu, &
              ocn_vel_hmix_leith_init
 
    !-------------------------------------------------------------------
@@ -137,19 +138,10 @@ contains
       if (hmixLeithOff) return
       call mpas_timer_start("vel leith")
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
-      !$acc            dcEdge, dvEdge, meshScalingDel2, div, relVort, &
-      !$acc            tend, edgeMask) &
-      !$acc    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
-      !$acc            dvEdgeInv, uDiff, visc2, visc2tmp)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
       !$omp            dvEdgeInv, uDiff, visc2, visc2tmp)
-#endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -186,16 +178,115 @@ contains
 
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       call mpas_timer_stop("vel leith")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_hmix_leith_tend!}}}
+
+   subroutine ocn_vel_hmix_leith_tend_gpu(div, relVort, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend             !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::           &
+         iEdge, k,         &! loop indices for edge, vertical loops
+         cell1, cell2,     &! neighbor cell addresses across edge
+         vertex1, vertex2   ! neighbor vertex addresses along edge
+
+      real (kind=RKIND) :: &!
+         uDiff,            &! velocity diffusion operator
+         dcEdgeInv,        &! 1/dcEdge
+         dvEdgeInv,        &! 1/dvEdge
+         visc2tmp,         &! common factor for visc2
+         visc2              ! scaled viscosity coeff
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** initialize return code and exit if Leith not chosen
+      !*** start timer if chosen
+
+      err = 0
+      if (hmixLeithOff) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_vel_hmix_leith_tend_gpu NOT EXECUTING"
+      call mpas_timer_start("vel leith gpu")
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
+      !$omp            dvEdgeInv, uDiff, visc2, visc2tmp)
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
+
+         visc2tmp = (leithParam*dxLeith*meshScalingDel2(iEdge)/pii)**3
+
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+
+            ! Here -( relativeVorticity(k,vertex2) - 
+            !         relativeVorticity(k,vertex1) ) / dvEdge(iEdge)
+            ! is - \nabla relativeVorticity pointing from vertex 2 to 
+            ! vertex 1, or equivalently
+            ! + k \times \nabla relativeVorticity pointing from cell1 
+            ! to cell2.
+
+            uDiff = (div(k,cell2)  - div(k,cell1))*dcEdgeInv &
+                   -(relVort(k,vertex2) - relVort(k,vertex1))*dvEdgeInv
+
+            ! Here the first line is (\delta x)^3
+            ! the second line is |\nabla \omega|
+            ! and u_diffusion is \nabla^2 u (see formula for $\bf{D}$ above).
+            visc2 = visc2tmp &
+                   *abs(relVort(k,vertex2) - relVort(k,vertex1))* &
+                    dcEdgeInv*sqrt3fact
+            visc2 = min(visc2, viscMaxLeith)
+
+            tend(k,iEdge) = tend(k,iEdge) + &
+                            edgeMask(k,iEdge)*visc2*uDiff
+
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("vel leith gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_hmix_leith_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/shared/mpas_ocn_vel_pressure_grad.F
@@ -46,6 +46,7 @@ module ocn_vel_pressure_grad
    !--------------------------------------------------------------------
 
    public :: ocn_vel_pressure_grad_tend, &
+             ocn_vel_pressure_grad_tend_gpu, &
              ocn_vel_pressure_grad_init
 
    !--------------------------------------------------------------------
@@ -194,16 +195,9 @@ contains
 
          ! pressure for sea surface height = - g grad ssh
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
-         !$acc            tend, edgeMask, ssh,surfacePressure) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -219,26 +213,17 @@ contains
                                                - surfacePressure(cell1)) )
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case (pGradTypePZmid)
 
          ! pressure for generalized coordinates
          ! -1/density_0 (grad p_k + density g grad z_k^{mid})
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, zMid, &
-         !$acc            tend, edgeMask, pressure, density) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -256,26 +241,17 @@ contains
                                  (zMid(k,cell2)-zMid(k,cell1)))
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case (pGradTypeMontPot)
 
          ! For pure isopycnal coordinates, this is just grad(M),
          ! the gradient of Montgomery Potential
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
-         !$acc            tend, edgeMask, montgomeryPotential) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -290,10 +266,8 @@ contains
                                   montgomeryPotential(k,cell1)))
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case (pGradTypeMontPotDens)
 
@@ -304,17 +278,9 @@ contains
          ! Where rho is the potential density.
          ! See Bleck (2002) equation 1, and last equation in Appendix A.
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, dcEdge, minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc            edgeMask, tend, montgomeryPotential, &
-         !$acc            pressure, potentialDensity) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -333,29 +299,17 @@ contains
                               - 1.0_RKIND/potentialDensity(k,cell1)))
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case (pGradTypeJacobDens)
 
          allocate(JacobianDxDs(nVertLevels,nEdgesAll))
-         !$acc enter data create (JacobianDxDs)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
-         !$acc            edgeMask, pressure, density, zMid, tend, &
-         !$acc            JacobianDxDs) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax, pGrad, &
-         !$acc            Area, zStar, zC, zGamma, rhoL, rhoR)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax, pGrad, &
          !$omp            Area, zStar, zC, zGamma, rhoL, rhoR)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -424,37 +378,21 @@ contains
 
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
         deallocate(JacobianDxDs)
-        !$acc exit data delete(JacobianDxDs)
 
      case (pGradTypeJacobTS)
 
          allocate(JacobianDxDs(nVertLevels,nEdgesAll), &
                   JacobianTz(nVertLevels,nEdgesAll), &
                   JacobianSz(nVertLevels,nEdgesAll))
-         !$acc enter data create(JacobianDxDs, &
-         !$acc                   JacobianTz, JacobianSz)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
-         !$acc            zMid, tracers, edgeMask, pressure, &
-         !$acc            density, tend, thermExpCoeff, &
-         !$acc            salineContractCoeff, &
-         !$acc            JacobianTz, JacobianSz, JacobianDxDs) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax, alpha, beta,&
-         !$acc         TL, TR, SL, SR, Area, zStar, zC, zGamma, pGrad)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp private(cell1, cell2, invdcEdge, k, kMin, kMax, alpha, beta, &
          !$omp         TL, TR, SL, SR, Area, zStar, zC, zGamma, pGrad)
-#endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -552,25 +490,16 @@ contains
 
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
-         !$acc exit data delete (JacobianDxDs, JacobianTz, JacobianSz)
          deallocate(JacobianDxDs, JacobianTz, JacobianSz)
 
       case (pGradTypeConstForced)
 
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(angleEdge,maxLevelEdgeTop, tend, edgeMask) &
-         !$acc    private(pGrad, k)
-#else
          !$omp parallel
          !$omp do schedule(runtime) &
          !$omp    private(pGrad, k)
-#endif
          do iEdge=1,nEdgesOwned
             ! compute the pressure gradient to be applied at the edge
             pGrad = zonalSshGrad * cos(angleEdge(iEdge)) + meridSshGrad * sin(angleEdge(iEdge))
@@ -579,10 +508,8 @@ contains
                tend(k,iEdge) = tend(k,iEdge) - gravity * edgeMask(k,iEdge) * pGrad
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
 
       case default
 
@@ -612,6 +539,464 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_pressure_grad_tend!}}}
+
+   subroutine ocn_vel_pressure_grad_tend_gpu(ssh, nonhydrostaticPressure, &
+                                  pressure, surfacePressure, &
+                                  montgomeryPotential, zMid, &
+                                  density, potentialDensity, &
+                                  indxT, indxS, tracers, &
+                                  thermExpCoeff, salineContractCoeff, &
+                                  tend, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         indxT,              &!< [in] tracer array index for temperature
+         indxS                !< [in] tracer array index for salt
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         ssh,                &!< [in] sea surface height
+         surfacePressure      !< [in] surface pressure
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         pressure,            &!< [in] Pressure field
+         montgomeryPotential, &!< [in] Mongomery potential
+         zMid,                &!< [in] z-coordinate at layer mid-depth
+         density,             &!< [in] density
+         potentialDensity      !< [in] potentialDensity
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         nonhydrostaticPressure     !< Input: nonhydrostatic pressure correction
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         thermExpCoeff,       &!< [in] in situ thermal expansion coeff
+         salineContractCoeff   !< [in] in situ saline contraction coeff
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] array of active tracers
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::           &
+         iEdge, iCell, k,  &! loop indices for edge, cell, vertical loops
+         cell1, cell2,     &! neighbor cell indices across edge
+         kMin, kMax         ! shallowest and deepest active layer
+
+      real (kind=RKIND) :: &
+         invdcEdge,        &! temporary for 1/dcEdge
+         pGrad,            &! vertically integrated pgrad
+         alpha, beta,      &! T,S expansion factors for Jacobian
+         Area,             &! Area for Jacobian calculation
+         zStar, zC, zGamma,&! z coordinate combination for Jacobian
+         rhoL, rhoR,       &! density neighbors for Jacobian
+         TL, TR,           &! temperature neighbors for Jacobian
+         SL, SR             ! salinity neighbors for Jacobian
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         JacobianDxDs,     &! Jacobian in density * Dx * DS
+         JacobianTz,       &! Jacobian associated with temperature
+         JacobianSz         ! Jacobian associated with salinity
+
+      real (kind=RKIND) :: &
+         meridSshGrad,     &! config_meridional_ssh_grad
+         zonalSshGrad       ! config_zonal_ssh_grad
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** set error code and exit if turned off
+      !*** start timer if turned on
+
+      err = 0
+      if (pgradOff) return
+      call mpas_timer_start("pressure grad gpu")
+
+      meridSshGrad = config_meridional_ssh_grad
+      zonalSshGrad = config_zonal_ssh_grad
+
+      !*** Compute pGrad based on method selected
+      select case (pGradType)
+
+      case (pGradTypeSSHgrad)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypeSSHgrad"
+         ! pressure for sea surface height = - g grad ssh
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            do k=kMin,kMax
+               tend(k,iEdge) = tend(k,iEdge) - &
+                               edgeMask(k,iEdge)*invdcEdge* &
+                               (  gravity*(ssh(cell2) - ssh(cell1)) &
+                                + density0Inv*(  surfacePressure(cell2) &
+                                               - surfacePressure(cell1)) )
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      case (pGradTypePZmid)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypePZmid"
+         ! pressure for generalized coordinates
+         ! -1/density_0 (grad p_k + density g grad z_k^{mid})
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            do k=kMin,kMax
+               tend(k,iEdge) = tend(k,iEdge) + &
+                               edgeMask(k,iEdge)*invdcEdge*( &
+                               - density0Inv*(pressure(k,cell2) - &
+                                              pressure(k,cell1)) &
+                               - gdensity0Inv*0.5_RKIND* &
+                                 (density(k,cell1)+density(k,cell2))* &
+                                 (zMid(k,cell2)-zMid(k,cell1)))
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      case (pGradTypeMontPot)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypeMontPot"
+         ! For pure isopycnal coordinates, this is just grad(M),
+         ! the gradient of Montgomery Potential
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            do k=kMin,kMax
+               tend(k,iEdge) = tend(k,iEdge) + &
+                               edgeMask(k,iEdge)*invdcEdge* ( &
+                               - (montgomeryPotential(k,cell2) - &
+                                  montgomeryPotential(k,cell1)))
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      case (pGradTypeMontPotDens)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypeMontPotDens"
+         ! This formulation has not been extensively tested and is not
+         ! supported at this time.
+
+         ! This is -grad(M)+p grad(1/rho)
+         ! Where rho is the potential density.
+         ! See Bleck (2002) equation 1, and last equation in Appendix A.
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            do k=kMin,kMax
+               tend(k,iEdge) = tend(k,iEdge) + &
+                               edgeMask(k,iEdge)*invdcEdge*( &
+                               - (montgomeryPotential(k,cell2) - &
+                                  montgomeryPotential(k,cell1)) &
+                               +  0.5_RKIND*(pressure(k,cell1) + &
+                                             pressure(k,cell2))* &
+                              ( 1.0_RKIND/potentialDensity(k,cell2) &
+                              - 1.0_RKIND/potentialDensity(k,cell1)))
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      case (pGradTypeJacobDens)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypeJacobDens"
+         allocate(JacobianDxDs(nVertLevels,nEdgesAll))
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax, pGrad, &
+         !$omp            Area, zStar, zC, zGamma, rhoL, rhoR)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            ! Compute the density-Jacobian in common_level form.
+            ! See Shchepetkin and McWilliams (2003) Ocean Modeling,
+            !   sections 2-4
+
+            JacobianDxDs(kMin,iEdge) = 0.0_RKIND
+
+            do k=kMin+1,kMax
+
+               ! eqn 2.7 in Shchepetkin and McWilliams (2003)
+               ! Note delta x was removed.  It must be an error in the
+               ! paper, ! as it makes the units incorrect.
+               Area = 0.5_RKIND*(zMid(k-1,cell1) - zMid(k,cell1) + &
+                                 zMid(k-1,cell2) - zMid(k,cell2))
+
+               ! eqn 2.8
+               zStar = ( zMid(k-1,cell2)*zMid(k-1,cell1) - &
+                         zMid(k  ,cell2)*zMid(k  ,cell1) )/ &
+                       ( zMid(k-1,cell2)-zMid(k  ,cell2) + &
+                         zMid(k-1,cell1)-zMid(k,cell1))
+
+               ! eqn 3.2
+               zC = 0.25_RKIND*(zMid(k,cell1) + zMid(k-1,cell1) + &
+                                zMid(k,cell2) + zMid(k-1,cell2))
+
+               ! eqn 4.1
+               zGamma = (1.0_RKIND - pGradLvlWgt)*zStar + pGradLvlWgt*zC
+
+               rhoL = (density(k  ,cell1)*(zMid(k-1,cell1)-zGamma) + &
+                       density(k-1,cell1)*(zGamma-zMid(k  ,cell1)))/ &
+                      (zMid(k-1,cell1) - zMid(k,cell1))
+               rhoR = (density(k  ,cell2)*(zMid(k-1,cell2)-zGamma) +  &
+                       density(k-1,cell2)*(zGamma-zMid(k  ,cell2)))/ &
+                      (zMid(k-1,cell2) - zMid(k,cell2))
+
+               ! eqn 2.6 in Shchepetkin and McWilliams (2003)
+               JacobianDxDs(k,iEdge) = Area * (rhoL - rhoR)
+            end do
+
+            ! In the top layer, use pressure for generalized coordinates
+            ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
+            k = kMin
+            pGrad = edgeMask(k,iEdge)*invdcEdge*( &
+                    - density0Inv*(pressure(k,cell2) - &
+                                   pressure(k,cell1)) &
+                    - gdensity0Inv*0.5_RKIND* &
+                      (density(k,cell1)+density(k,cell2))* &
+                      (zMid(k,cell2)- zMid(k,cell1) ) )
+
+            tend(k,iEdge) = tend(k,iEdge) + pGrad
+
+            do k=kMin+1,kMax
+
+               ! note JacobianDxDs includes negative sign, so
+               ! pGrad is - g/rho_0 dP/dx
+
+               pGrad = pGrad + gdensity0Inv*JacobianDxDs(k,iEdge)*invdcEdge
+
+               tend(k,iEdge) = tend(k,iEdge) + pGrad
+
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+        deallocate(JacobianDxDs)
+
+     case (pGradTypeJacobTS)
+
+         allocate(JacobianDxDs(nVertLevels,nEdgesAll), &
+                  JacobianTz(nVertLevels,nEdgesAll), &
+                  JacobianSz(nVertLevels,nEdgesAll))
+
+!$acc data present(cellsOnEdge,dcEdge,minLevelEdgeBot,maxLevelEdgeTop,edgeMask, &
+!$acc              JacobianTz,JacobianSz,zMid,tracers,pressure,density,tend, &
+!$acc              thermExpCoeff,salineContractCoeff) &
+!$acc      create(JacobianDxDs,JacobianTz,JacobianSz)
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(cell1, cell2, invdcEdge, k, kMin, kMax, alpha, beta, &
+         !$omp         TL, TR, SL, SR, Area, zStar, zC, zGamma, pGrad)
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,invdcEdge,kMin,kMax,pGrad,alpha,beta)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
+
+            ! compute J(T,z) and J(S,z)
+            ! in Shchepetkin and McWilliams (2003) (7.16)
+
+            JacobianTz(kMin,iEdge) = 0.0_RKIND
+            JacobianSz(kMin,iEdge) = 0.0_RKIND
+
+!$acc loop vector private(Area,zStar,zC,zGamma,TL,TR,SL,SR)
+            do k=kMin+1,kMax
+               ! eqn 2.7 in Shchepetkin and McWilliams (2003)
+               ! Note delta x was removed.  It must be an error in the
+               ! paper, ! as it makes the units incorrect.
+               Area = 0.5_RKIND*(zMid(k-1,cell1) - zMid(k,cell1) + &
+                                 zMid(k-1,cell2) - zMid(k,cell2))
+               ! eqn 2.8
+               zStar = ( zMid(k-1,cell2)*zMid(k-1,cell1) - &
+                         zMid(k  ,cell2)*zMid(k  ,cell1) )/ &
+                       ( zMid(k-1,cell2)-zMid(k  ,cell2) + &
+                         zMid(k-1,cell1)-zMid(k,cell1))
+               ! eqn 3.2
+               zC = 0.25_RKIND*(zMid(k,cell1) + zMid(k-1,cell1) + &
+                                zMid(k,cell2) + zMid(k-1,cell2))
+               ! eqn 4.1
+               zGamma = (1.0_RKIND - pGradLvlWgt)*zStar + pGradLvlWgt*zC
+
+               TL = (tracers(indxT,k  ,cell1)*(zMid(k-1,cell1)-zGamma) + &
+                     tracers(indxT,k-1,cell1)*(zGamma-zMid(k  ,cell1)))/ &
+                    (zMid(k-1,cell1) - zMid(k,cell1))
+               TR = (tracers(indxT,k  ,cell2)*(zMid(k-1,cell2)-zGamma) +  &
+                     tracers(indxT,k-1,cell2)*(zGamma-zMid(k  ,cell2)))/ &
+                    (zMid(k-1,cell2) - zMid(k,cell2))
+
+               SL = (tracers(indxS,k  ,cell1)*(zMid(k-1,cell1)-zGamma) + &
+                     tracers(indxS,k-1,cell1)*(zGamma-zMid(k  ,cell1)))/ &
+                    (zMid(k-1,cell1) - zMid(k,cell1))
+               SR = (tracers(indxS,k  ,cell2)*(zMid(k-1,cell2)-zGamma) +  &
+                     tracers(indxS,k-1,cell2)*(zGamma-zMid(k  ,cell2)))/ &
+                    (zMid(k-1,cell2) - zMid(k,cell2))
+
+               ! eqn 2.6 in Shchepetkin and McWilliams (2003)
+               JacobianTz(k,iEdge) = Area*(TL - TR)
+               JacobianSz(k,iEdge) = Area*(SL - SR)
+            end do
+
+            ! In top layer, use pressure for generalized coordinates
+            ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
+
+            pGrad = edgeMask(kMin,iEdge)*invdcEdge*( &
+                    - density0Inv*(pressure(kMin,cell2) - &
+                                   pressure(kMin,cell1)) &
+                    - gdensity0Inv*0.5_RKIND* &
+                      (density(kMin,cell1)+density(kMin,cell2))* &
+                      (zMid(kMin,cell2)- zMid(kMin,cell1) ) )
+
+            tend(kMin,iEdge) = tend(kMin,iEdge) + pGrad
+
+!$acc loop seq
+            do k=kMin+1,kMax
+               ! Average alpha and beta over four data points of the Jacobian cell.
+               ! Note that thermExpCoeff and salineContractCoeff include a 1/density factor,
+               ! so must multiply by density here.
+               alpha = 0.25_RKIND*( &
+                       density(k  ,cell1)*thermExpCoeff (k  ,cell1) &
+                     + density(k-1,cell1)*thermExpCoeff (k-1,cell1) &
+                     + density(k  ,cell2)*thermExpCoeff (k  ,cell2) &
+                     + density(k-1,cell2)*thermExpCoeff (k-1,cell2) )
+               beta  = 0.25_RKIND*( &
+                       density(k  ,cell1)*salineContractCoeff(k  ,cell1) &
+                     + density(k-1,cell1)*salineContractCoeff(k-1,cell1) &
+                     + density(k  ,cell2)*salineContractCoeff(k  ,cell2) &
+                     + density(k-1,cell2)*salineContractCoeff(k-1,cell2) )
+
+               ! Shchepetkin and McWilliams (2003) (7.16)
+               JacobianDxDs(k,iEdge) = -alpha*JacobianTz(k,iEdge) + &
+                                         beta*JacobianSz(k,iEdge)
+
+               ! note JacobianDxDs includes negative sign, so
+               ! pGrad is - g/rho_0 dP/dx
+
+               pGrad = pGrad + gdensity0Inv * JacobianDxDs(k,iEdge) * invdcEdge
+
+               tend(k,iEdge) = tend(k,iEdge) + pGrad
+
+            end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+
+!$acc end data
+
+         deallocate(JacobianDxDs, JacobianTz, JacobianSz)
+
+      case (pGradTypeConstForced)
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu pGradTypeConstForced"
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp    private(pGrad, k)
+         do iEdge=1,nEdgesOwned
+            ! compute the pressure gradient to be applied at the edge
+            pGrad = zonalSshGrad * cos(angleEdge(iEdge)) + meridSshGrad * sin(angleEdge(iEdge))
+
+            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+               tend(k,iEdge) = tend(k,iEdge) - gravity * edgeMask(k,iEdge) * pGrad
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      case default
+
+         !*** error already trapped during init
+
+      end select ! pGradType
+
+      if(config_enable_nonhydrostatic_mode) then
+!NV!     !!! NOT EXECUTING !!!
+         write(*,*) "ocn_vel_pressure_grad_tend_gpu config_enable_nonhydrostatic_mode"
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            
+            do k=1,maxLevelEdgeTop(iEdge)
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                 - ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) )
+            end do 
+         end do
+         !$omp end do
+         !$omp end parallel
+      endif
+
+      call mpas_timer_stop("pressure grad gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_pressure_grad_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -663,8 +663,9 @@ contains
         block_ptr => domain % blocklist
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
 
-        call mpas_pool_get_array(forcingPool, 'coastalSmoothingFactor', &
+        call mpas_pool_get_array_gpu(forcingPool, 'coastalSmoothingFactor', &
                                                coastalSmoothingFactor)
+!$acc update host(coastalSmoothingFactor)
 
         ! Set up coastal ssh smoothing
         allocate(sshSmoothed(nCellsAll))
@@ -679,6 +680,7 @@ contains
         else
            coastalSmoothingFactor(:) = 1.0_RKIND
         endif
+!$acc update device(coastalSmoothingFactor)
 
         ! Setup Alarm for SAL
         alarmTime = mpas_get_clock_time(domain % clock, MPAS_START_TIME, ierr=err)

--- a/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -50,6 +50,7 @@ module ocn_vel_tidal_potential
 
    public :: ocn_vel_tidal_potential_tend, &
              ocn_compute_tidal_potential_forcing, &
+             ocn_compute_tidal_potential_forcing_gpu, &
              ocn_vel_tidal_potential_init, &
              tidal_constituent_factors
 
@@ -157,15 +158,8 @@ contains
       err = 0
       if (tidalPotentialOff) return
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
-      !$acc            tidalPotEta, ssh, surfacePressure, tend, ssh_sal) &
-      !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
-#else
       !$omp parallel do schedule(runtime) &
       !$omp    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
-#endif
       do iEdge=1,nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -183,9 +177,7 @@ contains
                             edgeMask(k,iEdge)*potentialGrad
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end parallel do
-#endif
 
    end subroutine ocn_vel_tidal_potential_tend!}}}
 
@@ -266,6 +258,73 @@ contains
       end do
 
    end subroutine ocn_compute_tidal_potential_forcing!}}}
+
+   subroutine ocn_compute_tidal_potential_forcing_gpu(err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, jCon,  &! loop indices for cell, constituent loops
+         conType        ! id for constituent type
+
+      real (kind=RKIND) :: &
+         lon,&
+         tArg,&
+         ramp,&
+         t, &
+         nCycles,&
+         period
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set error flag and return early if not turned on
+      err = 0
+      if (tidalPotentialOff) return
+!NV!  !!! NOT EXECUTING !!!
+      write(*,*) "ocn_compute_tidal_potential_forcing_gpu NOT EXECUTING"
+
+      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotRamp)
+      t = daysSinceStartOfSim*86400.0_RKIND
+
+      do iCell = 1, nCellsAll
+         tidalPotEta(iCell) = 0.0_RKIND
+      end do
+
+      !*** Compute eta by summing all constituent contributions
+      do jCon = 1, nTidalConstituents
+         period = 2.0_RKIND*pii/tidalConstituentFrequency(jCon)
+         nCycles = real(int(t/period),RKIND)
+         targ = tidalConstituentFrequency(jCon)*(t - nCycles*period) + &
+                tidalConstituentNodalPhase(jCon) + &
+                tidalConstituentAstronomical(jCon)
+         conType = tidalConstituentType(jCon)
+         do iCell = 1, nCellsAll
+           lon = lonCell(iCell)
+           tidalPotEta(iCell) = tidalPotEta(iCell) + &
+                         ramp * tidalConstituentAmplitude(jCon) &
+                              * tidalConstituentNodalAmplitude(jCon) &
+                              * tidalConstituentLoveNumbers(jCon) &
+                              * latitudeFunction(iCell,conType+1) &
+                              * cos(tArg  + real(conType,RKIND)*lon)
+         end do
+        
+      end do
+
+   end subroutine ocn_compute_tidal_potential_forcing_gpu!}}}
 
 
 !***********************************************************************
@@ -353,38 +412,41 @@ contains
 
          call mpas_pool_get_dimension(block_ptr % dimensions, 'nCells', nCells)
 
-         call mpas_pool_get_array(meshPool, 'latCell', latCell)
+         call mpas_pool_get_array_gpu(meshPool, 'latCell', latCell)
 
-         call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', &
+         call mpas_pool_get_array_gpu(forcingPool, 'tidalPotentialEta', &
                                                 tidalPotEta)
 
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'nTidalPotentialConstituents', &
                              nTidalPotentialConstituents)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentAmplitude', & 
                              tidalConstituentAmplitude)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentFrequency', &
                             tidalConstituentFrequency)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentLoveNumbers', &
                             tidalConstituentLoveNumbers)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentNodalAmplitude', &
                             tidalConstituentNodalAmplitude)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentAstronomical', &
                             tidalConstituentAstronomical)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentNodalPhase', &
                             tidalConstituentNodalPhase)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialConstituentType', &
                             tidalConstituentType)
-         call mpas_pool_get_array(forcingPool, &
+         call mpas_pool_get_array_gpu(forcingPool, &
                             'tidalPotentialLatitudeFunction', &
                             latitudeFunction)
+!$acc update host(latCell,tidalPotEta,nTidalPotentialConstituents,tidalConstituentAmplitude,tidalConstituentFrequency,&
+!$acc             tidalConstituentLoveNumbers,tidalConstituentNodalAmplitude,tidalConstituentAstronomical,tidalConstituentNodalPhase,&
+!$acc             tidalConstituentType,latitudeFunction)
 
          call mpas_set_time(refTime, &
                dateTimeString=config_tidal_potential_reference_time)

--- a/src/shared/mpas_ocn_vel_vadv.F
+++ b/src/shared/mpas_ocn_vel_vadv.F
@@ -43,6 +43,7 @@ module ocn_vel_vadv
    !--------------------------------------------------------------------
 
    public :: ocn_vel_vadv_tend, &
+             ocn_vel_vadv_tend_gpu, &
              ocn_vel_vadv_init
 
    !--------------------------------------------------------------------
@@ -125,19 +126,10 @@ contains
 
 
       allocate(w_dudzTopEdge(nVertLevels+1,nEdgesAll))
-      !$acc enter data create(w_dudzTopEdge)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, w_dudzTopEdge, &
-      !$acc            vertAleTransportTop, normalVelocity, &
-      !$acc            layerThickEdgeFlux) &
-      !$acc    private(cell1, cell2, k, kmin, kmax, wAvg)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(cell1, cell2, k, kmin, kmax, wAvg)
-#endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -161,19 +153,11 @@ contains
          ! transport is zero at bottom
          w_dudzTopEdge(kmax+1,iEdge) = 0.0_RKIND
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
       ! Average w*du/dz from vertical interface to vertical middle of cell
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, tend, edgeMask, w_dudzTopEdge)&
-      !$acc    private(k, kmin, kmax)
-#else
       !$omp do schedule(runtime) &
       !$omp    private(k, kmin, kmax)
-#endif
       do iEdge = 1, nEdgesOwned
       kmin = minLevelEdgeBot(iEdge)
       kmax = maxLevelEdgeTop(iEdge)
@@ -183,12 +167,9 @@ contains
                                     w_dudzTopEdge(k+1,iEdge))
       enddo
       enddo
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !$acc exit data delete(w_dudzTopEdge)
       deallocate(w_dudzTopEdge)
 
       call mpas_timer_stop("vel vadv")
@@ -196,6 +177,123 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_vadv_tend!}}}
+
+   subroutine ocn_vel_vadv_tend_gpu(normalVelocity, layerThickEdgeFlux, &
+                                vertAleTransportTop, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity,     &!< [in] Horizontal velocity
+         layerThickEdgeFlux,     &!< [in] Layer thickness at edge
+         vertAleTransportTop  !< [in] Vertical velocity on top layer
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::       &
+         iEdge, k,     &! loop indices for edge, vertical loops
+         kmin, kmax,   &! shallowest and deepest active layer on edge
+         cell1, cell2   ! neighbor cell indices across edge
+
+      real (kind=RKIND) :: &
+         wAvg           ! ALE transport velocity across top edge
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         w_dudzTopEdge  ! w*du/dz at top of edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set return error code and return early if not turned on
+      !*** Start relevant timer
+
+      err = 0
+      if (velVadvOff) return
+      call mpas_timer_start("vel vadv gpu")
+
+
+      allocate(w_dudzTopEdge(nVertLevels+1,nEdgesAll))
+
+!$acc data present(cellsOnEdge,minLevelEdgeBot,maxLevelEdgeTop,edgeMask,&
+!$acc              vertAleTransportTop,normalVelocity,layerThickEdgeFlux,tend) &
+!$acc      create(w_dudzTopEdge)
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, k, kmin, kmax, wAvg)
+!$acc parallel
+!$acc loop gang worker private(cell1,cell2,kmin,kmax)
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         kmin  = minLevelEdgeBot(iEdge)
+         kmax  = maxLevelEdgeTop(iEdge)
+
+         w_dudzTopEdge(kmin,iEdge) = 0.0_RKIND ! flux is zero at top
+!$acc loop vector private(wAvg)
+         do k = kmin+1,kmax
+            ! Average w from cell center to edge
+            wAvg = 0.5_RKIND*(vertAleTransportTop(k,cell1) + &
+                              vertAleTransportTop(k,cell2))
+            ! compute dudz at vertical interface with first order derivative.
+            w_dudzTopEdge(k,iEdge) = wAvg* &
+                                     (normalVelocity(k-1,iEdge) - &
+                                      normalVelocity(k,  iEdge))/ &
+                         (0.5_RKIND*(layerThickEdgeFlux(k-1,iEdge) + &
+                                     layerThickEdgeFlux(k  ,iEdge)))
+         end do
+         ! transport is zero at bottom
+         w_dudzTopEdge(kmax+1,iEdge) = 0.0_RKIND
+      end do
+!$acc end parallel
+      !$omp end do
+
+      ! Average w*du/dz from vertical interface to vertical middle of cell
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kmin, kmax)
+!$acc parallel
+!$acc loop gang worker private(kmin,kmax)
+      do iEdge = 1, nEdgesOwned
+      kmin = minLevelEdgeBot(iEdge)
+      kmax = maxLevelEdgeTop(iEdge)
+!$acc loop vector
+      do k = kmin, kmax
+         tend(k,iEdge) = tend(k,iEdge) - edgeMask(k,iEdge)* &
+                         0.5_RKIND*(w_dudzTopEdge(k  ,iEdge) + &
+                                    w_dudzTopEdge(k+1,iEdge))
+      enddo
+      enddo
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(w_dudzTopEdge)
+
+      call mpas_timer_stop("vel vadv gpu")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_vadv_tend_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vertical_remap.F
+++ b/src/shared/mpas_ocn_vertical_remap.F
@@ -169,15 +169,8 @@ module ocn_vertical_remap
       !$omp end do
       !$omp end parallel
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(layerThickness, layerThickEdgeMean, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop, cellsOnEdge) &
-      !$acc    private(k, kmin, kmax, cell1, cell2)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
-#endif
       do iEdge = 1, nEdgesAll
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
@@ -195,10 +188,8 @@ module ocn_vertical_remap
                                           layerThicknessNew(k,cell2))
          end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       !$omp parallel
       !$omp do schedule(runtime) private(k, kTop, kBot, cell1, cell2)

--- a/src/shared/mpas_ocn_vmix.F
+++ b/src/shared/mpas_ocn_vmix.F
@@ -51,11 +51,15 @@ module ocn_vmix
    !--------------------------------------------------------------------
 
    public :: ocn_vmix_coefs, &
+             ocn_vmix_coefs_gpu, &
              ocn_vel_vmix_tend_implicit, &
+             ocn_vel_vmix_tend_implicit_gpu, &
              ocn_vertVel_vmix_tend_implicit, &
              ocn_tracer_vmix_tend_implicit, &
+             ocn_tracer_vmix_tend_implicit_gpu, &
              ocn_vmix_init, &
-             ocn_vmix_implicit
+             ocn_vmix_implicit, &
+             ocn_vmix_implicit_gpu
 
    !--------------------------------------------------------------------
    !
@@ -148,55 +152,144 @@ contains
 
       nEdges = nEdgesHalo( 1 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) present(vertViscTopOfEdge)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iEdge = 1, nEdges
       do k = 1, nVertLevels
          vertViscTopOfEdge(k, iEdge) = 0.0_RKIND
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsHalo( 1 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) present(vertDiffTopOfCell)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
-#endif
       do iCell = 1, nCells
       do k = 1, nVertLevels
          vertDiffTopOfCell(k, iCell) = 0.0_RKIND
       end do
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc update host(vertViscTopOfEdge, vertDiffTopOfCell)
-#endif
 
       call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err1, timeLevel)
       call ocn_vmix_coefs_redi_build(meshPool, statePool, err2, timeLevel)
 
-      err = ior(ior(err1, err2), err3)
+      err = ior(err1, err2)
 
-#ifdef MPAS_OPENACC
-      !$acc update device(vertDiffTopOfCell, vertViscTopOfCell, vertNonLocalFlux)
-#endif
    !--------------------------------------------------------------------
 
    end subroutine ocn_vmix_coefs!}}}
+
+   subroutine ocn_vmix_coefs_gpu(meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
+
+      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         statePool             !< Input/Output: state information
+
+      type (mpas_pool_type), intent(inout) :: &
+         forcingPool             !< Input/Output: forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: err1, err2, err3
+      integer :: timeLevel
+
+      integer :: iEdge, iCell, k, nEdges, nCells
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing coefficients
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+
+      nEdges = nEdgesHalo( 1 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+!$acc data present(vertViscTopOfEdge,vertDiffTopOfCell,k33,RediKappa)
+
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iEdge = 1, nEdges
+      do k = 1, nVertLevels
+         vertViscTopOfEdge(k, iEdge) = 0.0_RKIND
+      end do
+      end do
+!$acc end parallel
+
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsHalo( 1 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+
+!$acc parallel
+!$acc loop gang vector collapse(2)
+      do iCell = 1, nCells
+      do k = 1, nVertLevels
+         vertDiffTopOfCell(k, iCell) = 0.0_RKIND
+      end do
+      end do
+!$acc end parallel
+
+      !$omp end do
+      !$omp end parallel
+
+!NV!  ON CPU
+      call ocn_vmix_coefs_cvmix_build_gpu(meshPool, statePool, forcingPool, err1, timeLevel)
+      call ocn_vmix_coefs_redi_build_gpu(meshPool, statePool, err2, timeLevel)
+
+!$acc end data
+      err = ior(err1, err2)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vmix_coefs_gpu!}}}
 
 !***********************************************************************
 !
@@ -270,18 +363,9 @@ contains
 
       allocate(bTemp(nVertLevels),C(nVertLevels),rTemp(nVertLevels))
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(bTemp, C, rTemp)
-
-      !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell) &
-      !$acc    private(Nsurf, N, cell1, cell2, edgeThicknessTotal, A, bTemp, C, m, rTemp, k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(Nsurf, N, cell1, cell2, edgeThicknessTotal, k, A, bTemp, C, m, rTemp)
-#endif
       do iEdge = 1, nEdgesOwned
         Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
@@ -354,14 +438,8 @@ contains
          end if ! N=Nsurf, i.e. single layer
         end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(bTemp, C, rTemp)
-#endif
 
       deallocate(bTemp,C,rTemp)
 
@@ -440,17 +518,8 @@ contains
 
       allocate(bTemp(nVertLevels),C(nVertLevels),rTemp(nVertLevels))
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(bTemp, C, rTemp)
-
-      !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell) &
-      !$acc    private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
-#endif
       do iEdge = 1, nEdgesOwned
         N = maxLevelEdgeTop(iEdge)
         Nsurf = minLevelEdgeBot(iEdge)
@@ -508,20 +577,156 @@ contains
          end if ! N=Nsurf, i.e. single layer
         end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(bTemp, C, rTemp)
-#endif
 
       deallocate(bTemp,C,rTemp)
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_vmix_tend_implicit!}}}
+
+   subroutine ocn_vel_vmix_tend_implicit_gpu(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
+                                         layerThickEdgeMean, normalVelocity, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         kineticEnergyCell        !< Input: kinetic energy at cell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertViscTopOfEdge !< Input: vertical mixing coefficients
+
+      real (kind=RKIND), intent(in) :: &
+         dt            !< Input: time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness !< Input: thickness at cell center
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeMean !< Input: mean thickness at edge
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         normalVelocity             !< Input: velocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k, cell1, cell2, N, Nsurf
+
+      real (kind=RKIND), dimension(:), allocatable :: bTemp, C, rTemp
+      real (kind=RKIND) :: A, m
+
+      err = 0
+
+      if(.not.velVmixOn) return
+
+      allocate(bTemp(nVertLevels),C(nVertLevels),rTemp(nVertLevels))
+
+!$acc data present(maxLevelEdgeTop,minLevelEdgeBot,cellsOnEdge,&
+!$acc              normalVelocity,vertViscTopOfEdge,kineticEnergyCell,layerThickEdgeMean)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
+!$acc parallel
+!$acc loop gang worker private(bTemp,C,rTemp,N,Nsurf,cell1,cell2,A,m)
+      do iEdge = 1, nEdgesOwned
+        N = maxLevelEdgeTop(iEdge)
+        Nsurf = minLevelEdgeBot(iEdge)
+        if (N .gt. 0) then
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+
+         ! one active layer
+         if (N .eq. Nsurf) then
+            normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
+                / (1.0_RKIND + dt*implicitBottomDragCoef &
+                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
+         else
+
+           ! tridiagonal matrix algorithm
+           C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
+                      / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
+                      / layerThickEdgeMean(Nsurf,iEdge)
+           bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
+           rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
+
+           ! first pass: set the coefficients
+!$acc loop seq
+           do k = Nsurf+1, N-1
+              A        = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
+                     / (layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)) &
+                     / layerThickEdgeMean(k,iEdge)
+              m        = A/bTemp(k-1)
+              C(k)     = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
+                     / (layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k+1,iEdge)) &
+                     / layerThickEdgeMean(k,iEdge)
+              bTemp(k) = 1.0_RKIND - A - C(k) - m*C(k-1)
+              rTemp(k) = normalVelocity(k,iEdge) - m*rTemp(k-1)
+           enddo
+
+           A = -2.0_RKIND*dt*vertViscTopOfEdge(N,iEdge) &
+             / (layerThickEdgeMean(N-1,iEdge) + layerThickEdgeMean(N,iEdge)) &
+             / layerThickEdgeMean(N,iEdge)
+           m = A/bTemp(N-1)
+
+           ! x(N) = rTemp(N) / bTemp(N)
+           ! Apply bottom drag boundary condition on the viscous term
+           ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
+           normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
+               / (1.0_RKIND - A + dt*implicitBottomDragCoef &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               - m*C(N-1))
+           ! second pass: back substitution
+!$acc loop seq
+           do k = N-1, Nsurf, -1
+              normalVelocity(k,iEdge) = (rTemp(k) - C(k)*normalVelocity(k+1,iEdge)) / bTemp(k)
+           enddo
+!$acc loop vector
+           do k = 1, Nsurf-1
+              normalVelocity(k,iEdge) = 0.0_RKIND
+           enddo
+!$acc loop vector
+           do k = N+1, nVertLevels
+              normalVelocity(k,iEdge) = 0.0_RKIND
+           enddo
+
+         end if ! N=Nsurf, i.e. single layer
+        end if
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      deallocate(bTemp,C,rTemp)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_vmix_tend_implicit_gpu!}}}
 
 !***********************************************************************
 !
@@ -748,17 +953,7 @@ contains
 
       allocate(bTemp(nVertLevels),C(nVertLevels),rTemp(nVertLevels))
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(bTemp, C, rTemp)
-      !$acc enter data create(bottomDrag)
-
-      !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell, bottomDrag) &
-      !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
-#else
       !$omp do schedule(runtime)
-#endif
       do iEdge = 1, nEdgesOwned
         Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
@@ -817,14 +1012,8 @@ contains
          end if ! one active layer
         end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(bTemp, C, rTemp)
-      !$acc exit data delete(bottomDrag)
-#endif
       deallocate(bTemp,C,rTemp)
 
    !--------------------------------------------------------------------
@@ -934,11 +1123,6 @@ contains
 
       allocate(bTemp(nVertLevels),C(nVertLevels),rTemp(nVertLevels))
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(bTemp, C, rTemp)
-      !$acc enter data create(ssh, bottomDrag)
-#endif
-
       ! Compute bottomDrag (Manning roughness) induced by vegetation
       if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
         do iCell = 1, nCellsOwned
@@ -970,16 +1154,7 @@ contains
         enddo
       endif
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(vegetationManning)
-
-      !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell, bottomDrag, vegetationManning, ssh, bottomDepth) &
-      !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
-#else
       !$omp do schedule(runtime)
-#endif
       do iEdge = 1, nEdgesOwned
         Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
@@ -1055,14 +1230,8 @@ contains
          endif ! one active layer
         end if
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(bTemp, C, rTemp)
-      !$acc exit data delete(ssh, bottomDrag, vegetationManning)
-#endif
       deallocate(bTemp,C,rTemp)
 
    !--------------------------------------------------------------------
@@ -1147,16 +1316,8 @@ contains
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(bTemp, C, rTemp)
-
-      !$acc parallel loop present(maxLevelCell, minLevelCell, vertDiffTopOfCell, &
-      !$acc    layerThickness, tracers, tracerGroupSurfaceFlux, vertNonLocalFlux) &
-      !$acc    private(Nsurf, N, A, bTemp, C, m, rTemp, iTracer, k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(Nsurf, N, A, bTemp, C, m, rTemp, iTracer, k)
-#endif
       do iCell = 1, nCellsOwned
          Nsurf = minLevelCell(iCell)
          N = maxLevelCell(iCell)
@@ -1225,14 +1386,9 @@ contains
          tracers(:,N+1:nVertLevels,iCell) = -1e34
 
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(bTemp, C, rTemp)
-#endif
       call mpas_timer_stop('vmix tracers tend imp loop')
 
       deallocate(bTemp, C, rTemp)
@@ -1240,6 +1396,177 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_vmix_tend_implicit!}}}
+
+   subroutine ocn_tracer_vmix_tend_implicit_gpu(dt, vertDiffTopOfCell, layerThickness, tracers, &
+                  vertNonLocalFlux, tracerGroupSurfaceFlux, config_cvmix_kpp_nonlocal_with_implicit_mix, &
+                  err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertDiffTopOfCell !< Input: vertical mixing coefficients
+
+      real (kind=RKIND), intent(in) :: &
+         dt            !< Input: time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness, &             !< Input: thickness at cell center
+         tracerGroupSurfaceFlux        !< Input: surface flux for tracers nonlocal computation
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         vertNonLocalFlux             !non local flux at interfaces
+
+      logical, intent(in) :: config_cvmix_kpp_nonlocal_with_implicit_mix
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tracers        !< Input: tracers
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, iTracer, num_tracers, N, Nsurf
+
+      real (kind=RKIND), dimension(:), allocatable :: bTemp, C
+      real (kind=RKIND), dimension(:,:), allocatable :: rTemp
+      real (kind=RKIND) :: A, m
+
+      err = 0
+
+      if(.not.tracerVmixOn) return
+
+      num_tracers = size(tracers, dim=1)
+
+      allocate(bTemp(nVertLevels),C(nVertLevels))
+      allocate(rTemp(num_tracers,nVertLevels))
+
+      call mpas_timer_start('vmix tracers tend imp loop gpu', .false.)
+
+!$acc data present(minLevelCell,maxLevelCell,&
+!$acc              vertDiffTopOfCell,layerThickness,tracerGroupSurfaceFlux,vertNonLocalFlux,tracers)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(Nsurf, N, A, bTemp, C, m, rTemp, iTracer, k)
+!$acc parallel
+!$acc loop gang worker private(Nsurf,N,C,bTemp,rTemp,A,m)
+      do iCell = 1, nCellsOwned
+         Nsurf = minLevelCell(iCell)
+         N = maxLevelCell(iCell)
+
+         ! tridiagonal matrix algorithm
+         C(Nsurf) = -2.0_RKIND*dt*vertDiffTopOfCell(Nsurf+1,iCell) &
+                    / (layerThickness(Nsurf,iCell) + layerThickness(Nsurf+1,iCell)) &
+                    / layerThickness(Nsurf,iCell)
+         bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
+         if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
+            write(*,*) "config_cvmix_kpp_nonlocal_with_implicit_mix NOT EXECUTING"
+            do iTracer = 1, num_tracers
+               rTemp(iTracer,Nsurf) = tracers(iTracer,Nsurf,iCell) + dt*tracerGroupSurfaceFlux(iTracer,iCell) &
+                    * (-vertNonLocalFlux(1, Nsurf+1,iCell) )/ layerThickness(Nsurf,iCell)
+            enddo
+         else
+!$acc loop vector
+            do iTracer = 1, num_tracers
+               rTemp(iTracer,Nsurf) = tracers(iTracer,Nsurf,iCell)
+            enddo
+         endif
+
+         ! first pass: set the coefficients
+!$acc loop seq
+         do k = Nsurf+1, N-1
+            A        = -2.0_RKIND*dt*vertDiffTopOfCell(k,iCell) &
+                   / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) / layerThickness(k,iCell)
+            m        = A/bTemp(k-1)
+            C(k)     = -2.0_RKIND*dt*vertDiffTopOfCell(k+1,iCell) &
+                   / (layerThickness(k,iCell) + layerThickness(k+1,iCell)) / layerThickness(k,iCell)
+            bTemp(k) = 1.0_RKIND - A - C(k) - m*C(k-1)
+            if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
+               write(*,*) "config_cvmix_kpp_nonlocal_with_implicit_mix NOT EXECUTING"
+               do iTracer = 1, num_tracers
+                  rTemp(iTracer,k) = tracers(iTracer,k,iCell) + dt*tracerGroupSurfaceFlux(iTracer,iCell) &
+                       * (vertNonLocalFlux(1,k,iCell) - vertNonLocalFlux(1,k+1,iCell)) / layerThickness(k,iCell) &
+                       - m*rTemp(iTracer,k-1)
+               enddo
+            else
+!$acc loop vector
+               do iTracer = 1, num_tracers
+                  rTemp(iTracer,k) = tracers(iTracer,k,iCell) - m*rTemp(iTracer,k-1)
+               enddo
+            endif
+         enddo
+
+         A = -2.0_RKIND*dt*vertDiffTopOfCell(N,iCell) &
+           / (layerThickness(N-1,iCell) + layerThickness(N,iCell)) / layerThickness(N,iCell)
+         m = A/bTemp(N-1)
+
+         ! x(N) = rTemp(N) / bTemp(N)
+         if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
+            write(*,*) "config_cvmix_kpp_nonlocal_with_implicit_mix NOT EXECUTING"
+            do iTracer = 1, num_tracers
+               tracers(iTracer,N,iCell) = (tracers(iTracer,N,iCell) + dt*tracerGroupSurfaceFlux(iTracer,iCell) &
+                      * vertNonLocalFlux(1,N,iCell) / layerThickness(N,iCell) &
+                      - m*rTemp(iTracer,N-1)) / (1.0_RKIND - A - m*C(N-1))
+            enddo
+         else
+!$acc loop vector
+            do iTracer = 1, num_tracers
+               tracers(iTracer,N,iCell) = (tracers(iTracer,N,iCell) - m*rTemp(iTracer,N-1)) &
+                      / (1.0_RKIND - A - m*C(N-1))
+            enddo
+         endif
+         ! second pass: back subsititution
+!$acc loop seq
+         do k = N-1, Nsurf, -1
+!$acc loop vector
+            do iTracer = 1, num_tracers
+               tracers(iTracer,k,iCell) = (rTemp(iTracer,k) - C(k)*tracers(iTracer,k+1,iCell)) / bTemp(k)
+            enddo
+         enddo
+!$acc loop vector collapse(2)
+         do k = 1, Nsurf-1
+         do iTracer = 1, num_tracers
+         tracers(iTracer,k,iCell) = -1e34
+         enddo
+         enddo
+!$acc loop vector collapse(2) 
+         do k = N+1, nVertLevels
+         do iTracer = 1, num_tracers
+         tracers(iTracer,k,iCell) = -1e34
+         enddo
+         enddo
+      end do
+!$acc end parallel
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop('vmix tracers tend imp loop gpu')
+
+      deallocate(bTemp, C, rTemp)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_vmix_tend_implicit_gpu!}}}
 
 !***********************************************************************
 !
@@ -1304,14 +1631,8 @@ contains
       if ( config_use_cvmix ) then
 
          call mpas_timer_start('CVMix avg', .false.)
-#ifdef MPAS_OPENACC
-         !$acc parallel loop present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc    vertViscTopOfCell, vertViscTopOfEdge) &
-         !$acc    private(cell1, cell2, k, Nsurf, N)
-#else
          !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, k, Nsurf, N)
-#endif
          do iEdge=1,nEdgesOwned
             Nsurf = minLevelEdgeBot(iEdge)
             N = maxLevelEdgeTop(iEdge)
@@ -1319,17 +1640,12 @@ contains
             vertViscTopOfEdge(N+1:nVertLevels, iEdge) = 0.0_RKIND
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-#ifdef MPAS_OPENACC
-            !$acc loop vector
-#endif
             do k=Nsurf, N
                vertViscTopOfEdge(k,iEdge) = 0.5_RKIND*(vertViscTopOfCell(k,cell2)+vertViscTopOfCell(k,cell1))
             end do
          end do
-#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-#endif
          call mpas_timer_stop('CVMix avg')
       endif
 
@@ -1337,9 +1653,6 @@ contains
       !  Implicit vertical solve for momentum
       !
       call mpas_timer_start('vmix solve momentum', .false.)
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThickness, normalVelocity)
-#endif
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
@@ -1359,9 +1672,6 @@ contains
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       end if
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout(normalVelocity)
-#endif
       call mpas_timer_stop('vmix solve momentum')
       !
       !  If nonhydrostatic is enabled compute vertical velocity diffusion
@@ -1381,19 +1691,12 @@ contains
 
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
             call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroup, timeLevel)
-#ifdef MPAS_OPENACC
-            !$acc enter data copyin(tracersGroup)
-#endif
             ! store tracers
             if (trim(groupItr % memberName) == 'activeTracers') then
                if (config_compute_active_tracer_budgets) then
                   num_tracers = size(activeTracerVertMixTendency, dim=1)
-#ifdef MPAS_OPENACC
-                  !$acc parallel loop gang vector collapse(3) present(activeTracerVertMixTendency, tracersGroup)
-#else
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, iTracer)
-#endif
                   do iCell = 1, nCellsOwned
                   do k = 1, nVertLevels
                   do iTracer = 1, num_tracers
@@ -1401,10 +1704,8 @@ contains
                   end do
                   end do
                   end do
-#ifndef MPAS_OPENACC
                   !$omp end do
                   !$omp end parallel
-#endif
                endif
             endif
 
@@ -1417,27 +1718,17 @@ contains
                   call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), &
                           tracerGroupSurfaceFlux)
                endif
-#ifdef MPAS_OPENACC
-               !$acc enter data copyin(tracerGroupSurfaceFlux)
-#endif
 
                call ocn_tracer_vmix_tend_implicit(dt, vertDiffTopOfCell, layerThickness, tracersGroup, &
                         vertNonLocalFlux, tracerGroupSurfaceFlux,  &
                         config_cvmix_kpp_nonlocal_with_implicit_mix, err)
-#ifdef MPAS_OPENACC
-               !$acc exit data delete(tracerGroupSurfaceFlux)
-#endif
             end if
 
             ! difference tracers to compute influence of vertical mixing and divide by dt
             if (trim(groupItr % memberName) == 'activeTracers') then
                if (config_compute_active_tracer_budgets) then
-#ifdef MPAS_OPENACC
-                  !$acc parallel loop gang vector collapse(3) present(activeTracerVertMixTendency, tracersGroup)
-#else
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, iTracer)
-#endif
                   do iCell = 1, nCellsOwned
                   do k = 1, nVertLevels
                   do iTracer = 1, num_tracers
@@ -1446,31 +1737,208 @@ contains
                   end do
                   end do
                   end do
-#ifndef MPAS_OPENACC
                   !$omp end do
                   !$omp end parallel
-#endif
 
-#ifdef MPAS_OPENACC
-                  !$acc update host(activeTracerVertMixTendency)
-#endif
                endif
             endif
-
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout(tracersGroup)
-#endif
          end if
       end do
       call mpas_timer_stop('vmix solve tracers')
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(layerThickness)
-#endif
-
       call mpas_timer_stop('vmix imp')
 
    end subroutine ocn_vmix_implicit!}}}
+
+   subroutine ocn_vmix_implicit_gpu(dt, meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
+      real (kind=RKIND), intent(in) :: dt
+      type (mpas_pool_type), intent(in) :: meshPool
+      type (mpas_pool_type), intent(inout) :: statePool
+      type (mpas_pool_type), intent(inout) :: forcingPool
+      type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
+      integer, intent(out) :: err
+      integer, intent(in), optional :: timeLevelIn
+
+      type (mpas_pool_type), pointer :: tracersPool, tracersSurfaceFluxPool
+
+      integer :: iCell, timeLevel, k, cell1, cell2, iEdge, iTracer, num_tracers, nCells, nEdges, N, Nsurf
+      real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness, vertVelocityNonhydro
+      real (kind=RKIND), dimension(:,:), pointer :: tracerGroupSurfaceFlux
+      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
+      real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
+
+      type (mpas_pool_iterator_type) :: groupItr
+
+      character (len=StrKIND) :: modifiedGroupName
+      err = 0
+
+      call mpas_timer_start('vmix imp gpu')
+
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'vertVelocityNonhydro', vertVelocityNonhydro, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, timeLevel)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'bottomDrag', bottomDrag)
+
+      call mpas_timer_start('vmix coefs gpu', .false.)
+      call ocn_vmix_coefs_gpu(meshPool, statePool, forcingPool, scratchPool, err, timeLevel)
+      call mpas_timer_stop('vmix coefs gpu')
+
+      ! if using CVMix, then viscosity has to be averaged from cell centers to cell edges
+      if ( config_use_cvmix ) then
+
+         call mpas_timer_start('CVMix avg gpu', .false.)
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, k, Nsurf, N)
+!$acc parallel
+!$acc loop gang private(Nsurf,N,cell1,cell2)
+         do iEdge=1,nEdgesOwned
+            Nsurf = minLevelEdgeBot(iEdge)
+            N = maxLevelEdgeTop(iEdge)
+!$acc loop vector
+            do k=1,Nsurf-1
+               vertViscTopOfEdge(k, iEdge) = 0.0_RKIND
+            end do
+!$acc loop vector
+            do k=N+1,nVertLevels
+               vertViscTopOfEdge(k, iEdge) = 0.0_RKIND
+            end do
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+!$acc loop vector
+            do k=Nsurf, N
+               vertViscTopOfEdge(k,iEdge) = 0.5_RKIND*(vertViscTopOfCell(k,cell2)+vertViscTopOfCell(k,cell1))
+            end do
+         end do
+!$acc end parallel
+         !$omp end do
+         !$omp end parallel
+         call mpas_timer_stop('CVMix avg gpu')
+      endif
+
+
+      !
+      !  Implicit vertical solve for momentum
+      !
+      call mpas_timer_start('vmix solve momentum gpu', .false.)
+      if (config_use_implicit_bottom_drag_variable) then
+        write(*,*) "ocn_vmix_implicit_gpu config_use_implicit_bottom_drag_variable NOT EXECUTING"
+        call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+      else if (config_use_implicit_bottom_drag_variable_mannings.or. &
+               config_use_implicit_bottom_roughness) then
+        write(*,*) "ocn_vmix_implicit_gpu config_use_implicit_bottom_drag_variable_mannings NOT EXECUTING"
+        ! update bottomDrag via Cd=g*n^2*h^(-1/3)
+        call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
+          dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, &
+          ssh, err)
+      else if (config_Rayleigh_friction.or. &
+               config_Rayleigh_bottom_friction.or. &
+               config_Rayleigh_damping_depth_variable) then
+        write(*,*) "ocn_vmix_implicit_gpu config_Rayleigh_friction NOT EXECUTING"
+        call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+      else
+        call ocn_vel_vmix_tend_implicit_gpu(dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+      end if
+      call mpas_timer_stop('vmix solve momentum gpu')
+      !
+      !  If nonhydrostatic is enabled compute vertical velocity diffusion
+      !
+      if (config_enable_nonhydrostatic_mode) then
+         write(*,*) "ocn_vmix_implicit_gpu config_enable_nonhydrostatic_mode NOT EXECUTING"
+         call ocn_vertVel_vmix_tend_implicit(meshPool, dt, vertViscTopOfCell, layerThickness, &
+                                               vertVelocityNonhydro, err)
+      endif 
+
+      !
+      !  Implicit vertical solve for all tracers
+      !
+
+      call mpas_timer_start('vmix solve tracers gpu', .false.)
+      call mpas_pool_begin_iteration(tracersPool)
+      do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
+
+         if ( groupItr % memberType == MPAS_POOL_FIELD ) then
+            call mpas_pool_get_array_gpu(tracersPool, groupItr % memberName, tracersGroup, timeLevel)
+!!!$acc update device(tracersGroup)
+            ! store tracers
+            if (trim(groupItr % memberName) == 'activeTracers') then
+               if (config_compute_active_tracer_budgets) then
+                  num_tracers = size(activeTracerVertMixTendency, dim=1)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iTracer)
+!$acc parallel
+!$acc loop gang vector collapse(3)
+                  do iCell = 1, nCellsOwned
+                  do k = 1, nVertLevels
+                  do iTracer = 1, num_tracers
+                     activeTracerVertMixTendency(iTracer,k,iCell)=tracersGroup(iTracer,k,iCell)
+                  end do
+                  end do
+                  end do
+!$acc end parallel
+                  !$omp end do
+                  !$omp end parallel
+               endif
+            endif
+
+            if ( associated(tracersGroup) ) then
+               if (trim(groupItr % memberName) == 'activeTracers') then
+                  call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, 'nonLocalSurfaceTracerFlux', &
+                           tracerGroupSurfaceFlux)
+               else
+                  modifiedGroupName = trim(groupItr % memberName) // "SurfaceFlux"
+                  call mpas_pool_get_array_gpu(tracersSurfaceFluxPool, trim(modifiedGroupName), &
+                          tracerGroupSurfaceFlux)
+               endif
+
+               call ocn_tracer_vmix_tend_implicit_gpu(dt, vertDiffTopOfCell, layerThickness, tracersGroup, &
+                        vertNonLocalFlux, tracerGroupSurfaceFlux,  &
+                        config_cvmix_kpp_nonlocal_with_implicit_mix, err)
+            end if
+
+            ! difference tracers to compute influence of vertical mixing and divide by dt
+            if (trim(groupItr % memberName) == 'activeTracers') then
+               if (config_compute_active_tracer_budgets) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iTracer)
+!$acc parallel
+!$acc loop gang vector collapse(3)
+                  do iCell = 1, nCellsOwned
+                  do k = 1, nVertLevels
+                  do iTracer = 1, num_tracers
+                     activeTracerVertMixTendency(iTracer,k,iCell) = &
+                        (tracersGroup(iTracer,k,iCell) - activeTracerVertMixTendency(iTracer,k,iCell)) / dt
+                  end do
+                  end do
+                  end do
+!$acc end parallel
+                  !$omp end do
+                  !$omp end parallel
+               endif
+            endif
+!$acc update host(tracersGroup)
+         end if
+      end do
+      call mpas_timer_stop('vmix solve tracers gpu')
+
+      call mpas_timer_stop('vmix imp gpu')
+
+   end subroutine ocn_vmix_implicit_gpu!}}}
 
 !***********************************************************************
 !

--- a/src/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/shared/mpas_ocn_vmix_coefs_redi.F
@@ -41,6 +41,7 @@ module ocn_vmix_coefs_redi
    private :: ocn_tracer_vmix_coefs_redi
 
    public :: ocn_vmix_coefs_redi_build, &
+             ocn_vmix_coefs_redi_build_gpu, &
              ocn_vmix_coefs_redi_init
 
    !--------------------------------------------------------------------
@@ -122,6 +123,60 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vmix_coefs_redi_build!}}}
+
+   subroutine ocn_vmix_coefs_redi_build_gpu(meshPool, statePool, err, timeLevelIn)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         statePool             !< Input/Output: state information
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if (config_use_Redi) then
+          call ocn_tracer_vmix_coefs_redi_gpu(meshPool, vertDiffTopOfCell, k33, RediKappa, err)
+      end if
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vmix_coefs_redi_build_gpu!}}}
 
 !***********************************************************************
 !
@@ -218,6 +273,103 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_vmix_coefs_redi!}}}
+
+   subroutine ocn_tracer_vmix_coefs_redi_gpu(meshPool, vertDiffTopOfCell, k33, RediKappa, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: vertDiffTopOfCell !< Output: Vertical diffusion
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         RediKappa
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         k33
+
+      real (kind=RKIND) :: rediKappaCell
+      real (kind=RKIND),dimension(:),pointer :: dvEdge, dcEdge, areaCell
+
+      integer :: i, iCell, nCells, iEdge
+
+      integer, dimension(:), pointer :: nEdgesOnCell, nCellsArray
+      integer, dimension(:,:), pointer :: edgesOnCell
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      if(.not.rediDiffOn) return
+
+
+      call mpas_timer_start('tracer redi coef gpu')
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array_gpu(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+
+      nCells = nCellsArray(1)
+
+!$acc data present(nEdgesOnCell,edgesOnCell,dvEdge,dcEdge,areaCell,&
+!$acc              RediKappa,vertDiffTopOfCell,k33)
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, rediKappaCell, iEdge)
+
+!$acc parallel
+!$acc loop gang private(rediKappaCell,iEdge)
+      do iCell = 1, nCells
+         rediKappaCell = 0.0_RKIND
+!$acc loop seq
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            rediKappaCell = rediKappaCell + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
+         enddo
+!$acc loop vector
+         do i = 1, size(vertDiffTopOfCell,1)
+         vertDiffTopOfCell(i, iCell) = vertDiffTopOfCell(i, iCell) + rediKappaCell * k33(i, iCell) &
+                        / areaCell(iCell)
+         enddo
+      end do
+!$acc end parallel
+
+      !$omp end do
+      !$omp end parallel
+
+!$acc end data
+
+      call mpas_timer_stop('tracer redi coef gpu')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_vmix_coefs_redi_gpu!}}}
 
 
 !***********************************************************************

--- a/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/shared/mpas_ocn_vmix_cvmix.F
@@ -51,6 +51,7 @@ module ocn_vmix_cvmix
    !--------------------------------------------------------------------
 
    public :: ocn_vmix_coefs_cvmix_build, &
+             ocn_vmix_coefs_cvmix_build_gpu, &
              ocn_vmix_cvmix_init
 
    !--------------------------------------------------------------------
@@ -842,6 +843,771 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vmix_coefs_cvmix_build!}}}
+
+   subroutine ocn_vmix_coefs_cvmix_build_gpu(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      integer, intent(in), optional :: timeLevelIn !< Input: time level for state pool
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         statePool         !< Input/Output: state information
+
+      type (mpas_pool_type), intent(inout) :: &
+         forcingPool   !< Input/Output: forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type(cvmix_data_type) :: cvmix_variables
+
+      integer, dimension(:), pointer :: &
+        maxLevelCell, minLevelCell, nEdgesOnCell, maxLevelEdgeTop, minLevelEdgeBot
+
+      real (kind=RKIND), dimension(:), pointer :: &
+        latCell, lonCell, bottomDepth, fCell, &
+        ssh, dcEdge, dvEdge, areaCell, iceFraction, &
+        windSpeed10m, langmuirNumber
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+        layerThickness, &
+        normalVelocity
+
+      integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, cellsOnCell, cellMask
+
+      integer :: k, i, iCell, iNeighbor, timeLevel, kIndexOBL, kav, iEdge, nCells
+      integer :: edgeCount, nEdges, topIndex, nsmooth, kpp_stage
+      integer, pointer :: nVertLevels, nVertLevelsP1
+      integer, dimension(:), pointer :: nCellsArray
+      integer, dimension(:), allocatable :: surfaceAverageIndex
+
+      real (kind=RKIND) :: x, bulkRichardsonNumberStop, sfc_layer_depth
+      real (kind=RKIND) :: normalVelocityAv, delU2, areaSum, blTemp
+      real (kind=RKIND) :: sigma
+      real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, turbulentScalarVelocityScale, &
+                                                      deltaVelocitySquared, normalVelocitySum, &
+                                                      potentialDensitySum, RiTemp,              &
+                                                      layerThicknessSum, layerThicknessEdgeSum
+      real (kind=RKIND), dimension(:), allocatable, target :: RiSmoothed, BVFSmoothed, OBLDepths, interfaceForcings
+      logical :: bulkRichardsonFlag
+
+      real (kind=RKIND) :: langmuirEnhancementFactor, alphaAngle
+
+      real(kind=RKIND), dimension(:,:), pointer :: stokesDriftZonalWavenumber
+      real(kind=RKIND), dimension(:,:), pointer :: stokesDriftMeridionalWavenumber
+      real(kind=RKIND), dimension(:), pointer :: significantWaveHeight
+      real(kind=RKIND), dimension(:), pointer :: windStressZonal, windStressMeridional
+
+
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing mixing-related fields
+      ! note that the user can choose multiple options and the
+      !   mixing fields have to be added/merged together
+      !
+      !-----------------------------------------------------------------
+
+      !
+      ! assume no errors during initialization and set to 1 when error is encountered
+      !
+      err=0
+
+      if (present(timeLevelIn)) then
+         timeLevel = timeLevelIn
+      else
+         timeLevel = 1
+      end if
+
+      !
+      ! only build up viscosity/diffusivity if CVMix is turned on
+      !
+      if ( .not. cvmixOn ) return
+
+      !
+      ! set parameters
+      !
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', nVertLevelsP1)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_array_gpu(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array_gpu(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array_gpu(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array_gpu(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array_gpu(meshPool, 'cellMask', cellMask)
+
+      !
+      ! set pointers for fields related to position on sphere
+      !
+      call mpas_pool_get_array_gpu(meshPool, 'latCell', latCell)
+      call mpas_pool_get_array_gpu(meshPool, 'lonCell', lonCell)
+      call mpas_pool_get_array_gpu(meshPool, 'fCell', fCell)
+
+      !
+      ! set pointers for fields related to vertical mesh
+      !
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array_gpu(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array_gpu(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array_gpu(meshPool, 'bottomDepth', bottomDepth)
+
+      call mpas_pool_get_array_gpu(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array_gpu(statePool, 'ssh', ssh, timeLevel)
+
+      !
+      ! set pointers for fields related to ocean forcing state
+      !
+      call mpas_pool_get_array_gpu(forcingPool, 'iceFraction', iceFraction)
+      call mpas_pool_get_array_gpu(forcingPool, 'windSpeed10m', windSpeed10m)
+      call mpas_pool_get_array_gpu(forcingPool, 'windStressZonal', windStressZonal)
+      call mpas_pool_get_array_gpu(forcingPool, 'windStressMeridional', windStressMeridional)
+      call mpas_pool_get_array_gpu(forcingPool, 'langmuirNumber', langmuirNumber)
+
+      call mpas_pool_get_array_gpu(forcingPool, 'significantWaveHeight', significantWaveHeight)
+      call mpas_pool_get_array_gpu(forcingPool, 'stokesDriftZonalWavenumber', stokesDriftZonalWavenumber)
+      call mpas_pool_get_array_gpu(forcingPool, 'stokesDriftMeridionalWavenumber', stokesDriftMeridionalWavenumber)
+
+      nCells = nCellsArray( size(nCellsArray) )
+
+!$acc update host(dcEdge,dvEdge,nEdgesOnCell,areaCell,normalVelocity,edgesOnCell,cellsOnCell,cellsOnEdge,&
+!$acc             cellMask,latCell,lonCell,fCell,maxLevelCell,minLevelCell,maxLevelEdgeTop,minLevelEdgeBot,&
+!$acc             bottomDepth,layerThickness,ssh,iceFraction,windSpeed10m,windStressZonal,windStressMeridional,&
+!$acc             langmuirNumber,significantWaveHeight,stokesDriftZonalWavenumber,stokesDriftMeridionalWavenumber,&
+!$acc             vertViscTopOfCell,vertDiffTopOfCell,vertNonLocalFlux,density,displacedDensity,RiTopOfCell,&
+!$acc             BruntVaisalaFreqTop,surfaceFrictionVelocity,surfaceBuoyancyForcing,bulkRichardsonNumber,&
+!$acc             boundaryLayerDepth,layerThickEdgeMean,edgeAreaFractionOfCell,potentialDensity,&
+!$acc             bulkRichardsonNumberShear,bulkRichardsonNumberBuoy,indexBoundaryLayerDepth,boundaryLayerDepthSmooth)
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         vertViscTopOfCell(:, iCell) = 0.0_RKIND
+         vertDiffTopOfCell(:, iCell) = 0.0_RKIND
+         vertNonLocalFlux(:, :, iCell) = 0.0_RKIND
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsArray( 3 )
+
+      !
+      ! start by adding the mininum background values to the viscocity/diffusivity arrays
+      !
+      if (cvmixBackgroundChoice == cvmixBackgroundTypeConstant) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+            do k = 1, nVertLevelsP1
+               vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + config_cvmix_background_viscosity
+               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + config_cvmix_background_diffusion
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      endif
+
+      !
+      ! allocate selected cvmix variables and loop over columns
+      !
+      cvmix_variables % max_nlev = nVertLevels
+      allocate(cvmix_variables % Mdiff_iface(nVertLevels+1))
+      allocate(cvmix_variables % Tdiff_iface(nVertLevels+1))
+      allocate(cvmix_variables % Sdiff_iface(nVertLevels+1))
+      allocate(cvmix_variables % zw_iface(nVertLevels+1))
+      allocate(cvmix_variables % dzw(nVertLevels+1))
+      allocate(cvmix_variables % zt_cntr(nVertLevels))
+      allocate(cvmix_variables % dzt(nVertLevels))
+      allocate(cvmix_variables % kpp_Tnonlocal_iface(nVertLevels+1))
+      allocate(cvmix_variables % kpp_Snonlocal_iface(nVertLevels+1))
+
+      ! Initialize some of the cvmix variables that are not set later.
+      cvmix_variables % Mdiff_iface(1:nVertLevels+1) = 0.0_RKIND
+      cvmix_variables % Tdiff_iface(1:nVertLevels+1) = 0.0_RKIND
+      cvmix_variables % Sdiff_iface(1:nVertLevels+1) = 0.0_RKIND
+
+      allocate(OBLDepths(nVertLevels))
+      allocate(interfaceForcings(nVertLevels))
+
+      allocate(Nsqr_iface(nVertLevels+1))
+      allocate(turbulentScalarVelocityScale(nVertLevels))
+      allocate(RiSmoothed(nVertLevels+1))
+      allocate(BVFSmoothed(nVertLevels+1))
+      allocate(RiTemp(nVertLevels+1))
+
+      allocate(normalVelocitySum(nVertLevels))
+      allocate(potentialDensitySum(nVertLevels))
+      allocate(surfaceAverageIndex(nVertLevels))
+      allocate(deltaVelocitySquared(nVertLevels))
+      allocate(layerThicknessSum(nVertLevels))
+      allocate(layerThicknessEdgeSum(nVertLevels))
+
+      do k = 1, nVertLevels
+         Nsqr_iface(k) = 0.0_RKIND
+         turbulentScalarVelocityScale(k) = 0.0_RKIND
+      end do
+      Nsqr_iface(nVertLevelsP1) = 0.0_RKIND
+
+      if (config_use_active_wave) then
+        write(*,*) "config_use_active_wave NOT EXECUTING"
+        !call ocn_stokes_drift_reconstruct(forcingPool)
+        call ocn_surface_stokes_drift(forcingPool)
+      end if
+
+      call mpas_timer_start('cvmix cell loop gpu', .false.)
+      do kpp_stage = 1,2
+      ! TODO, mdt: determine where the openmp data race is coming from in this loop
+!      !$omp parallel
+!      !$omp do schedule(runtime) &
+!      !$omp private(k, RiSmoothed, RiTemp, nsmooth, BVFSmoothed, alphaAngle, &
+!      !$omp         langmuirEnhancementFactor, bulkRichardsonNumberStop, bulkRichardsonFlag, &
+!      !$omp         topIndex, kIndexOBL, deltaVelocitySquared, sigma, OBLDepths, interfaceForcings, &
+!      !$omp         surfaceAverageIndex, sfc_layer_depth, kav, i, iEdge, &
+!      !$omp         normalVelocitySum, layerThicknessEdgeSum, normalVelocityAv, delU2, potentialDensitySum, &
+!      !$omp         layerThicknessSum, blTemp, zonalWavenumberCoeff, meridionalWavenumberCoeff) &
+!      !$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
+      do iCell = 1, nCells
+
+         ! specify geometry/location
+         cvmix_variables % SeaSurfaceHeight = ssh(iCell)
+         cvmix_variables % Coriolis = fCell(iCell)
+         cvmix_variables % lat = latCell(iCell) * 180.0_RKIND / 3.14_RKIND
+         cvmix_variables % lon = lonCell(iCell) * 180.0_RKIND / 3.14_RKIND
+
+         ! fill vertical position of column
+         ! CVMix assume top of ocean is at z=0, so building all z-coordinate data based on layerThickness
+         do k = 1, minLevelCell(iCell) - 1
+            cvmix_variables % zw_iface(k) = 0.0_RKIND
+            cvmix_variables % zt_cntr(k) = 0.0_RKIND
+            cvmix_variables % dzw(k) = 0.0_RKIND
+            cvmix_variables % dzt(k) = 0.0_RKIND
+         enddo
+         cvmix_variables % zw_iface(minLevelCell(iCell)) = 0.0_RKIND
+         cvmix_variables % dzw(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+         cvmix_variables % zt_cntr(minLevelCell(iCell)) = -layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+         do k=minLevelCell(iCell)+1,maxLevelCell(iCell)
+            cvmix_variables % zw_iface(k) = cvmix_variables % zw_iface(k-1) - layerThickness(k-1,iCell)
+            cvmix_variables % zt_cntr(k) = cvmix_variables %  zw_iface(k) - layerThickness(k,iCell)/2.0_RKIND
+            cvmix_variables % dzw(k) = cvmix_variables % zt_cntr(k-1) - cvmix_variables % zt_cntr(k)
+            cvmix_variables % dzt(k) = layerThickness(k,iCell)
+         enddo
+         k = maxLevelCell(iCell)+1
+         cvmix_variables % zw_iface(k) = cvmix_variables % zw_iface(k-1) - layerThickness(k-1,iCell)
+         cvmix_variables % dzw(k) = cvmix_variables % zt_cntr(k-1) - cvmix_variables % zw_iface(k)
+         do k = maxLevelCell(iCell) + 1, nVertLevels
+            cvmix_variables % zw_iface(k+1) = cvmix_variables % zw_iface(maxLevelCell(iCell)+1)
+            cvmix_variables % zt_cntr(k) = cvmix_variables % zw_iface(maxLevelCell(iCell)+1)
+            cvmix_variables % dzw(k+1) = 0.0_RKIND
+            cvmix_variables % dzt(k) = 0.0_RKIND
+         enddo
+
+         ! fill the intent(in) convective adjustment
+         cvmix_variables % nlev = maxLevelCell(iCell)
+         cvmix_variables % OceanDepth = bottomDepth(iCell)
+         cvmix_variables % WaterDensity_cntr => density(1:maxLevelCell(iCell), iCell)
+         cvmix_variables % AdiabWaterDensity_cntr => displacedDensity(1:maxLevelCell(iCell), iCell)
+
+         if (kpp_stage == 2) then
+         if (cvmixBackgroundChoice == cvmixBackgroundTypeBryanLewis) then
+            ! See equation 9 in Bryan, K., and Lewis, L. J. (1979), A water mass
+            ! model of the World Ocean, J. Geophys. Res., 84( C5), 2503– 2517
+            ! https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/JC084iC05p02503
+            ! The standard atan formulation is approximated following equation (13) of Girones et al (2012)
+            ! https://doi.org/10.1109/MSP.2012.2219677
+            do k = minLevelCell(iCell),maxLevelCell(iCell)
+               x = (abs(cvmix_variables % zw_iface(k)) - config_cvmix_BryanLewis_transitionDepth) / &
+                   config_cvmix_BryanLewis_transitionWidth
+               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + config_cvmix_BryanLewis_bl1 + &
+                        (config_cvmix_BryanLewis_bl2/2.0_RKIND)*(sign(1.0_RKIND, x)*(0.596227_RKIND*     &
+                        abs(x)+x**2)/(1.0_RKIND+1.192454_RKIND*abs(x)+x**2))
+               vertViscTopOfCell(k, iCell) = config_cvmix_prandtl_number*vertDiffTopOfCell(k, iCell)
+            enddo
+         endif
+
+         ! fill Ri
+         RiSmoothed(1:minLevelCell(iCell)-1) = RiTopOfCell(minLevelCell(iCell),iCell)
+         RiSmoothed(minLevelCell(iCell):maxLevelCell(iCell)) = RiTopOfCell(minLevelCell(iCell):maxLevelCell(iCell),iCell)
+         RiSmoothed(maxLevelCell(iCell)+1) = RiSmoothed(maxLevelCell(iCell))
+         RiTemp(1:maxLevelCell(iCell)+1) = RiSmoothed(1:maxLevelCell(iCell)+1)
+
+         ! Use a 1-2-1 filter to remove 2 dz noise in RiTopOfCell
+         ! Note: loop limits here must not be minLevelCell or non-bfb changes are introduced
+         do nsmooth=1,config_cvmix_num_ri_smooth_loops
+            do k=2,maxLevelCell(iCell)
+                 RiSmoothed(k) = (RiTemp(k-1) + 2.0_RKIND*RiTemp(k) + RiTemp(k+1))  / 4.0_RKIND
+            enddo
+            RiTemp(1:maxLevelCell(iCell)) = RiSmoothed(1:maxLevelCell(iCell))
+         enddo
+
+         cvmix_variables%ShearRichardson_iface => RiSmoothed(minLevelCell(iCell):maxLevelCell(iCell)+1)
+
+         endif
+
+         ! fill BVF
+         BVFSmoothed(minLevelCell(iCell):maxLevelCell(iCell)) = max(0.0_RKIND, &
+                        BruntVaisalaFreqTop(minLevelCell(iCell):maxLevelCell(iCell),iCell))
+         BVFSmoothed(1:minLevelCell(iCell)-1) = max(0.0_RKIND,BVFSmoothed(minLevelCell(iCell)))
+         BVFSmoothed(maxLevelCell(iCell)+1) = max(0.0_RKIND,BVFSmoothed(maxLevelCell(iCell)))
+         cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed(minLevelCell(iCell):maxLevelCell(iCell)+1)
+
+         ! fill the intent(in) KPP
+         cvmix_variables % SurfaceFriction = surfaceFrictionVelocity(iCell)
+         cvmix_variables % SurfaceBuoyancyForcing = surfaceBuoyancyForcing(iCell)
+         cvmix_variables % BulkRichardson_cntr => bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell), iCell)
+
+         if (kpp_stage == 2) then
+         if (config_use_cvmix_shear) then
+
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+               cvmix_variables % Mdiff_iface(k) = 0.0_RKIND
+               cvmix_variables % Tdiff_iface(k) = 0.0_RKIND
+            end do
+            call cvmix_coeffs_shear( &
+                 cvmix_variables, &
+                 cvmix_shear_params)
+            ! add shear mixing to vertical viscosity/diffusivity
+            ! at present, shear mixing adds in background values when using PP, but background is
+            ! accounted for seperately. so remove bac    kground from shear mixing values
+
+            if(cvmixShearMixingChoice==cvmixShearMixingTypePP) then
+               do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+                  cvmix_variables % Mdiff_iface(k) = cvmix_variables % Mdiff_iface(k) - config_cvmix_background_viscosity
+                  cvmix_variables % Tdiff_iface(k) = cvmix_variables % Tdiff_iface(k) - config_cvmix_background_diffusion
+               end do
+            endif
+
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + cvmix_variables % Mdiff_iface(k)
+               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + cvmix_variables % Tdiff_iface(k)
+            end do
+
+         endif ! if (config_use_cvmix_shear)
+          endif ! stage 2 shear compute
+         ! call kpp ocean mixed layer scheme
+         if (cvmixKPPOn) then
+
+          if (kpp_stage==1) then
+            if (config_use_cvmix_fixed_boundary_layer) then
+               cvmix_variables % BoundaryLayerDepth = config_cvmix_kpp_boundary_layer_depth
+               cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+
+            else
+
+              ! set stratification
+              do k=minLevelCell(iCell),maxLevelCell(iCell)
+                  Nsqr_iface(k) = BVFSmoothed(k)
+              enddo
+              Nsqr_iface(minLevelCell(iCell):minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
+              k=min(maxLevelCell(iCell)+1,nVertLevels)
+              Nsqr_iface(k:maxLevelCell(iCell)+1) = Nsqr_iface(k-1)
+
+              ! compute Langmuir number and Langmuir enhancement factor
+              if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+                 langmuirNumber(iCell) =  sqrt(surfaceFrictionVelocity(iCell) / ( &
+                         cvmix_kpp_ustokes_SL_model(windSpeed10m(iCell), &
+                                                    boundaryLayerDepth(iCell), &
+                                                    cvmix_global_params)+1e-15_RKIND) )
+                 langmuirEnhancementFactor =  &
+                         cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
+                                                 surfaceFrictionVelocity(iCell), &
+                                                 boundaryLayerDepth(iCell), &
+                                                 cvmix_global_params)
+              else if (config_cvmix_kpp_use_active_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+                 call ocn_stokes_drift_langmuir_number(windStressZonal(iCell), &
+                                                       windStressMeridional(iCell), &
+                                                       surfaceFrictionVelocity(iCell), &
+                                                       significantWaveHeight(iCell), &
+                                                       boundaryLayerDepth(iCell), &
+                                                       stokesDriftZonalWavenumber(:,iCell), &
+                                                       stokesDriftMeridionalWavenumber(:,iCell), &
+                                                       alphaAngle, &
+                                                       langmuirNumber(iCell))
+                 call ocn_stokes_drift_kpp_enhancement_factor(alphaAngle, &
+                                                              langmuirNumber(iCell), &
+                                                              langmuirEnhancementFactor)
+              else
+                 ! arbitrarily large Langmuir number
+                 langmuirNumber(iCell) = 1.e10_RKIND
+                 langmuirEnhancementFactor = 1.0_RKIND
+              end if
+
+              ! compute bulk Richardson number
+              ! assume boundary layer depth is at bottom of every kIndexOBL cell
+              bulkRichardsonNumberStop = config_cvmix_kpp_stop_OBL_search * config_cvmix_kpp_criticalBulkRichardsonNumber
+              bulkRichardsonFlag = .false.
+              topIndex = minLevelCell(iCell)
+!             call mpas_timer_start('Bulk Richardson kIndexOBL loops')
+              ! compute the index of the last cell in the KPP defined surface layer
+              ! this index is used for the necessary surface layer averages of buoyancy and momentum
+              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
+
+                 ! Reset deltaVelocitySquared and bulkRichardsonNumber at this layer for the later computation
+                 deltaVelocitySquared(kIndexOBL) = 0.0_RKIND
+                 bulkRichardsonNumber(kIndexOBL, iCell) = bulkRichardsonNumberStop - 1.0_RKIND
+
+                 ! set OBL at bottom of kIndexOBL cell for computation of bulk Richardson number
+                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables % zw_iface(kIndexOBL+1))
+                 sigma = -cvmix_variables % zt_cntr(kIndexOBL) / cvmix_variables % BoundaryLayerDepth
+
+                 OBLDepths(kIndexOBL) = abs(cvmix_variables % zw_iface(kIndexOBL+1))
+                 interfaceForcings(kIndexOBL) = cvmix_variables % SurfaceBuoyancyForcing
+
+                 ! initialize the surfaceAverageIndex for cases when the if statement below is not true
+                 surfaceAverageIndex(kIndexOBL) = minLevelCell(iCell)
+                 ! move progressively downward to find the bottom most layer within the surface layer
+                 sfc_layer_depth = cvmix_variables % BoundaryLayerDepth * config_cvmix_kpp_surface_layer_extent
+                 do kav=topIndex,kIndexOBL
+                    if(cvmix_variables%zw_iface(kav+1) < -sfc_layer_depth) then
+                       surfaceAverageIndex(kIndexOBL) = kav
+                       exit
+                    end if
+                 enddo
+                 topIndex = max(1, surfaceAverageIndex(kIndexOBL) - 1)
+              end do
+
+              ! compute the turbulent scales in order to compute the bulk Richardson number
+              call cvmix_kpp_compute_turbulent_scales( &
+                   sigma_coord = config_cvmix_kpp_surface_layer_extent, &
+                   OBL_depth = OBLDepths(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_buoy_force = interfaceForcings(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_fric_vel = cvmix_variables % SurfaceFriction, &
+                   w_s = turbulentScalarVelocityScale(minLevelCell(iCell):maxLevelCell(iCell)))
+
+              ! averaging over a surface layer assuming that BLdepth is cell bottom
+              ! Build deltaVelocitySquared
+              do i = 1, nEdgesOnCell(iCell)
+                 iEdge = edgesOnCell(i, iCell)
+
+                 deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
+
+                 normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
+                                                          layerThickEdgeMean(minLevelCell(iCell),iEdge)
+                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdgeMean(minLevelCell(iCell),iEdge)
+
+                 do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
+                    normalVelocitySum(kIndexOBL) = normalVelocitySum(kIndexOBL-1) + &
+                                      layerThickEdgeMean(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
+                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdgeMean(kIndexOBL, iEdge)
+                 end do
+
+                 do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
+                    normalVelocityAv = normalVelocitySum(surfaceAverageIndex(kIndexOBL )) / &
+                        layerThicknessEdgeSum(surfaceAverageIndex(kIndexOBL))
+                    delU2 = ( normalVelocityAv - normalVelocity(kIndexOBL, iEdge) )**2
+                    deltaVelocitySquared(kIndexOBL) = deltaVelocitySquared(kIndexOBL) + edgeAreaFractionOfCell(i,iCell) * delU2
+                 end do
+              end do
+
+              potentialDensitySum(minLevelCell(iCell)) = potentialDensity(minLevelCell(iCell), iCell)* &
+                                                         layerThickness(minLevelCell(iCell), iCell)
+              layerThicknessSum(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell), iCell)
+              do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
+                layerThicknessSum(kIndexOBL) = layerThicknessSum(kIndexOBL-1) + layerThickness(kIndexOBL, iCell)
+                potentialDensitySum(kIndexOBL) = potentialDensitySum(kIndexOBL-1) + &
+                    layerThickness(kIndexOBL, iCell)*potentialDensity(kIndexOBL, iCell)
+              end do
+
+              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
+                ! !compute shear contribution assuming BLdepth is cell bottom
+                !Note that the factor of two is from averaging dot products to cell centers on a C-grid
+                bulkRichardsonNumberShear(kIndexOBL,iCell) = max(2.0_RKIND*deltaVelocitySquared(kIndexOBL), 1.0e-15_RKIND)
+
+                bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity * (potentialDensity(kIndexOBL, iCell) &
+                                  - potentialDensitySum(surfaceAverageIndex(kIndexOBL)) &
+                                  / layerThicknessSum(surfaceAverageIndex(kIndexOBL))) / rho_sw
+              end do ! do kIndexOBL
+!             call mpas_timer_stop('Bulk Richardson kIndexOBL loops')
+
+              cvmix_variables % bulkRichardson_cntr(:) = cvmix_kpp_compute_bulk_Richardson( &
+                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   delta_buoy_cntr = bulkRichardsonNumberBuoy(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   delta_Vsqr_cntr = bulkRichardsonNumberShear(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   ws_cntr = turbulentScalarVelocityScale(:), &
+                   Nsqr_iface = Nsqr_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                   EFactor = langmuirEnhancementFactor, &
+                   LaSL = langmuirNumber(iCell), &
+                   ustar = cvmix_variables%SurfaceFriction )
+              ! TODO: the surface buoyancy forcing here does not include penetrative solar radiation? <05-09-18, Qing Li> !
+
+              ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
+
+              call cvmix_kpp_compute_OBL_depth(  &
+                   Ri_bulk = bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   zw_iface = cvmix_variables % zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                   OBL_depth = cvmix_variables % BoundaryLayerDepth, &
+                   kOBL_depth = cvmix_variables % kOBL_depth, &
+                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_fric = cvmix_variables % SurfaceFriction, &
+                   Coriolis = cvmix_variables % Coriolis)
+
+             endif  ! if (config_use_cvmix_fixed_boundary_layer) then
+
+             ! apply minimum limit to OBL
+             if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND) then
+                cvmix_variables % BoundaryLayerDepth = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+             endif
+
+             ! apply minimum limit to OBL under sea-ice
+             if(iceFraction(iCell).gt.0.15_RKIND) then
+             if(cvmix_variables % BoundaryLayerDepth .lt. configure_cvmix_kpp_minimum_OBL_under_sea_ice) then
+                cvmix_variables % BoundaryLayerDepth = configure_cvmix_kpp_minimum_OBL_under_sea_ice
+                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+             endif
+             endif
+
+             ! apply maximum limit to OBL
+             if(cvmix_variables % BoundaryLayerDepth .gt. abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))) then
+                cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))
+                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+
+             endif
+
+             boundaryLayerDepth(iCell) = cvmix_variables % BoundaryLayerDepth
+     endif !kpp stage 1 -- boundary layer compute
+
+     if (kpp_stage == 2) then
+            ! copy data into cvmix_variables
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+              cvmix_variables % Mdiff_iface(k) = vertViscTopOfCell(k, iCell)
+              cvmix_variables % Tdiff_iface(k) = vertDiffTopOfCell(k, iCell)
+            end do
+
+            !must reapply max and min limits to boundaryLayerDepth
+            blTemp = max(boundaryLayerDepth(iCell), layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND)
+            boundaryLayerDepth(iCell) = min(blTemp, abs(cvmix_variables%zt_cntr(maxLevelCell(iCell))))
+
+            cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          OBL_depth = boundaryLayerDepth(iCell) )
+
+            ! update Langmuir enhancement factor
+            if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+               langmuirEnhancementFactor =  &
+                       cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
+                                               surfaceFrictionVelocity(iCell), &
+                                               boundaryLayerDepth(iCell), &
+                                               cvmix_global_params)
+            else if (config_cvmix_kpp_use_active_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+                 call ocn_stokes_drift_langmuir_number(windStressZonal(iCell), &
+                                                       windStressMeridional(iCell), &
+                                                       surfaceFrictionVelocity(iCell), &
+                                                       significantWaveHeight(iCell), &
+                                                       boundaryLayerDepth(iCell), &
+                                                       stokesDriftZonalWavenumber(:,iCell), &
+                                                       stokesDriftMeridionalWavenumber(:,iCell), &
+                                                       alphaAngle, &
+                                                       langmuirNumber(iCell))
+                 call ocn_stokes_drift_kpp_enhancement_factor(alphaAngle, &
+                                                              langmuirNumber(iCell), &
+                                                              langmuirEnhancementFactor)
+            else
+               langmuirEnhancementFactor = 1.0_RKIND
+            end if
+
+!           call mpas_timer_start('cvmix coeffs kpp', .false.)
+            call cvmix_coeffs_kpp(                                              &
+                          Mdiff_out = cvmix_variables % Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          Tdiff_out = cvmix_variables % Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          Sdiff_out = cvmix_variables % Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          zw = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),            &
+                          zt = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),               &
+                          old_Mdiff = cvmix_variables%Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
+                          old_Tdiff = cvmix_variables%Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
+                          old_Sdiff = cvmix_variables%Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
+                          OBL_depth = boundaryLayerDepth(iCell),                   &
+                          kOBL_depth = cvmix_variables%kOBL_depth,                           &
+                          Tnonlocal = cvmix_variables%kpp_Tnonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          Snonlocal = cvmix_variables%kpp_Snonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          surf_fric = cvmix_variables%SurfaceFriction,                      &
+                          surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
+                          nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 1,             &
+                          max_nlev = nVertLevels,         &
+                          Langmuir_EFactor = langmuirEnhancementFactor )
+!           call mpas_timer_stop('cvmix coeffs kpp')
+
+            ! intent out of BoundaryLayerDepth is boundary layer depth measured in meters and vertical index
+            indexBoundaryLayerDepth(iCell) = cvmix_variables % kOBL_depth
+
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+                vertViscTopOfCell(k, iCell) = cvmix_variables % Mdiff_iface(k)
+                vertDiffTopOfCell(k, iCell) = cvmix_variables % Tdiff_iface(k)
+            end do
+
+            ! store non-local flux terms
+            ! these flux terms must be multiplied by the surfaceTracerFlux field
+            ! the tracer tendency is then the vertical divergence of vertNonLocalFlux*surfaceTracerFlux
+            ! both of these operations are done in ocn_tracer_nonlocalflux_tend routine
+            vertNonLocalFlux(index_vertNonLocalFluxTemp,:,iCell) = cvmix_variables % kpp_Tnonlocal_iface(:)
+
+    endif ! kpp stage 2
+         endif !if (config_use_cvmix_kpp)
+
+         if ( kpp_stage == 2) then
+         ! call convective mixing scheme
+         if (config_use_cvmix_convection) then
+            do k = 1, maxLevelCell(iCell) + 1
+               cvmix_variables % Mdiff_iface(k) = 0.0_RKIND
+               cvmix_variables % Tdiff_iface(k) = 0.0_RKIND
+            end do
+            call cvmix_coeffs_conv( CVmix_vars = cvmix_variables )
+
+            ! add convective mixing to vertical viscosity/diffusivity
+            ! if using KPP, then do not apply convective mixing within the ocean boundary layer
+            if(config_use_cvmix_kpp) then
+               do k = ceiling(indexBoundaryLayerDepth(iCell)) + 1, maxLevelCell(iCell)
+                  vertViscTopOfCell(k,iCell) = vertViscTopOfCell(k,iCell) + cvmix_variables % Mdiff_iface(k)
+                  vertDiffTopOfCell(k,iCell) = vertDiffTopOfCell(k,iCell) + cvmix_variables % Tdiff_iface(k)
+               enddo
+            else
+               vertViscTopOfCell(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+               vertDiffTopOfCell(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+               do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+                  vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + cvmix_variables % Mdiff_iface(k)
+                  vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + cvmix_variables % Tdiff_iface(k)
+               end do
+            endif
+         endif  ! if (config_use_cvmix_convection)
+
+         !
+         ! put tidal mixing here
+         !
+
+         !
+         ! put double diffusion mxing here
+         !
+
+
+         ! computation of viscosity/diffusivity complete
+         ! impose no-flux boundary conditions at top and bottom by zero viscosity/diffusivity
+         vertViscTopOfCell(1:minLevelCell(iCell), iCell) = 0.0_RKIND
+         vertDiffTopOfCell(1:minLevelCell(iCell), iCell) = 0.0_RKIND
+         do k = maxLevelCell(iCell)+1, nVertLevelsP1
+            vertViscTopOfCell(k, iCell)=0.0_RKIND
+            vertDiffTopOfCell(k, iCell)=0.0_RKIND
+         end do
+
+ endif ! kpp stage 2 convection calc
+      end do  ! do iCell=1,mesh%nCells
+!      !$omp end do
+!      !$omp end parallel
+
+      if (kpp_stage == 1 .and. config_cvmix_use_BLD_smoothing) then ! smooth boundary layer
+         nCells = nCellsArray(2)
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(nEdges, areaSum, edgeCount, iEdge, iNeighbor)
+         do iCell=1,nCells
+            nEdges = nEdgesOnCell(iCell)
+            boundaryLayerDepthSmooth(iCell) = 0.0_RKIND
+            areaSum = 0.0_RKIND
+            edgeCount = 0
+
+            do iEdge = 1,nEdges
+               iNeighbor = cellsOnCell(iEdge,iCell)
+               boundaryLayerDepthSmooth(iCell) = boundaryLayerDepthSmooth(iCell) +  &
+                             2.0_RKIND * cellMask(minLevelCell(iNeighbor),iNeighbor) * areaCell(iNeighbor)    &
+                             * boundaryLayerDepth(iNeighbor)
+               areaSum = areaSum + 2.0_RKIND * areaCell(iNeighbor) * cellMask(minLevelCell(iNeighbor),iNeighbor)
+               edgeCount = edgeCount + cellMask(minLevelCell(iNeighbor),iNeighbor)
+            end do
+            areaSum = areaSum + edgeCount * areaCell(iCell)
+            boundaryLayerDepthSmooth(iCell) = boundaryLayerDepthSmooth(iCell) +   &
+                         boundaryLayerDepth(iCell) * edgeCount * areaCell(iCell)
+            boundaryLayerDepthSmooth(iCell) = boundaryLayerDepthSmooth(iCell) / areaSum
+         end do
+         !$omp end do
+
+         !$omp do schedule(runtime)
+          do iCell=1, nCells
+             boundaryLayerDepth(iCell) = boundaryLayerDepthSmooth(iCell)
+          enddo
+         !$omp end do
+         !$omp end parallel
+
+       endif !stage 1 BLD smoothing
+      end do ! kpp_stage
+      call mpas_timer_stop('cvmix cell loop gpu')
+
+      ! dellocate cmvix variables
+      deallocate(cvmix_variables % Mdiff_iface)
+      deallocate(cvmix_variables % Tdiff_iface)
+      deallocate(cvmix_variables % Sdiff_iface)
+      deallocate(cvmix_variables % zw_iface)
+      deallocate(cvmix_variables % dzw)
+      deallocate(cvmix_variables % zt_cntr)
+      deallocate(cvmix_variables % dzt)
+      deallocate(cvmix_variables % kpp_Tnonlocal_iface)
+      deallocate(cvmix_variables % kpp_Snonlocal_iface)
+
+      deallocate(Nsqr_iface)
+      deallocate(turbulentScalarVelocityScale)
+      deallocate(RiSmoothed)
+      deallocate(RiTemp)
+      deallocate(BVFSmoothed)
+      deallocate(normalVelocitySum)
+      deallocate(potentialDensitySum)
+      deallocate(surfaceAverageIndex)
+      deallocate(deltaVelocitySquared)
+      deallocate(layerThicknessEdgeSum)
+      deallocate(layerThicknessSum)
+
+      deallocate(OBLDepths)
+      deallocate(interfaceForcings)
+
+!$acc update device(dcEdge,dvEdge,nEdgesOnCell,areaCell,normalVelocity,edgesOnCell,cellsOnCell,cellsOnEdge,&
+!$acc               cellMask,latCell,lonCell,fCell,maxLevelCell,minLevelCell,maxLevelEdgeTop,minLevelEdgeBot,&
+!$acc               bottomDepth,layerThickness,ssh,iceFraction,windSpeed10m,windStressZonal,windStressMeridional,&
+!$acc               langmuirNumber,significantWaveHeight,stokesDriftZonalWavenumber,stokesDriftMeridionalWavenumber,&
+!$acc               vertViscTopOfCell,vertDiffTopOfCell,vertNonLocalFlux,density,displacedDensity,RiTopOfCell,&
+!$acc               BruntVaisalaFreqTop,surfaceFrictionVelocity,surfaceBuoyancyForcing,bulkRichardsonNumber,&
+!$acc               boundaryLayerDepth,layerThickEdgeMean,edgeAreaFractionOfCell,potentialDensity,&
+!$acc               bulkRichardsonNumberShear,bulkRichardsonNumberBuoy,indexBoundaryLayerDepth,boundaryLayerDepthSmooth)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vmix_coefs_cvmix_build_gpu!}}}
 
 !***********************************************************************
 !


### PR DESCRIPTION
Edited: This PR includes OpenACC changes to Split-Explicit (SE) implementation. Below is the summary of the changes:
- Ported all the routines invoked in the SE implementations based on namelist configuration used.
- Additional OpenACC kernel optimizations are implemented.

NOTE: This PR also require the changes from [MPAS-framework#16](https://github.com/EarthWorksOrg/mpas-framework/pull/16) to enable appropriate data transfers.